### PR TITLE
fix: asset list reactivity, CoinGecko rate limits, token ID display

### DIFF
--- a/src/components/wallet/L3/hooks/useWallet.ts
+++ b/src/components/wallet/L3/hooks/useWallet.ts
@@ -342,8 +342,8 @@ export const useWallet = () => {
   const pricesQuery = useQuery({
     queryKey: KEYS.PRICES,
     queryFn: ApiService.fetchPrices,
-    refetchInterval: 60000,
-    staleTime: 30000, // Consider data fresh for 30 seconds
+    refetchInterval: 5 * 60_000, // 5 min — SDK handles primary price updates
+    staleTime: 60_000,
   });
 
   const tokensQuery = useQuery({

--- a/src/components/wallet/L3/modals/PaymentRequestModal.tsx
+++ b/src/components/wallet/L3/modals/PaymentRequestModal.tsx
@@ -32,9 +32,10 @@ export function PaymentRequestsModal({ isOpen, onClose }: PaymentRequestsModalPr
     setProcessingId(req.id);
     setErrors(prev => ({ ...prev, [req.id]: '' }));
     try {
-      console.log(`Initiating payment for request ${req.requestId} to @${req.recipientNametag}`);
+      const recipient = req.recipientNametag ? `@${req.recipientNametag}` : req.senderPubkey;
+      console.log(`Initiating payment for request ${req.requestId} to ${recipient}`);
       await transfer({
-        recipient: `@${req.recipientNametag}`,
+        recipient,
         amount: req.amount.toString(),
         coinId: req.coinId,
       });
@@ -171,7 +172,9 @@ function RequestCard({ req, error, onPay, onReject, isProcessing, isGlobalDisabl
           <div className="flex flex-col">
             <span className="text-[10px] text-neutral-500 font-bold uppercase tracking-wider mb-1.5">From</span>
             <div className="flex items-center gap-2">
-              <span className="text-neutral-900 dark:text-white font-bold text-base">@{req.recipientNametag}</span>
+              <span className="text-neutral-900 dark:text-white font-bold text-base">
+                {req.recipientNametag ? `@${req.recipientNametag}` : `${req.senderPubkey.slice(0, 12)}...`}
+              </span>
             </div>
           </div>
           <div className="bg-neutral-200/50 dark:bg-neutral-700/50 px-2.5 py-1 rounded-lg text-[10px] text-neutral-500 dark:text-neutral-400 font-medium">

--- a/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
+++ b/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 import { ArrowUpRight, ArrowDownLeft, Loader2, Clock } from 'lucide-react';
-import { useTransactionHistory } from '../hooks/useTransactionHistory';
+import { useTransactionHistory } from '../../../../sdk';
 import { RegistryService } from '../services/RegistryService';
 import { useMemo } from 'react';
 import { BaseModal, ModalHeader, EmptyState } from '../../ui';
@@ -35,6 +35,7 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
       return {
         ...entry,
         formattedAmount,
+        iconUrl: def ? registryService.getIconUrl(def) : null,
         date: new Date(entry.timestamp).toLocaleDateString('en-US', {
           month: 'short',
           day: 'numeric',

--- a/src/components/wallet/shared/components/AssetRow.tsx
+++ b/src/components/wallet/shared/components/AssetRow.tsx
@@ -13,12 +13,16 @@ interface AssetRowProps {
   isNew?: boolean;
 }
 
-// Custom comparison: allow re-render when amount changes (for number animation)
+// Custom comparison: allow re-render when amount or price changes (for number animation)
 function areAssetPropsEqual(prev: AssetRowProps, next: AssetRowProps): boolean {
   return (
     prev.asset.coinId === next.asset.coinId &&
     prev.asset.symbol === next.asset.symbol &&
+    prev.asset.totalAmount === next.asset.totalAmount &&
+    prev.asset.tokenCount === next.asset.tokenCount &&
+    prev.asset.priceUsd === next.asset.priceUsd &&
     prev.asset.change24h === next.asset.change24h &&
+    prev.asset.iconUrl === next.asset.iconUrl &&
     prev.showBalances === next.showBalances &&
     prev.layer === next.layer &&
     prev.isNew === next.isNew &&

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -44,7 +44,7 @@ export function SphereProvider({
 
       const browserProviders = createBrowserProviders({
         network,
-        price: { platform: 'coingecko', baseUrl: '/coingecko' },
+        price: { platform: 'coingecko', baseUrl: '/coingecko', cacheTtlMs: 5 * 60_000 },
       });
       setProviders(browserProviders);
 

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -13,29 +13,23 @@ export function useSphereEvents(): void {
   useEffect(() => {
     if (!sphere) return;
 
-    const handleIncomingTransfer = () => {
+    const invalidatePayments = () => {
       queryClient.invalidateQueries({
         queryKey: SPHERE_KEYS.payments.tokens.all,
       });
       queryClient.invalidateQueries({
         queryKey: SPHERE_KEYS.payments.balance.all,
-      });
-      queryClient.invalidateQueries({
-        queryKey: SPHERE_KEYS.payments.transactions.all,
       });
       queryClient.invalidateQueries({
         queryKey: SPHERE_KEYS.payments.assets.all,
       });
+      queryClient.invalidateQueries({
+        queryKey: SPHERE_KEYS.payments.transactions.all,
+      });
     };
 
-    const handleTransferConfirmed = () => {
-      queryClient.invalidateQueries({
-        queryKey: SPHERE_KEYS.payments.tokens.all,
-      });
-      queryClient.invalidateQueries({
-        queryKey: SPHERE_KEYS.payments.balance.all,
-      });
-    };
+    const handleIncomingTransfer = invalidatePayments;
+    const handleTransferConfirmed = invalidatePayments;
 
     const handleNametagChange = () => {
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.identity.all });
@@ -47,17 +41,7 @@ export function useSphereEvents(): void {
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.l1.all });
     };
 
-    const handleSyncCompleted = () => {
-      queryClient.invalidateQueries({
-        queryKey: SPHERE_KEYS.payments.tokens.all,
-      });
-      queryClient.invalidateQueries({
-        queryKey: SPHERE_KEYS.payments.balance.all,
-      });
-      queryClient.invalidateQueries({
-        queryKey: SPHERE_KEYS.payments.assets.all,
-      });
-    };
+    const handleSyncCompleted = invalidatePayments;
 
     // Bridge incoming SDK DMs to ChatRepository and fire custom event
     const handleDmReceived = (dm: DirectMessage) => {

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -18,10 +18,7 @@ export type { UseAssetsReturn } from './payments/useAssets';
 export { useTransfer } from './payments/useTransfer';
 export type { UseTransferReturn, TransferParams } from './payments/useTransfer';
 export { useTransactionHistory } from './payments/useTransactionHistory';
-export type {
-  UseTransactionHistoryReturn,
-  Transaction,
-} from './payments/useTransactionHistory';
+export type { UseTransactionHistoryReturn } from './payments/useTransactionHistory';
 
 // L1
 export { useL1Balance } from './l1/useL1Balance';

--- a/src/sdk/hooks/payments/useAssets.ts
+++ b/src/sdk/hooks/payments/useAssets.ts
@@ -21,6 +21,7 @@ export function useAssets(): UseAssetsReturn {
     },
     enabled: !!sphere,
     staleTime: 30_000,
+    structuralSharing: false,
   });
 
   const assets = query.data ?? [];

--- a/src/sdk/hooks/payments/useBalance.ts
+++ b/src/sdk/hooks/payments/useBalance.ts
@@ -38,6 +38,7 @@ export function useBalance(coinId?: string): UseBalanceReturn {
     },
     enabled: !!sphere,
     staleTime: 30_000,
+    structuralSharing: false,
   });
 
   const asset = (coinId && query.data && typeof query.data !== 'number') ? query.data as Asset : null;

--- a/src/sdk/hooks/payments/useTokens.ts
+++ b/src/sdk/hooks/payments/useTokens.ts
@@ -24,7 +24,8 @@ export function useTokens(): UseTokensReturn {
       return sphere.payments.getTokens();
     },
     enabled: !!sphere,
-    staleTime: Infinity,
+    staleTime: 30_000,
+    structuralSharing: false,
   });
 
   const tokens = query.data ?? [];

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -41,19 +41,23 @@ export function useTransfer(): UseTransferReturn {
 
         setLastResult(result);
 
-        // Invalidate related queries
-        queryClient.invalidateQueries({
-          queryKey: SPHERE_KEYS.payments.tokens.all,
-        });
-        queryClient.invalidateQueries({
-          queryKey: SPHERE_KEYS.payments.balance.all,
-        });
-        queryClient.invalidateQueries({
-          queryKey: SPHERE_KEYS.payments.assets.all,
-        });
-        queryClient.invalidateQueries({
-          queryKey: SPHERE_KEYS.payments.transactions.all,
-        });
+        // Force refetch all payment queries with fresh data.
+        // Use refetchQueries (not invalidateQueries) to guarantee a new fetch
+        // even if a previous refetch from the transfer:confirmed event is in-flight.
+        await Promise.all([
+          queryClient.refetchQueries({
+            queryKey: SPHERE_KEYS.payments.tokens.all,
+          }),
+          queryClient.refetchQueries({
+            queryKey: SPHERE_KEYS.payments.balance.all,
+          }),
+          queryClient.refetchQueries({
+            queryKey: SPHERE_KEYS.payments.assets.all,
+          }),
+          queryClient.refetchQueries({
+            queryKey: SPHERE_KEYS.payments.transactions.all,
+          }),
+        ]);
 
         return result;
       } catch (err) {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -18,4 +18,5 @@ export type {
   IncomingPaymentRequest,
   PaymentRequest,
   Asset,
+  TransactionHistoryEntry,
 } from '@unicitylabs/sphere-sdk';


### PR DESCRIPTION
- Fix AssetRow memo comparison to include totalAmount, tokenCount, priceUsd, iconUrl so balances update immediately after transfers without tab switching
- Change useTokens staleTime from Infinity to 30s for consistent cache behavior
- Switch useSphereEvents from refetchQueries to invalidateQueries for reliable updates
- Route legacy ApiService.fetchPrices through Vite proxy (/coingecko) with 5min cache
- Increase CoinGecko cache TTL to 5min in both SDK provider and legacy ApiService
- Fix TokenId display: use toJSON() instead of toString() to show clean hex
- Fix payment request symbol: resolve via TokenRegistry instead of raw coinId hex
- Fix payment request sender: fallback to truncated pubkey when nametag unavailable