### PR TITLE
ci: re-enable Dockerfile.ssl in validate matrix

### DIFF
--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -1,21 +1,14 @@
 name: Validate Docker Images
 
-# Build-validate Dockerfiles on PRs and main pushes so image-definition
-# regressions fail CI, not deploy. No push — validation only.
+# Build-validate both Dockerfiles on PRs and main pushes so image-
+# definition regressions fail CI, not deploy. No push — validation only.
 #
-# NOTE on Dockerfile.ssl: its base image is
-# `ghcr.io/unicitynetwork/ssl-manager` which lives in a *different* org
-# than this repo (unicity-sphere). The default GITHUB_TOKEN cannot read
-# packages across orgs, so Dockerfile.ssl cannot be validated here
-# without additional configuration. To enable:
-#   (a) Grant the unicity-sphere/sphere repo read access to the
-#       unicitynetwork/ssl-manager package (GitHub → Packages → ssl-manager
-#       → Package settings → Manage Actions access → add sphere), or
-#   (b) Add a PAT with packages:read on unicitynetwork as a repo secret
-#       (e.g. GHCR_CROSS_ORG_TOKEN) and log in with it below.
-# Until then, Dockerfile.ssl is build-validated locally on deploy hosts
-# (see run-sphere.sh) — the Dockerfile matrix row below catches the
-# shared builder stage regardless.
+# Dockerfile.ssl pulls `ghcr.io/unicitynetwork/ssl-manager` as its base.
+# That package is published publicly on GHCR, so no registry auth is
+# needed. If it ever goes private again, either grant this repo read
+# access via the package's "Manage Actions access" settings, or add a
+# docker/login-action step below (using GITHUB_TOKEN within-org or a
+# cross-org PAT secret for external-org packages).
 on:
   pull_request:
     paths:
@@ -35,7 +28,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   validate:
@@ -43,8 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Dockerfile.ssl is intentionally excluded — see top-of-file note.
-        dockerfile: [Dockerfile]
+        dockerfile: [Dockerfile, Dockerfile.ssl]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Now that \`ghcr.io/unicitynetwork/ssl-manager\` is public, the validate workflow can pull it anonymously. Restores \`Dockerfile.ssl\` in the matrix row that #298 had to skip.

- Re-add \`Dockerfile.ssl\` to the matrix in \`.github/workflows/docker-validate.yml\`.
- Drop \`packages: read\` (no longer needed for public images).
- Replace the multi-option privacy workaround comment with a one-liner describing what to do if it ever goes private again.

## Test plan

- [x] \`docker pull ghcr.io/unicitynetwork/ssl-manager@sha256:d73f…\` works anonymously.
- [ ] CI on this PR: \`validate (Dockerfile.ssl)\` goes green — gate for merge.