### PR TITLE
feat: add persistent Connect session via hidden iframe bridge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { IntroPage } from './pages/IntroPage';
 import { HomePage } from './pages/HomePage';
 import { AgentPage } from './pages/AgentPage';
 import { ConnectPage } from './pages/ConnectPage';
+import { ConnectBridgePage } from './pages/ConnectBridgePage';
 import { useSphereEvents } from './sdk';
 
 // Retry wrapper: auto-reload page once on chunk load failure (stale deployment)
@@ -46,6 +47,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<IntroPage />} />
       <Route path="/connect" element={<ConnectPage />} />
+      <Route path="/connect-bridge" element={<ConnectBridgePage />} />
       <Route element={<DashboardLayout />}>
         <Route path="/home" element={<HomePage />} />
         <Route path="/agents/:agentId" element={<AgentPage />} />

--- a/src/pages/ConnectBridgePage.tsx
+++ b/src/pages/ConnectBridgePage.tsx
@@ -1,0 +1,221 @@
+// ---------------------------------------------------------------------------
+// ConnectBridgePage — headless page loaded in a hidden iframe by dApps.
+//
+// Hosts a persistent ConnectHost that survives popup close/reopen.
+// Queries and events are handled directly. Intents and first-time approvals
+// are delegated to a popup via BroadcastChannel.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { ConnectHost, HOST_READY_TYPE } from '@unicitylabs/sphere-sdk/connect';
+import type { DAppMetadata, PermissionScope } from '@unicitylabs/sphere-sdk/connect';
+import { PostMessageTransport } from '@unicitylabs/sphere-sdk/connect/browser';
+import { useSphereContext } from '../sdk/hooks/core/useSphere';
+import {
+  getApprovedOrigin,
+  saveApprovedOrigin,
+  updateLastSeen,
+  revokeApprovedOrigin,
+} from '../utils/connected-sites';
+import {
+  createBridgeChannel,
+  BRIDGE_MSG,
+  type BridgeChannelMessage,
+  type IntentResultMessage,
+  type ApprovalResultMessage,
+} from '../utils/connect-bridge-channel';
+
+// Message type sent to the dApp (parent) when popup interaction is needed
+const OPEN_POPUP_MSG = 'sphere-connect:open-popup';
+
+export function ConnectBridgePage() {
+  const [searchParams] = useSearchParams();
+  const origin = searchParams.get('origin');
+  const { sphere, isLoading } = useSphereContext();
+  const initializedRef = useRef(false);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  const sphereRef = useRef(sphere);
+  sphereRef.current = sphere;
+
+  const sphereReady = !isLoading && !!sphere;
+
+  useEffect(() => {
+    console.log('[ConnectBridge] effect: sphereReady:', sphereReady, 'origin:', origin, 'initialized:', initializedRef.current);
+    if (!sphereReady) return;
+    if (initializedRef.current) return;
+
+    if (!origin) {
+      console.error('[ConnectBridge] no origin param');
+      setStatus('error');
+      return;
+    }
+
+    if (!window.parent || window.parent === window) {
+      console.error('[ConnectBridge] not in iframe (window.parent === window)');
+      setStatus('error');
+      return;
+    }
+
+    console.log('[ConnectBridge] initializing for origin:', origin);
+    initializedRef.current = true;
+    const currentSphere = sphereRef.current!;
+
+    // Transport to communicate with the dApp (parent window)
+    const transport = PostMessageTransport.forHost(window.parent, {
+      allowedOrigins: [origin],
+    });
+
+    // BroadcastChannel for coordinating with popup (same-origin only)
+    const channel = createBridgeChannel(origin);
+
+    // Track pending operations waiting for popup
+    const pendingIntents = new Map<
+      string,
+      { resolve: (r: { result?: unknown; error?: { code: number; message: string } }) => void }
+    >();
+    const pendingApprovals = new Map<
+      string,
+      { resolve: (r: { approved: boolean; grantedPermissions: PermissionScope[] }) => void }
+    >();
+
+    // Listen for messages from popup
+    channel.onmessage = (event: MessageEvent<BridgeChannelMessage>) => {
+      const msg = event.data;
+
+      if (msg.type === BRIDGE_MSG.POPUP_READY || msg.type === BRIDGE_MSG.POPUP_CLOSED) {
+        return;
+      }
+
+      if (msg.type === BRIDGE_MSG.INTENT_RESULT) {
+        const resultMsg = msg as IntentResultMessage;
+        const pending = pendingIntents.get(resultMsg.intentId);
+        if (pending) {
+          pendingIntents.delete(resultMsg.intentId);
+          if (resultMsg.error) {
+            pending.resolve({ error: resultMsg.error });
+          } else {
+            pending.resolve({ result: resultMsg.result });
+          }
+        }
+        return;
+      }
+
+      if (msg.type === BRIDGE_MSG.APPROVAL_RESULT) {
+        const resultMsg = msg as ApprovalResultMessage;
+        const pending = pendingApprovals.get(resultMsg.approvalId);
+        if (pending) {
+          pendingApprovals.delete(resultMsg.approvalId);
+          pending.resolve({
+            approved: resultMsg.approved,
+            grantedPermissions: resultMsg.grantedPermissions as PermissionScope[],
+          });
+        }
+        return;
+      }
+    };
+
+    // ConnectHost handles queries/events directly; delegates intents to popup
+    void new ConnectHost({
+      sphere: currentSphere,
+      transport,
+
+      onConnectionRequest: async (
+        dapp: DAppMetadata,
+        perms: PermissionScope[],
+        silent?: boolean,
+      ) => {
+        // Check if origin was already approved
+        const saved = getApprovedOrigin(origin);
+        if (saved) {
+          updateLastSeen(origin);
+          return { approved: true, grantedPermissions: saved.permissions };
+        }
+
+        // Silent mode: reject immediately without UI
+        if (silent) {
+          return { approved: false, grantedPermissions: [] };
+        }
+
+        // Need popup for first-time approval
+        const approvalId = crypto.randomUUID();
+
+        // Signal dApp to open popup
+        (window.parent as Window).postMessage(
+          { type: OPEN_POPUP_MSG, reason: 'approval' },
+          origin,
+        );
+
+        // Send approval request to popup via BroadcastChannel
+        channel.postMessage({
+          type: BRIDGE_MSG.APPROVAL_REQUEST,
+          approvalId,
+          dapp,
+          permissions: perms,
+        });
+
+        // Wait for popup to respond
+        return new Promise((resolve) => {
+          pendingApprovals.set(approvalId, {
+            resolve: (result) => {
+              if (result.approved) {
+                saveApprovedOrigin(origin, dapp, result.grantedPermissions);
+              }
+              resolve(result);
+            },
+          });
+        });
+      },
+
+      onDisconnect: () => {
+        revokeApprovedOrigin(origin);
+      },
+
+      onIntent: async (action: string, params: Record<string, unknown>) => {
+        const intentId = crypto.randomUUID();
+
+        // Signal dApp to open popup for intent approval
+        (window.parent as Window).postMessage(
+          { type: OPEN_POPUP_MSG, reason: 'intent' },
+          origin,
+        );
+
+        // Send intent to popup via BroadcastChannel
+        channel.postMessage({
+          type: BRIDGE_MSG.INTENT_REQUEST,
+          intentId,
+          action,
+          params,
+        });
+
+        // Wait for popup to respond
+        return new Promise((resolve) => {
+          pendingIntents.set(intentId, { resolve });
+        });
+      },
+    });
+
+    setStatus('ready');
+    console.log('[ConnectBridge] ConnectHost created, sending HOST_READY to', origin);
+
+    // Signal to dApp that bridge is ready
+    try {
+      (window.parent as Window).postMessage({ type: HOST_READY_TYPE }, origin);
+    } catch (err) {
+      console.warn('[ConnectBridge] postMessage with origin failed, trying *', err);
+      try {
+        (window.parent as Window).postMessage({ type: HOST_READY_TYPE }, '*');
+      } catch { /* ignore */ }
+    }
+
+    // No cleanup — iframe is GC'd when parent navigates away.
+    // Returning a cleanup would break StrictMode.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sphereReady, origin]);
+
+  // Render nothing visible — this is a headless bridge
+  return (
+    <div style={{ display: 'none' }} data-bridge-status={status} />
+  );
+}

--- a/src/pages/ConnectPage.tsx
+++ b/src/pages/ConnectPage.tsx
@@ -12,10 +12,18 @@ import {
   updateLastSeen,
   revokeApprovedOrigin,
 } from '../utils/connected-sites';
+import {
+  createBridgeChannel,
+  BRIDGE_MSG,
+  type BridgeChannelMessage,
+  type IntentRequestMessage,
+  type ApprovalRequestMessage,
+} from '../utils/connect-bridge-channel';
 
 export function ConnectPage() {
   const [searchParams] = useSearchParams();
   const origin = searchParams.get('origin');
+  const isBridgeMode = searchParams.has('bridge');
   const { sphere, isLoading } = useSphereContext();
   const { requestApproval, requestIntent, setConnectHost } = useConnectContext();
   const hostRef = useRef<ConnectHost | null>(null);
@@ -24,7 +32,6 @@ export function ConnectPage() {
   const [errorMsg, setErrorMsg] = useState('');
   const [connectedDapp, setConnectedDapp] = useState<string | null>(null);
 
-  // Stable refs so the effect doesn't re-run when these change
   const sphereRef = useRef(sphere);
   sphereRef.current = sphere;
   const requestApprovalRef = useRef(requestApproval);
@@ -32,18 +39,80 @@ export function ConnectPage() {
   const requestIntentRef = useRef(requestIntent);
   requestIntentRef.current = requestIntent;
 
-  // Track whether sphere has been available at least once
   const sphereReady = !isLoading && !!sphere;
-
-  // Prevent StrictMode double-mount from destroying the host.
-  // In dev, React runs: mount → cleanup → mount. The cleanup would destroy host1,
-  // then mount creates host2 — but the dApp already connected to host1.
-  // Since this is a popup page, browser GC handles cleanup when the window closes.
   const initializedRef = useRef(false);
 
+  // ---------------------------------------------------------------------------
+  // Bridge mode: popup acts as intent/approval UI for the bridge iframe.
+  // No ConnectHost here — the bridge iframe owns the session.
+  // ---------------------------------------------------------------------------
   useEffect(() => {
+    if (!isBridgeMode) return;
+    if (!origin) return;
     if (!sphereReady) return;
-    // Already initialized (incl. StrictMode second mount) — skip
+    if (initializedRef.current) return;
+
+    initializedRef.current = true;
+    setStatus('ready');
+
+    const channel = createBridgeChannel(origin);
+
+    // Notify bridge that popup is ready
+    channel.postMessage({ type: BRIDGE_MSG.POPUP_READY });
+
+    // Notify bridge when popup is closing
+    const handleBeforeUnload = () => {
+      channel.postMessage({ type: BRIDGE_MSG.POPUP_CLOSED });
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    // Listen for intents and approvals from bridge
+    channel.onmessage = (event: MessageEvent<BridgeChannelMessage>) => {
+      const msg = event.data;
+
+      if (msg.type === BRIDGE_MSG.INTENT_REQUEST) {
+        const intentMsg = msg as IntentRequestMessage;
+        requestIntentRef.current(intentMsg.action, intentMsg.params).then((result) => {
+          channel.postMessage({
+            type: BRIDGE_MSG.INTENT_RESULT,
+            intentId: intentMsg.intentId,
+            result: result.result,
+            error: result.error,
+          });
+        });
+        return;
+      }
+
+      if (msg.type === BRIDGE_MSG.APPROVAL_REQUEST) {
+        const approvalMsg = msg as ApprovalRequestMessage;
+        requestApprovalRef.current(
+          approvalMsg.dapp as DAppMetadata,
+          approvalMsg.permissions as PermissionScope[],
+        ).then((result) => {
+          channel.postMessage({
+            type: BRIDGE_MSG.APPROVAL_RESULT,
+            approvalId: approvalMsg.approvalId,
+            approved: result.approved,
+            grantedPermissions: result.grantedPermissions,
+          });
+        });
+        return;
+      }
+    };
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      channel.close();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isBridgeMode, sphereReady, origin]);
+
+  // ---------------------------------------------------------------------------
+  // Standalone mode (original): popup owns the ConnectHost + session.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (isBridgeMode) return;
+    if (!sphereReady) return;
     if (initializedRef.current) return;
 
     if (!origin) {
@@ -69,7 +138,6 @@ export function ConnectPage() {
       sphere: currentSphere,
       transport,
       onConnectionRequest: async (dapp: DAppMetadata, perms: PermissionScope[], silent?: boolean) => {
-        // Check if this origin was already approved
         const saved = getApprovedOrigin(origin);
         if (saved) {
           updateLastSeen(origin);
@@ -77,12 +145,10 @@ export function ConnectPage() {
           return { approved: true, grantedPermissions: saved.permissions };
         }
 
-        // Silent mode: reject immediately without showing UI
         if (silent) {
           return { approved: false, grantedPermissions: [] };
         }
 
-        // First time — show approval modal
         const result = await requestApprovalRef.current(dapp, perms);
         if (result.approved) {
           setConnectedDapp(dapp.name);
@@ -102,7 +168,6 @@ export function ConnectPage() {
 
     setStatus('ready');
 
-    // Signal to dApp that host is ready
     try {
       (window.opener as Window).postMessage(
         { type: HOST_READY_TYPE },
@@ -117,8 +182,6 @@ export function ConnectPage() {
       } catch { /* ignore */ }
     }
 
-    // No cleanup — popup page is GC'd when window closes.
-    // Returning a cleanup would break StrictMode (destroy host on first unmount).
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sphereReady, origin]);
 
@@ -131,7 +194,9 @@ export function ConnectPage() {
             <div className="flex items-center gap-2">
               <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
               <span className="text-sm font-medium text-gray-700 dark:text-neutral-300">
-                {connectedDapp ? `Connected to ${connectedDapp}` : 'Ready for connections'}
+                {isBridgeMode
+                  ? 'Wallet approval window'
+                  : connectedDapp ? `Connected to ${connectedDapp}` : 'Ready for connections'}
               </span>
             </div>
             {origin && (
@@ -156,7 +221,9 @@ export function ConnectPage() {
         {/* Hint */}
         {status === 'ready' && (
           <p className="text-xs text-center text-gray-400 dark:text-neutral-500 px-4">
-            You can close this window. It will re-open automatically when the dApp needs your wallet.
+            {isBridgeMode
+              ? 'This window handles wallet approvals. You can close it after approving.'
+              : 'You can close this window. The dApp will re-open it when needed.'}
           </p>
         )}
       </div>

--- a/src/utils/connect-bridge-channel.ts
+++ b/src/utils/connect-bridge-channel.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// BroadcastChannel wrapper for iframe bridge ↔ popup intent coordination.
+// Channel scoped per dApp origin to prevent cross-dApp interference.
+// BroadcastChannel is same-origin only — secure by design.
+// ---------------------------------------------------------------------------
+
+export const BRIDGE_MSG = {
+  INTENT_REQUEST: 'intent-request',
+  INTENT_RESULT: 'intent-result',
+  APPROVAL_REQUEST: 'approval-request',
+  APPROVAL_RESULT: 'approval-result',
+  POPUP_READY: 'popup-ready',
+  POPUP_CLOSED: 'popup-closed',
+  OPEN_POPUP: 'open-popup',
+} as const;
+
+export interface IntentRequestMessage {
+  type: typeof BRIDGE_MSG.INTENT_REQUEST;
+  intentId: string;
+  action: string;
+  params: Record<string, unknown>;
+}
+
+export interface IntentResultMessage {
+  type: typeof BRIDGE_MSG.INTENT_RESULT;
+  intentId: string;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+export interface ApprovalRequestMessage {
+  type: typeof BRIDGE_MSG.APPROVAL_REQUEST;
+  approvalId: string;
+  dapp: { name: string; description?: string; url: string; icon?: string };
+  permissions: string[];
+}
+
+export interface ApprovalResultMessage {
+  type: typeof BRIDGE_MSG.APPROVAL_RESULT;
+  approvalId: string;
+  approved: boolean;
+  grantedPermissions: string[];
+}
+
+export interface PopupReadyMessage {
+  type: typeof BRIDGE_MSG.POPUP_READY;
+}
+
+export interface PopupClosedMessage {
+  type: typeof BRIDGE_MSG.POPUP_CLOSED;
+}
+
+export interface OpenPopupMessage {
+  type: typeof BRIDGE_MSG.OPEN_POPUP;
+  reason: 'intent' | 'approval';
+}
+
+export type BridgeChannelMessage =
+  | IntentRequestMessage
+  | IntentResultMessage
+  | ApprovalRequestMessage
+  | ApprovalResultMessage
+  | PopupReadyMessage
+  | PopupClosedMessage
+  | OpenPopupMessage;
+
+function channelName(origin: string): string {
+  return `sphere-connect-bridge:${origin}`;
+}
+
+export function createBridgeChannel(origin: string): BroadcastChannel {
+  return new BroadcastChannel(channelName(origin));
+}


### PR DESCRIPTION
Introduce /connect-bridge route with headless ConnectBridgePage that hosts ConnectHost in a hidden iframe, keeping the session alive after popup close. Popup now only handles intents and first-time approvals via BroadcastChannel.