### PR TITLE
deps(sphere): bump @unicitylabs/sphere-sdk to 0.6.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.90.10",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.6.13",
+        "@unicitylabs/sphere-sdk": "^0.6.14",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
         "framer-motion": "^12.23.24",
@@ -2666,9 +2666,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.6.13.tgz",
-      "integrity": "sha512-H31wFkFjFtUlqVB+Fo+/pRjVhnZWoErqtmio6ml8y98Ggg8dEBDa/lly0vS8NuAnJEbdna+msEas+PhushPIdg==",
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.6.14.tgz",
+      "integrity": "sha512-7SaAK1xkDC+n3aAb+2a7XYiMk8rtd9eep3CvuKNjTmFSa+/RGPVsh4kAI00HWLsACjTOabLwjn69mQ0xWbty3g==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.90.10",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.6.13",
+    "@unicitylabs/sphere-sdk": "^0.6.14",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",
     "framer-motion": "^12.23.24",


### PR DESCRIPTION
## Summary
- Bumps `@unicitylabs/sphere-sdk` from 0.6.13 to 0.6.14
- Upstream changes are additive-only (CLI hang fix, instant-split change-token preservation, new optional `waitForPendingOperations()` API)
- No breaking changes, no code adjustments needed in sphere

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run test:run` — 37/37 tests pass
- [ ] Smoke test send/receive flows in the dev server

Note: independent of the in-flight sphere-sdk fix PR (unicity-sphere/sphere-sdk#113 — publishEvent retry on relay rejection). That fix will land in a later sphere-sdk release and warrant a follow-up bump.