### PR TITLE
Add nametag availability check and input validation

### DIFF
--- a/src/components/wallet/L3/hooks/useWallet.ts
+++ b/src/components/wallet/L3/hooks/useWallet.ts
@@ -85,6 +85,10 @@ export const useWallet = () => {
     enabled: !!identityQuery.data?.address,
   });
 
+  const checkNametagAvailability = async(nametag: string): Promise<boolean> => {
+    return await nametagService.isNametagAvailable(nametag);
+  }
+
   // Ensure registry is loaded before aggregating assets
   const registryQuery = useQuery({
     queryKey: KEYS.REGISTRY,
@@ -581,5 +585,6 @@ export const useWallet = () => {
     getSeedPhrase,
     getL1Address,
     getUnifiedKeyManager,
+    checkNametagAvailability,
   };
 };

--- a/src/components/wallet/L3/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/L3/onboarding/CreateWalletFlow.tsx
@@ -32,7 +32,7 @@ const SESSION_KEY = "user-pin-1234";
 const identityManager = IdentityManager.getInstance(SESSION_KEY);
 
 export function CreateWalletFlow() {
-  const { identity, createWallet, restoreWallet, mintNametag, nametag, getUnifiedKeyManager } = useWallet();
+  const { identity, createWallet, restoreWallet, mintNametag, nametag, getUnifiedKeyManager, checkNametagAvailability } = useWallet();
 
   const [step, setStep] = useState<'start' | 'restoreMethod' | 'restore' | 'importFile' | 'addressSelection' | 'nametag' | 'processing'>('start');
   const [nametagInput, setNametagInput] = useState('');
@@ -230,6 +230,16 @@ export function CreateWalletFlow() {
 
     try {
       const cleanTag = nametagInput.trim().replace('@', '');
+
+      const isNametagAvailable = await checkNametagAvailability(cleanTag);
+      console.log(isNametagAvailable)
+      if(!isNametagAvailable) {
+        console.log("Setting error")
+        setError(`${cleanTag} already exists.`);
+        setStep('nametag')
+        return;
+      }
+
       await mintNametag(cleanTag);
       // Successfully minted nametag - reload to reinitialize with new nametag
       // This ensures React Query refreshes and the app transitions to main wallet view
@@ -1103,7 +1113,13 @@ export function CreateWalletFlow() {
               <input
                 type="text"
                 value={nametagInput}
-                onChange={(e) => setNametagInput(e.target.value)}
+                onChange={(e) => {
+                  // Allow only Latin letters, numbers, hyphen, underscore, plus, dot
+                  const value = e.target.value;
+                  if (/^[a-z0-9_\-+.]*$/.test(value)) {
+                    setNametagInput(value);
+                  }
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && nametagInput && !isBusy) handleMintNametag();
                 }}

--- a/src/components/wallet/L3/services/NametagService.ts
+++ b/src/components/wallet/L3/services/NametagService.ts
@@ -40,6 +40,14 @@ export class NametagService {
     return NametagService.instance;
   }
 
+  async isNametagAvailable(nametag: string): Promise<boolean> {
+    const client = ServiceProvider.stateTransitionClient;
+    const rootTrustBase = ServiceProvider.getRootTrustBase();
+    const nametagTokenId = await TokenId.fromNameTag(nametag);
+
+    return await !client.isMinted(rootTrustBase, nametagTokenId);
+  }
+
   async mintNametagAndPublish(nametag: string): Promise<MintResult> {
     try {
       const cleanTag = nametag.replace("@unicity", "").replace("@", "").trim();


### PR DESCRIPTION
- Add isNametagAvailable method to NametagService
- Implement checkNametagAvailability in useWallet hook
- Validate nametag availability before minting in CreateWalletFlow
- Add input validation to allow only Latin letters, numbers, and special chars (_, -, +, .)
- Show error message if nametag already exists