### PR TITLE
feat: SSL Docker deployment with HAProxy integration

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Block git commit if language-specific checks fail.
+# Auto-detects project type from Cargo.toml, package.json, or go.mod.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only intercept git commit commands
+if ! echo "$COMMAND" | grep -q "git commit"; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+BLOCKED=false
+REASONS=""
+
+# --- Rust ---
+if [ -f "Cargo.toml" ]; then
+  if ! cargo fmt --all --check >/dev/null 2>&1; then
+    BLOCKED=true
+    REASONS="${REASONS}cargo fmt --all --check failed. Run cargo fmt --all to fix formatting.\n"
+  fi
+
+  if ! cargo clippy --workspace -- -D warnings 2>&1 | tail -1 | grep -q "^$\|Finished\|warning: 0 warnings"; then
+    CLIPPY_OUTPUT=$(cargo clippy --workspace -- -D warnings 2>&1 | tail -5)
+    BLOCKED=true
+    REASONS="${REASONS}cargo clippy failed:\n${CLIPPY_OUTPUT}\n"
+  fi
+fi
+
+# --- TypeScript / Node.js ---
+if [ -f "package.json" ]; then
+  # Check if lint script exists
+  if jq -e '.scripts.lint' package.json >/dev/null 2>&1; then
+    LINT_OUTPUT=$(npm run lint --silent 2>&1)
+    if [ $? -ne 0 ]; then
+      BLOCKED=true
+      REASONS="${REASONS}npm run lint failed:\n$(echo "$LINT_OUTPUT" | tail -5)\n"
+    fi
+  fi
+
+  # Check if typecheck script exists
+  if jq -e '.scripts.typecheck' package.json >/dev/null 2>&1; then
+    if ! npm run typecheck --silent >/dev/null 2>&1; then
+      TC_OUTPUT=$(npm run typecheck --silent 2>&1 | tail -5)
+      BLOCKED=true
+      REASONS="${REASONS}npm run typecheck failed:\n${TC_OUTPUT}\n"
+    fi
+  fi
+fi
+
+# --- Go ---
+if [ -f "go.mod" ]; then
+  if ! go vet ./... 2>&1 | grep -q "^$"; then
+    VET_OUTPUT=$(go vet ./... 2>&1 | tail -5)
+    # go vet outputs nothing on success
+    if [ -n "$VET_OUTPUT" ]; then
+      BLOCKED=true
+      REASONS="${REASONS}go vet failed:\n${VET_OUTPUT}\n"
+    fi
+  fi
+
+  # Check gofmt
+  UNFORMATTED=$(gofmt -l . 2>/dev/null)
+  if [ -n "$UNFORMATTED" ]; then
+    BLOCKED=true
+    REASONS="${REASONS}gofmt: unformatted files:\n${UNFORMATTED}\n"
+  fi
+fi
+
+if [ "$BLOCKED" = true ]; then
+  jq -n --arg reason "Pre-commit checks failed. Fix before committing:\n${REASONS}" '{
+    "decision": "block",
+    "reason": $reason
+  }'
+  exit 0
+fi
+
+exit 0

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
-node_modules
-dist
-.git
-.github
-.env
-.env.*
-*.md
-tests
+# Whitelist approach: exclude everything, then allow only what's needed for build
+*
+
+# Node build inputs
+!package.json
+!package-lock.json
+!src/
+!public/
+!tsconfig*.json
+!vite.config.ts
+
+# Entrypoint for ssl-manager stage
+!deploy/entrypoint.sh

--- a/Dockerfile.ssl
+++ b/Dockerfile.ssl
@@ -1,0 +1,29 @@
+# Stage 1: Build React app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+ARG VITE_AGGREGATOR_URL=https://goggregator-test.unicity.network
+ARG VITE_KBBOT_URL=https://sphere.unicity.network
+
+RUN npm run build
+
+# Stage 2: ssl-manager base + nginx
+# Pin digest for reproducible builds. Update with:
+#   docker pull ghcr.io/unicitynetwork/ssl-manager:latest
+#   docker inspect ghcr.io/unicitynetwork/ssl-manager:latest --format '{{index .RepoDigests 0}}'
+FROM ghcr.io/unicitynetwork/ssl-manager@sha256:d73f7df00a38fa3feae88ed2d5d21db68a5d748573441b23d86f30381d6719ae
+
+RUN apt-get update && apt-get install -y --no-install-recommends nginx && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+COPY deploy/entrypoint.sh /usr/local/bin/sphere-entrypoint
+RUN chmod +x /usr/local/bin/sphere-entrypoint
+
+EXPOSE 80 443
+
+ENTRYPOINT ["/usr/local/bin/sphere-entrypoint"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -e
+
+# ── Export env so ssl-setup inherits our defaults ────────────────────────────
+export APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+export SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+
+# ── Validate env vars before use in nginx config ────────────────────────────
+validate_port() {
+    if ! [[ "$2" =~ ^[0-9]+$ ]] || [ "$2" -lt 1 ] || [ "$2" -gt 65535 ]; then
+        echo "ERROR: $1 must be a port number (1-65535), got: '$2'" >&2; exit 1
+    fi
+}
+validate_path() {
+    local allowed='^[a-zA-Z0-9/._-]+$'
+    if ! [[ "$2" =~ $allowed ]]; then
+        echo "ERROR: $1 contains invalid characters: '$2'" >&2; exit 1
+    fi
+    if [[ "$2" == *..* ]]; then
+        echo "ERROR: $1 contains path traversal: '$2'" >&2; exit 1
+    fi
+}
+validate_port "APP_HTTP_PORT" "$APP_HTTP_PORT"
+validate_port "SSL_HTTPS_PORT" "$SSL_HTTPS_PORT"
+
+# ── SSL setup (certs + HAProxy registration) ─────────────────────────────────
+ssl-setup || {
+    rc=$?
+    echo "WARNING: SSL setup failed (exit $rc)"
+    # Kill any orphaned ssl-manager processes from partial setup
+    kill "$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null)" 2>/dev/null || true
+    if [ "${SSL_REQUIRED:-true}" = "true" ]; then exit 1; fi
+}
+
+# Parse cert paths from ssl-env without sourcing (avoid code execution)
+SSL_CERT_FILE=""
+SSL_KEY_FILE=""
+if [ -f /tmp/.ssl-env ]; then
+    SSL_CERT_FILE=$(grep '^SSL_CERT_FILE=' /tmp/.ssl-env | head -1 | cut -d= -f2- || true)
+    SSL_KEY_FILE=$(grep '^SSL_KEY_FILE=' /tmp/.ssl-env | head -1 | cut -d= -f2- || true)
+fi
+
+# Validate cert paths if set
+if [ -n "$SSL_CERT_FILE" ]; then validate_path "SSL_CERT_FILE" "$SSL_CERT_FILE"; fi
+if [ -n "$SSL_KEY_FILE" ]; then validate_path "SSL_KEY_FILE" "$SSL_KEY_FILE"; fi
+
+# Ensure cert directories are readable by nginx workers
+chmod 0755 /etc/letsencrypt/archive/ /etc/letsencrypt/live/ 2>/dev/null || true
+
+# ── Generate nginx config ────────────────────────────────────────────────────
+rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
+
+NGINX_CONF=/etc/nginx/conf.d/sphere.conf
+
+if [ -n "$SSL_CERT_FILE" ] && [ -f "$SSL_CERT_FILE" ] && [ -f "$SSL_KEY_FILE" ]; then
+    cat > "$NGINX_CONF" <<NGINX
+server {
+    listen ${APP_HTTP_PORT};
+    server_name _;
+    return 301 https://\$host\$request_uri;
+}
+
+server {
+    listen ${SSL_HTTPS_PORT} ssl;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    ssl_certificate     ${SSL_CERT_FILE};
+    ssl_certificate_key ${SSL_KEY_FILE};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    resolver 1.1.1.1 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+    ssl_stapling        on;
+    ssl_stapling_verify on;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location = /index.html {
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+    location /assets/ {
+        expires 1y;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "public, immutable";
+    }
+    location / {
+        try_files \$uri \$uri/ /index.html;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}
+NGINX
+    echo "nginx: HTTP :${APP_HTTP_PORT} (redirect), HTTPS :${SSL_HTTPS_PORT}"
+else
+    cat > "$NGINX_CONF" <<NGINX
+server {
+    listen ${APP_HTTP_PORT};
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+}
+NGINX
+    echo "nginx: HTTP-only on :${APP_HTTP_PORT} (no SSL certs found)"
+fi
+
+# ── Graceful shutdown: forward signals to ssl-manager background processes ───
+NGINX_PID=""
+cleanup() {
+    echo "Shutting down..."
+    kill "$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null)" 2>/dev/null || true
+    kill "$(cat /tmp/.ssl-renew.pid 2>/dev/null)" 2>/dev/null || true
+    nginx -s quit 2>/dev/null || true
+    [ -n "$NGINX_PID" ] && wait "$NGINX_PID" 2>/dev/null
+}
+trap cleanup EXIT
+trap 'exit 0' TERM INT
+
+# ── Start nginx ──────────────────────────────────────────────────────────────
+echo "Starting nginx..."
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+wait "$NGINX_PID" 2>/dev/null || true

--- a/run-sphere.sh
+++ b/run-sphere.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Sphere App — Docker launcher with SSL + HAProxy integration
+#
+# Usage:
+#   ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email admin@example.com
+#   ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-test-mode   # self-signed
+#   ./run-sphere.sh --no-ssl                                          # HTTP only
+#   ./run-sphere.sh --no-haproxy --domain sphere-test.dyndns.org      # direct ports
+#
+# Build first:
+#   docker build -f Dockerfile.ssl -t sphere-app:latest .
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── App identity ─────────────────────────────────────────────────────────────
+CONTAINER_NAME="${CONTAINER_NAME:-sphere-app}"
+IMAGE_NAME="${SPHERE_IMAGE:-sphere-app:latest}"
+APP_TITLE="Sphere App"
+
+# ── App networking ───────────────────────────────────────────────────────────
+# APP_NET intentionally unset — sphere needs no app-specific network.
+# run-lib.sh's ${APP_NET:-default} falls back correctly when unset.
+unset APP_NET
+DATA_VOLUME="${DATA_VOLUME:-sphere-data}"
+SSL_CHECK_PORT=443
+SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+
+# ── Source ssl-manager run library ───────────────────────────────────────────
+SSL_MANAGER_DIR="${SSL_MANAGER_DIR:-$(cd "$SCRIPT_DIR/../ssl-manager" 2>/dev/null && pwd || echo "")}"
+if [ -z "$SSL_MANAGER_DIR" ] || [ ! -f "${SSL_MANAGER_DIR}/run-lib.sh" ]; then
+    echo "ERROR: ssl-manager/run-lib.sh not found." >&2
+    echo "  Tried: ${SSL_MANAGER_DIR:-$SCRIPT_DIR/../ssl-manager}" >&2
+    echo "  Set SSL_MANAGER_DIR to the ssl-manager repo path." >&2
+    exit 1
+fi
+source "${SSL_MANAGER_DIR}/run-lib.sh"
+
+# ── App hooks ────────────────────────────────────────────────────────────────
+
+# Called after CLI parsing — sync HEALTH_PORT with final APP_HTTP_PORT
+app_validate() {
+    HEALTH_PORT="$APP_HTTP_PORT"
+}
+
+app_health_check() {
+    local container="$1"
+    local resp
+    if [ "$APP_HTTP_PORT" != "0" ]; then
+        resp=$(docker exec "$container" curl -sf "http://localhost:${APP_HTTP_PORT}/" 2>/dev/null | head -c 100)
+        if [ -n "$resp" ]; then
+            echo "pass:HTTP endpoint responding"
+        else
+            echo "fail:HTTP endpoint not responding"
+        fi
+    fi
+
+    if [ -n "$SSL_DOMAIN" ]; then
+        resp=$(docker exec "$container" curl -sfk "https://localhost:${SSL_HTTPS_PORT}/" 2>/dev/null | head -c 100)
+        if [ -n "$resp" ]; then
+            echo "pass:HTTPS endpoint responding"
+        else
+            echo "fail:HTTPS endpoint not responding"
+        fi
+    fi
+}
+
+app_summary() {
+    echo ""
+    echo "Endpoints:"
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ] && [ -n "$SSL_DOMAIN" ]; then
+        echo "  HTTPS: https://$SSL_DOMAIN"
+        echo "  HTTP:  http://$SSL_DOMAIN"
+    elif [ -n "$SSL_DOMAIN" ]; then
+        echo "  HTTPS: https://localhost"
+        echo "  HTTP:  http://localhost"
+    else
+        echo "  HTTP:  http://localhost"
+    fi
+}
+
+app_help() {
+    cat <<'HELP'
+Sphere Build:
+  Build the image first:
+    docker build -f Dockerfile.ssl -t sphere-app:latest .
+
+  With custom env:
+    docker build -f Dockerfile.ssl -t sphere-app:latest \
+      --build-arg VITE_AGGREGATOR_URL=https://... \
+      --build-arg VITE_KBBOT_URL=https://... .
+HELP
+}
+
+ssl_manager_run "$@"


### PR DESCRIPTION
## Summary

- Adds production-ready Docker deployment for `sphere-test.dyndns.org` with automatic Let's Encrypt SSL via ssl-manager and HAProxy reverse proxy registration
- New `Dockerfile.ssl` (multi-stage: React build → ssl-manager + nginx), `deploy/entrypoint.sh` (container entrypoint), and `run-sphere.sh` (host-side launcher)
- Switches `.dockerignore` to whitelist approach (~15KB build context, no secret leaks)
- Fixes pre-commit hook false positive when `npm run lint` produces no output

### Security hardening (3 rounds of adversarial review)

- Pinned ssl-manager image digest for reproducible builds
- Input validation on all env vars interpolated into nginx config
- Path traversal prevention in cert path validation
- Safe `/tmp/.ssl-env` parsing (grep/cut instead of bash source)
- PID 1 signal handling (`trap 'exit 0' TERM INT` + EXIT trap) for graceful shutdown
- HSTS, X-Content-Type-Options, X-Frame-Options security headers
- OCSP stapling with DNS resolver
- Cert directory permissions for nginx workers

### Usage

    # Build
    docker build -f Dockerfile.ssl -t sphere-app:latest .

    # Launch with HAProxy + real SSL
    ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email admin@example.com

    # Launch with self-signed cert (dev)
    ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-test-mode

    # HTTP only (no SSL)
    ./run-sphere.sh --no-ssl

## Test plan

- [x] Docker image builds successfully (~15KB context)
- [x] Container starts, ssl-setup provisions cert, registers with HAProxy
- [x] HTTPS returns 200 with correct security headers
- [x] HTTP returns 301 redirect to HTTPS
- [x] OCSP stapling configured with resolver
- [x] Graceful shutdown completes in <5s
- [x] No secrets in Docker build context
- [x] npm run lint and npx tsc --noEmit pass cleanly
- [ ] Verify --no-ssl and --no-haproxy modes
- [ ] Verify --app-http-port CLI flag syncs HEALTH_PORT