### PR TITLE
ci(docker): add SSL + HAProxy serving setup

### DIFF
--- a/Dockerfile.ssl
+++ b/Dockerfile.ssl
@@ -1,0 +1,29 @@
+# Stage 1: Build React app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+ARG VITE_AGGREGATOR_URL=https://goggregator-test.unicity.network
+ARG VITE_KBBOT_URL=https://sphere.unicity.network
+
+RUN npm run build
+
+# Stage 2: ssl-manager base + nginx
+# Pin digest for reproducible builds. Update with:
+#   docker pull ghcr.io/unicitynetwork/ssl-manager:latest
+#   docker inspect ghcr.io/unicitynetwork/ssl-manager:latest --format '{{index .RepoDigests 0}}'
+FROM ghcr.io/unicitynetwork/ssl-manager@sha256:d73f7df00a38fa3feae88ed2d5d21db68a5d748573441b23d86f30381d6719ae
+
+RUN apt-get update && apt-get install -y --no-install-recommends nginx && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+COPY deploy/entrypoint.sh /usr/local/bin/sphere-entrypoint
+RUN chmod +x /usr/local/bin/sphere-entrypoint
+
+EXPOSE 80 443
+
+ENTRYPOINT ["/usr/local/bin/sphere-entrypoint"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -e
+
+# ── Export env so ssl-setup inherits our defaults ────────────────────────────
+export APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+export SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+
+# ── Validate env vars before use in nginx config ────────────────────────────
+validate_port() {
+    if ! [[ "$2" =~ ^[0-9]+$ ]] || [ "$2" -lt 1 ] || [ "$2" -gt 65535 ]; then
+        echo "ERROR: $1 must be a port number (1-65535), got: '$2'" >&2; exit 1
+    fi
+}
+validate_path() {
+    local allowed='^[a-zA-Z0-9/._-]+$'
+    if ! [[ "$2" =~ $allowed ]]; then
+        echo "ERROR: $1 contains invalid characters: '$2'" >&2; exit 1
+    fi
+    if [[ "$2" == *..* ]]; then
+        echo "ERROR: $1 contains path traversal: '$2'" >&2; exit 1
+    fi
+}
+validate_port "APP_HTTP_PORT" "$APP_HTTP_PORT"
+validate_port "SSL_HTTPS_PORT" "$SSL_HTTPS_PORT"
+
+# ── SSL setup (certs + HAProxy registration) ─────────────────────────────────
+ssl-setup || {
+    rc=$?
+    echo "WARNING: SSL setup failed (exit $rc)"
+    # Kill any orphaned ssl-manager processes from partial setup
+    kill "$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null)" 2>/dev/null || true
+    if [ "${SSL_REQUIRED:-true}" = "true" ]; then exit 1; fi
+}
+
+# Parse cert paths from ssl-env without sourcing (avoid code execution)
+SSL_CERT_FILE=""
+SSL_KEY_FILE=""
+if [ -f /tmp/.ssl-env ]; then
+    SSL_CERT_FILE=$(grep '^SSL_CERT_FILE=' /tmp/.ssl-env | head -1 | cut -d= -f2- || true)
+    SSL_KEY_FILE=$(grep '^SSL_KEY_FILE=' /tmp/.ssl-env | head -1 | cut -d= -f2- || true)
+fi
+
+# Validate cert paths if set
+if [ -n "$SSL_CERT_FILE" ]; then validate_path "SSL_CERT_FILE" "$SSL_CERT_FILE"; fi
+if [ -n "$SSL_KEY_FILE" ]; then validate_path "SSL_KEY_FILE" "$SSL_KEY_FILE"; fi
+
+# Ensure cert directories are readable by nginx workers
+chmod 0755 /etc/letsencrypt/archive/ /etc/letsencrypt/live/ 2>/dev/null || true
+
+# ── Generate nginx config ────────────────────────────────────────────────────
+rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
+
+NGINX_CONF=/etc/nginx/conf.d/sphere.conf
+
+if [ -n "$SSL_CERT_FILE" ] && [ -f "$SSL_CERT_FILE" ] && [ -f "$SSL_KEY_FILE" ]; then
+    cat > "$NGINX_CONF" <<NGINX
+server {
+    listen ${APP_HTTP_PORT};
+    server_name _;
+    return 301 https://\$host\$request_uri;
+}
+
+server {
+    listen ${SSL_HTTPS_PORT} ssl;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    ssl_certificate     ${SSL_CERT_FILE};
+    ssl_certificate_key ${SSL_KEY_FILE};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    resolver 1.1.1.1 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+    ssl_stapling        on;
+    ssl_stapling_verify on;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location = /index.html {
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+    location /assets/ {
+        expires 1y;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "public, immutable";
+    }
+    location / {
+        try_files \$uri \$uri/ /index.html;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}
+NGINX
+    echo "nginx: HTTP :${APP_HTTP_PORT} (redirect), HTTPS :${SSL_HTTPS_PORT}"
+else
+    cat > "$NGINX_CONF" <<NGINX
+server {
+    listen ${APP_HTTP_PORT};
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+}
+NGINX
+    echo "nginx: HTTP-only on :${APP_HTTP_PORT} (no SSL certs found)"
+fi
+
+# ── Graceful shutdown: forward signals to ssl-manager background processes ───
+NGINX_PID=""
+cleanup() {
+    echo "Shutting down..."
+    kill "$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null)" 2>/dev/null || true
+    kill "$(cat /tmp/.ssl-renew.pid 2>/dev/null)" 2>/dev/null || true
+    nginx -s quit 2>/dev/null || true
+    [ -n "$NGINX_PID" ] && wait "$NGINX_PID" 2>/dev/null
+}
+trap cleanup EXIT
+trap 'exit 0' TERM INT
+
+# ── Start nginx ──────────────────────────────────────────────────────────────
+echo "Starting nginx..."
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+wait "$NGINX_PID" 2>/dev/null || true

--- a/run-sphere.sh
+++ b/run-sphere.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Sphere App — Docker launcher with SSL + HAProxy integration
+#
+# Usage:
+#   ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email admin@example.com
+#   ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-test-mode   # self-signed
+#   ./run-sphere.sh --no-ssl                                          # HTTP only
+#   ./run-sphere.sh --no-haproxy --domain sphere-test.dyndns.org      # direct ports
+#
+# Build first:
+#   docker build -f Dockerfile.ssl -t sphere-app:latest .
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── App identity ─────────────────────────────────────────────────────────────
+CONTAINER_NAME="${CONTAINER_NAME:-sphere-app}"
+IMAGE_NAME="${SPHERE_IMAGE:-sphere-app:latest}"
+APP_TITLE="Sphere App"
+
+# ── App networking ───────────────────────────────────────────────────────────
+# APP_NET intentionally unset — sphere needs no app-specific network.
+# run-lib.sh's ${APP_NET:-default} falls back correctly when unset.
+unset APP_NET
+DATA_VOLUME="${DATA_VOLUME:-sphere-data}"
+SSL_CHECK_PORT=443
+SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+
+# ── Source ssl-manager run library ───────────────────────────────────────────
+SSL_MANAGER_DIR="${SSL_MANAGER_DIR:-$(cd "$SCRIPT_DIR/../ssl-manager" 2>/dev/null && pwd || echo "")}"
+if [ -z "$SSL_MANAGER_DIR" ] || [ ! -f "${SSL_MANAGER_DIR}/run-lib.sh" ]; then
+    echo "ERROR: ssl-manager/run-lib.sh not found." >&2
+    echo "  Tried: ${SSL_MANAGER_DIR:-$SCRIPT_DIR/../ssl-manager}" >&2
+    echo "  Set SSL_MANAGER_DIR to the ssl-manager repo path." >&2
+    exit 1
+fi
+source "${SSL_MANAGER_DIR}/run-lib.sh"
+
+# ── App hooks ────────────────────────────────────────────────────────────────
+
+# Called after CLI parsing — sync HEALTH_PORT with final APP_HTTP_PORT
+app_validate() {
+    HEALTH_PORT="$APP_HTTP_PORT"
+}
+
+app_health_check() {
+    local container="$1"
+    local resp
+    if [ "$APP_HTTP_PORT" != "0" ]; then
+        resp=$(docker exec "$container" curl -sf "http://localhost:${APP_HTTP_PORT}/" 2>/dev/null | head -c 100)
+        if [ -n "$resp" ]; then
+            echo "pass:HTTP endpoint responding"
+        else
+            echo "fail:HTTP endpoint not responding"
+        fi
+    fi
+
+    if [ -n "$SSL_DOMAIN" ]; then
+        resp=$(docker exec "$container" curl -sfk "https://localhost:${SSL_HTTPS_PORT}/" 2>/dev/null | head -c 100)
+        if [ -n "$resp" ]; then
+            echo "pass:HTTPS endpoint responding"
+        else
+            echo "fail:HTTPS endpoint not responding"
+        fi
+    fi
+}
+
+app_summary() {
+    echo ""
+    echo "Endpoints:"
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ] && [ -n "$SSL_DOMAIN" ]; then
+        echo "  HTTPS: https://$SSL_DOMAIN"
+        echo "  HTTP:  http://$SSL_DOMAIN"
+    elif [ -n "$SSL_DOMAIN" ]; then
+        echo "  HTTPS: https://localhost"
+        echo "  HTTP:  http://localhost"
+    else
+        echo "  HTTP:  http://localhost"
+    fi
+}
+
+app_help() {
+    cat <<'HELP'
+Sphere Build:
+  Build the image first:
+    docker build -f Dockerfile.ssl -t sphere-app:latest .
+
+  With custom env:
+    docker build -f Dockerfile.ssl -t sphere-app:latest \
+      --build-arg VITE_AGGREGATOR_URL=https://... \
+      --build-arg VITE_KBBOT_URL=https://... .
+HELP
+}
+
+ssl_manager_run "$@"


### PR DESCRIPTION
## Summary

Adds a production-grade Docker image and launcher for serving Sphere via nginx behind HAProxy with SSL termination, ported from `sphere.telco` (branch `feat/telco-webrtc-calls`).

- `Dockerfile.ssl` — multi-stage build. `node:20-alpine` builds the Vite bundle; stage 2 is the `ghcr.io/unicitynetwork/ssl-manager` image (pinned by digest) with nginx installed on top, and the built `dist/` copied to `/usr/share/nginx/html`.
- `deploy/entrypoint.sh` — runs `ssl-setup`, parses cert paths from `/tmp/.ssl-env`, generates the nginx config (HTTPS with HSTS + redirect, or HTTP-only fallback), and supervises nginx.
- `run-sphere.sh` — wrapper that sources `ssl-manager/run-lib.sh` and implements the app-specific hooks (validate, health check, summary, help). Usage examples:

  ```bash
  docker build -f Dockerfile.ssl -t sphere-app:latest .
  ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email admin@example.com
  ./run-sphere.sh --no-ssl                     # HTTP only
  ```

No changes to the existing simple `Dockerfile` / `docker-compose.yml` — this is an additive deployment option.

## Test plan

- [x] `npm ci && npm run build` succeeds on `main` with current `@unicitylabs/sphere-sdk@^0.6.13`.
- [x] `npm run dev` serves over HTTPS (returns 200 on `https://localhost:<port>/`).
- [x] `docker build -f Dockerfile.ssl -t sphere-app:pr-test .` builds cleanly (multi-stage completes, nginx installed, `dist/` copied, entrypoint chmod'd).
- [ ] End-to-end: `./run-sphere.sh --domain <host> --ssl-test-mode` brings the container up behind HAProxy and serves HTTPS. (requires a configured ssl-manager + haproxy deployment on the target host.)