### PR TITLE
feat(deploy): HAProxy-fronted Docker serving + sphere-sdk 0.7.0

### DIFF
--- a/Dockerfile.ssl
+++ b/Dockerfile.ssl
@@ -1,0 +1,29 @@
+# Stage 1: Build React app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+ARG VITE_AGGREGATOR_URL=https://goggregator-test.unicity.network
+ARG VITE_KBBOT_URL=https://sphere.unicity.network
+
+RUN npm run build
+
+# Stage 2: ssl-manager base + nginx
+# Pin digest for reproducible builds. Update with:
+#   docker pull ghcr.io/unicitynetwork/ssl-manager:latest
+#   docker inspect ghcr.io/unicitynetwork/ssl-manager:latest --format '{{index .RepoDigests 0}}'
+FROM ghcr.io/unicitynetwork/ssl-manager@sha256:d73f7df00a38fa3feae88ed2d5d21db68a5d748573441b23d86f30381d6719ae
+
+RUN apt-get update && apt-get install -y --no-install-recommends nginx && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+COPY deploy/entrypoint.sh /usr/local/bin/sphere-entrypoint
+RUN chmod +x /usr/local/bin/sphere-entrypoint
+
+EXPOSE 80 443
+
+ENTRYPOINT ["/usr/local/bin/sphere-entrypoint"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -e
+
+# ── Export env so ssl-setup inherits our defaults ────────────────────────────
+export APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+export SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+
+# ── Validate env vars before use in nginx config ────────────────────────────
+validate_port() {
+    if ! [[ "$2" =~ ^[0-9]+$ ]] || [ "$2" -lt 1 ] || [ "$2" -gt 65535 ]; then
+        echo "ERROR: $1 must be a port number (1-65535), got: '$2'" >&2; exit 1
+    fi
+}
+validate_path() {
+    local allowed='^[a-zA-Z0-9/._-]+$'
+    if ! [[ "$2" =~ $allowed ]]; then
+        echo "ERROR: $1 contains invalid characters: '$2'" >&2; exit 1
+    fi
+    if [[ "$2" == *..* ]]; then
+        echo "ERROR: $1 contains path traversal: '$2'" >&2; exit 1
+    fi
+}
+validate_port "APP_HTTP_PORT" "$APP_HTTP_PORT"
+validate_port "SSL_HTTPS_PORT" "$SSL_HTTPS_PORT"
+
+# ── SSL setup (certs + HAProxy registration) ─────────────────────────────────
+ssl-setup || {
+    rc=$?
+    echo "WARNING: SSL setup failed (exit $rc)"
+    # Kill any orphaned ssl-manager processes from partial setup
+    kill "$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null)" 2>/dev/null || true
+    if [ "${SSL_REQUIRED:-true}" = "true" ]; then exit 1; fi
+}
+
+# Parse cert paths from ssl-env without sourcing (avoid code execution)
+SSL_CERT_FILE=""
+SSL_KEY_FILE=""
+if [ -f /tmp/.ssl-env ]; then
+    SSL_CERT_FILE=$(grep '^SSL_CERT_FILE=' /tmp/.ssl-env | head -1 | cut -d= -f2- || true)
+    SSL_KEY_FILE=$(grep '^SSL_KEY_FILE=' /tmp/.ssl-env | head -1 | cut -d= -f2- || true)
+fi
+
+# Validate cert paths if set
+if [ -n "$SSL_CERT_FILE" ]; then validate_path "SSL_CERT_FILE" "$SSL_CERT_FILE"; fi
+if [ -n "$SSL_KEY_FILE" ]; then validate_path "SSL_KEY_FILE" "$SSL_KEY_FILE"; fi
+
+# Ensure cert directories are readable by nginx workers
+chmod 0755 /etc/letsencrypt/archive/ /etc/letsencrypt/live/ 2>/dev/null || true
+
+# ── Generate nginx config ────────────────────────────────────────────────────
+rm -f /etc/nginx/sites-enabled/default /etc/nginx/conf.d/default.conf
+
+NGINX_CONF=/etc/nginx/conf.d/sphere.conf
+
+if [ -n "$SSL_CERT_FILE" ] && [ -f "$SSL_CERT_FILE" ] && [ -f "$SSL_KEY_FILE" ]; then
+    cat > "$NGINX_CONF" <<NGINX
+server {
+    listen ${APP_HTTP_PORT};
+    server_name _;
+    return 301 https://\$host\$request_uri;
+}
+
+server {
+    listen ${SSL_HTTPS_PORT} ssl;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    ssl_certificate     ${SSL_CERT_FILE};
+    ssl_certificate_key ${SSL_KEY_FILE};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    resolver 1.1.1.1 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+    ssl_stapling        on;
+    ssl_stapling_verify on;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location = /index.html {
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+    location /assets/ {
+        expires 1y;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "public, immutable";
+    }
+    location / {
+        try_files \$uri \$uri/ /index.html;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}
+NGINX
+    echo "nginx: HTTP :${APP_HTTP_PORT} (redirect), HTTPS :${SSL_HTTPS_PORT}"
+else
+    cat > "$NGINX_CONF" <<NGINX
+server {
+    listen ${APP_HTTP_PORT};
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+}
+NGINX
+    echo "nginx: HTTP-only on :${APP_HTTP_PORT} (no SSL certs found)"
+fi
+
+# ── Graceful shutdown: forward signals to ssl-manager background processes ───
+NGINX_PID=""
+cleanup() {
+    echo "Shutting down..."
+    kill "$(cat /tmp/.ssl-http-proxy.pid 2>/dev/null)" 2>/dev/null || true
+    kill "$(cat /tmp/.ssl-renew.pid 2>/dev/null)" 2>/dev/null || true
+    nginx -s quit 2>/dev/null || true
+    [ -n "$NGINX_PID" ] && wait "$NGINX_PID" 2>/dev/null
+}
+trap cleanup EXIT
+trap 'exit 0' TERM INT
+
+# ── Start nginx ──────────────────────────────────────────────────────────────
+echo "Starting nginx..."
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+wait "$NGINX_PID" 2>/dev/null || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.90.10",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.6.13",
+        "@unicitylabs/sphere-sdk": "^0.7.0",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
         "framer-motion": "^12.23.24",
@@ -2666,9 +2666,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.6.13.tgz",
-      "integrity": "sha512-H31wFkFjFtUlqVB+Fo+/pRjVhnZWoErqtmio6ml8y98Ggg8dEBDa/lly0vS8NuAnJEbdna+msEas+PhushPIdg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.7.0.tgz",
+      "integrity": "sha512-QZ+TG3Nr41m6wIhppj2cJSjHPr/gO1X0NONkEXVQV+g9QIqW0lzKi1OYdZDUgYIFjoIO9sNgiuqW1vsher6hgg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",
@@ -2677,6 +2677,7 @@
         "@unicitylabs/state-transition-sdk": "1.6.1-rc.f37cb85",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1"
       },
@@ -3432,6 +3433,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cborg": {
       "version": "4.5.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@tailwindcss/vite": "^4.1.16",
     "@tanstack/react-query": "^5.90.10",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.6.13",
+    "@unicitylabs/sphere-sdk": "^0.7.0",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",
     "framer-motion": "^12.23.24",

--- a/run-sphere.sh
+++ b/run-sphere.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Sphere App — Docker launcher with SSL + HAProxy integration
+#
+# Usage:
+#   ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email admin@example.com
+#   ./run-sphere.sh --domain sphere-test.dyndns.org --ssl-test-mode   # self-signed
+#   ./run-sphere.sh --no-ssl                                          # HTTP only
+#   ./run-sphere.sh --no-haproxy --domain sphere-test.dyndns.org      # direct ports
+#
+# Build first:
+#   docker build -f Dockerfile.ssl -t sphere-app:latest .
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── App identity ─────────────────────────────────────────────────────────────
+CONTAINER_NAME="${CONTAINER_NAME:-sphere-app}"
+IMAGE_NAME="${SPHERE_IMAGE:-sphere-app:latest}"
+APP_TITLE="Sphere App"
+
+# ── App networking ───────────────────────────────────────────────────────────
+# APP_NET intentionally unset — sphere needs no app-specific network.
+# run-lib.sh's ${APP_NET:-default} falls back correctly when unset.
+unset APP_NET
+DATA_VOLUME="${DATA_VOLUME:-sphere-data}"
+SSL_CHECK_PORT=443
+SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
+APP_HTTP_PORT="${APP_HTTP_PORT:-8080}"
+
+# ── Source ssl-manager run library ───────────────────────────────────────────
+SSL_MANAGER_DIR="${SSL_MANAGER_DIR:-$(cd "$SCRIPT_DIR/../ssl-manager" 2>/dev/null && pwd || echo "")}"
+if [ -z "$SSL_MANAGER_DIR" ] || [ ! -f "${SSL_MANAGER_DIR}/run-lib.sh" ]; then
+    echo "ERROR: ssl-manager/run-lib.sh not found." >&2
+    echo "  Tried: ${SSL_MANAGER_DIR:-$SCRIPT_DIR/../ssl-manager}" >&2
+    echo "  Set SSL_MANAGER_DIR to the ssl-manager repo path." >&2
+    exit 1
+fi
+source "${SSL_MANAGER_DIR}/run-lib.sh"
+
+# ── App hooks ────────────────────────────────────────────────────────────────
+
+# Called after CLI parsing — sync HEALTH_PORT with final APP_HTTP_PORT
+app_validate() {
+    HEALTH_PORT="$APP_HTTP_PORT"
+}
+
+app_health_check() {
+    local container="$1"
+    local resp
+    if [ "$APP_HTTP_PORT" != "0" ]; then
+        resp=$(docker exec "$container" curl -sf "http://localhost:${APP_HTTP_PORT}/" 2>/dev/null | head -c 100)
+        if [ -n "$resp" ]; then
+            echo "pass:HTTP endpoint responding"
+        else
+            echo "fail:HTTP endpoint not responding"
+        fi
+    fi
+
+    if [ -n "$SSL_DOMAIN" ]; then
+        resp=$(docker exec "$container" curl -sfk "https://localhost:${SSL_HTTPS_PORT}/" 2>/dev/null | head -c 100)
+        if [ -n "$resp" ]; then
+            echo "pass:HTTPS endpoint responding"
+        else
+            echo "fail:HTTPS endpoint not responding"
+        fi
+    fi
+}
+
+app_summary() {
+    echo ""
+    echo "Endpoints:"
+    if [ "$USE_HAPROXY" = true ] && [ -n "$HAPROXY_HOST" ] && [ -n "$SSL_DOMAIN" ]; then
+        echo "  HTTPS: https://$SSL_DOMAIN"
+        echo "  HTTP:  http://$SSL_DOMAIN"
+    elif [ -n "$SSL_DOMAIN" ]; then
+        echo "  HTTPS: https://localhost"
+        echo "  HTTP:  http://localhost"
+    else
+        echo "  HTTP:  http://localhost"
+    fi
+}
+
+app_help() {
+    cat <<'HELP'
+Sphere Build:
+  Build the image first:
+    docker build -f Dockerfile.ssl -t sphere-app:latest .
+
+  With custom env:
+    docker build -f Dockerfile.ssl -t sphere-app:latest \
+      --build-arg VITE_AGGREGATOR_URL=https://... \
+      --build-arg VITE_KBBOT_URL=https://... .
+HELP
+}
+
+ssl_manager_run "$@"


### PR DESCRIPTION
## Summary

Single PR containing everything needed to operate Sphere behind the HAProxy Docker setup on `sphere-test.dyndns.org` (and any similar ssl-manager + HAProxy host).

Combines the two scoped PRs:
- #295 — docker/haproxy serving setup (`Dockerfile.ssl`, `deploy/entrypoint.sh`, `run-sphere.sh`)
- #296 — `@unicitylabs/sphere-sdk` `^0.6.13` → `^0.7.0`

Merge this PR (or the two component PRs) and the `run-sphere.sh` launcher will register the container with the running HAProxy and serve the latest SDK.

## What ships

| File | Purpose |
|---|---|
| `Dockerfile.ssl` | Multi-stage build: `node:20-alpine` produces `dist/`, then `ghcr.io/unicitynetwork/ssl-manager` (pinned by digest) + nginx copies it to `/usr/share/nginx/html`. |
| `deploy/entrypoint.sh` | Runs `ssl-setup`, parses cert paths from `/tmp/.ssl-env`, generates the nginx config (HTTPS + HSTS + 80→443 redirect, or HTTP-only fallback), and supervises nginx. |
| `run-sphere.sh` | Thin wrapper over `ssl-manager/run-lib.sh` implementing the app hooks (validate/health/summary/help). |
| `package.json` / `package-lock.json` | `@unicitylabs/sphere-sdk` bumped to `^0.7.0` from the npm registry (no `file:` dep). |

## Operating instructions

On a host with the HAProxy container (`haproxy` on network `haproxy-net`) and the ssl-manager repo at `../ssl-manager`:

```bash
# 1. Build the image
docker build -f Dockerfile.ssl -t sphere-app:latest .

# 2. Replace the running container (if any) and register with HAProxy
docker rm -f sphere-app 2>/dev/null || true
./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email admin@unicity.network

# 3. Verify
curl -sSI https://sphere-test.dyndns.org/ | head -5
```

Flags of interest:
- `--ssl-test-mode` — self-signed cert, avoids Let's Encrypt rate limits on first bring-up.
- `--no-ssl` — HTTP only (still HAProxy-registered).
- `--no-haproxy --domain …` — bind host ports directly, skip HAProxy.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run build` — passes
- [x] `npm run test:run` — 37/37 passing
- [x] `docker build -f Dockerfile.ssl -t sphere-app:combined-test .` — completes cleanly
- [ ] Manual on-host: `./run-sphere.sh --domain sphere-test.dyndns.org --ssl-email …`, then `curl -sSI https://sphere-test.dyndns.org/` returns 200 and HAProxy `https-domains.map` points at the new container ID.

## Relation to the component PRs

This PR is a superset. Close #295 and #296 as superseded if this one merges, or merge those individually if you prefer the smaller diffs — the outcome on `main` is the same.