### PR TITLE
deps(sphere): bump @unicitylabs/sphere-sdk to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.90.10",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.6.14",
+        "@unicitylabs/sphere-sdk": "^0.7.0",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
         "framer-motion": "^12.23.24",
@@ -2666,9 +2666,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.6.14.tgz",
-      "integrity": "sha512-7SaAK1xkDC+n3aAb+2a7XYiMk8rtd9eep3CvuKNjTmFSa+/RGPVsh4kAI00HWLsACjTOabLwjn69mQ0xWbty3g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.7.0.tgz",
+      "integrity": "sha512-QZ+TG3Nr41m6wIhppj2cJSjHPr/gO1X0NONkEXVQV+g9QIqW0lzKi1OYdZDUgYIFjoIO9sNgiuqW1vsher6hgg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",
@@ -2677,6 +2677,7 @@
         "@unicitylabs/state-transition-sdk": "1.6.1-rc.f37cb85",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1"
       },
@@ -3432,6 +3433,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cborg": {
       "version": "4.5.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.90.10",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.6.14",
+    "@unicitylabs/sphere-sdk": "^0.7.0",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",
     "framer-motion": "^12.23.24",


### PR DESCRIPTION
## Summary

Bumps `@unicitylabs/sphere-sdk` from `^0.6.13` → `^0.7.0` (npm registry, no local `file:` dep).

Upstream highlights in 0.7.0:
- **AccountingModule** — invoice lifecycle, payment attribution, privacy-preserving hashed invoice IDs on-chain
- **SwapModule** — P2P token swap with escrow protocol
- **Transport hardening** — `publishEvent` retry against flaky relays, verified publishes with jittered delays, subscription health check (90s wallet / 60s chat), shared `TransportAddressResolver` with in-flight dedup
- **Payments** — SpendQueue + TOCTOU fix for concurrent `send()` calls, `excludeReservationId`, bounded `drainAll()`
- **CLI overhaul** — unified `<amount> <symbol>` asset convention, shell completion, accounting/swap/asset commands

## Consumer impact on sphere

No code changes needed in `src/` — the surface sphere uses is backwards-compatible in 0.7.0.

## Test plan

- [x] `npx tsc --noEmit` (exit 0)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test:run` — 37/37 passing
- [x] `npm run dev` serves HTTPS 200 locally
- [ ] Manual smoke: L1/L3 wallet, DM, group chat, agents (to be exercised in preview deploy)