### PR TITLE
- Automatically convert uppercase letters to lowercase in nametag input field

### DIFF
--- a/src/components/wallet/L3/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/L3/onboarding/CreateWalletFlow.tsx
@@ -1114,8 +1114,7 @@ export function CreateWalletFlow() {
                 type="text"
                 value={nametagInput}
                 onChange={(e) => {
-                  // Allow only Latin letters, numbers, hyphen, underscore, plus, dot
-                  const value = e.target.value;
+                  const value = e.target.value.toLowerCase();
                   if (/^[a-z0-9_\-+.]*$/.test(value)) {
                     setNametagInput(value);
                   }


### PR DESCRIPTION
Fixed issue when users were not able to input uppercase letters at all. Now whenever user is typing using uppercase letter they instantly convert to the lovercase