### PR TITLE
fix(deploy): second-round hardening — drain budget, CI smoke, SSL_REQUIRED trim

### DIFF
--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -25,6 +25,7 @@ on:
       - '.github/workflows/docker-validate.yml'
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -43,12 +44,46 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # load: true hands the built image to the runner's docker daemon so
+      # the smoke step below can actually run it. Without this, a Dockerfile
+      # that compiles but produces a broken image (bad entrypoint path,
+      # missing runtime binary, nginx config syntax error deferred until
+      # runtime) would pass validation and fail only at deploy.
       - name: Build ${{ matrix.dockerfile }}
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           push: false
-          load: false
+          load: true
+          tags: sphere-validate:${{ matrix.dockerfile }}
           cache-from: type=gha,scope=${{ matrix.dockerfile }}
           cache-to: type=gha,mode=max,scope=${{ matrix.dockerfile }}
+
+      # Smoke test: verify nginx's runtime config is parseable. Catches
+      # heredoc-interpolation bugs in deploy/entrypoint.sh (Dockerfile.ssl)
+      # and default-config regressions (Dockerfile).
+      - name: Smoke — nginx config parses
+        if: matrix.dockerfile == 'Dockerfile'
+        run: |
+          docker run --rm --entrypoint nginx \
+            sphere-validate:${{ matrix.dockerfile }} -t
+
+      # Smoke for the SSL image: entrypoint is tini → sphere-entrypoint.
+      # We can't run the real entrypoint in CI (ssl-setup would need
+      # SSL_DOMAIN / network), but we can verify tini, the entrypoint
+      # script, curl, and nginx are all present and executable, and that
+      # the script itself is syntactically valid bash.
+      - name: Smoke — image contents present and entrypoint syntactic
+        if: matrix.dockerfile == 'Dockerfile.ssl'
+        run: |
+          docker run --rm --entrypoint /bin/bash \
+            sphere-validate:${{ matrix.dockerfile }} -c '
+              set -e
+              test -x /usr/bin/tini
+              test -x /usr/local/bin/sphere-entrypoint
+              command -v curl >/dev/null
+              command -v nginx >/dev/null
+              bash -n /usr/local/bin/sphere-entrypoint
+              echo "smoke ok"
+            '

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -7,12 +7,18 @@ export SSL_HTTPS_PORT="${SSL_HTTPS_PORT:-443}"
 
 # ── Normalize SSL_REQUIRED (fail closed on unknown values) ───────────────────
 # Accept common boolean spellings; anything else errors so a typo doesn't
-# silently downgrade the security posture.
-case "${SSL_REQUIRED:-true}" in
+# silently downgrade the security posture. Whitespace is trimmed first
+# because operators commonly paste values with stray spaces from .env files
+# or orchestrator dashboards.
+_ssl_req="${SSL_REQUIRED:-true}"
+_ssl_req="${_ssl_req#"${_ssl_req%%[![:space:]]*}"}"  # ltrim
+_ssl_req="${_ssl_req%"${_ssl_req##*[![:space:]]}"}"  # rtrim
+case "$_ssl_req" in
     true|TRUE|True|1|yes|YES|Yes) SSL_REQUIRED=true ;;
     false|FALSE|False|0|no|NO|No) SSL_REQUIRED=false ;;
     *) echo "ERROR: SSL_REQUIRED must be true/false, got: '${SSL_REQUIRED}'" >&2; exit 1 ;;
 esac
+unset _ssl_req
 
 # ── Validate env vars before use in nginx config ────────────────────────────
 validate_port() {
@@ -176,12 +182,19 @@ cleanup() {
     kill_pidfile /tmp/.ssl-http-proxy.pid
     kill_pidfile /tmp/.ssl-renew.pid
     nginx -s quit 2>/dev/null || true
-    # Poll briefly for nginx to flush rather than re-waiting on a reaped PID.
+    # Poll for nginx to flush rather than re-waiting on a reaped PID.
+    # 10s matches nginx's own graceful-stop SLA; integer sleeps keep the
+    # loop portable to BusyBox if the base image is ever swapped from
+    # Debian (which has GNU coreutils sleep supporting fractions).
     if [ -n "$NGINX_PID" ]; then
+        local _drained=""
         for _ in 1 2 3 4 5 6 7 8 9 10; do
-            kill -0 "$NGINX_PID" 2>/dev/null || break
-            sleep 0.2
+            kill -0 "$NGINX_PID" 2>/dev/null || { _drained=1; break; }
+            sleep 1
         done
+        if [ -z "$_drained" ]; then
+            echo "WARNING: nginx did not drain within 10s; forcing exit" >&2
+        fi
     fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary

Second pass of the steelman review on the hardening landed via #298. All findings from that review that could be addressed with code are addressed here. Branch protection on \`main\` is the only outstanding item and needs a GitHub Settings UI click, not code.

### entrypoint.sh
- **nginx drain budget 2s → 10s.** The previous poll loop (\`10 × sleep 0.2\`) gave in-flight requests only 2 seconds to finish before tini SIGKILLed nginx. Matches nginx's own graceful-stop SLA now.
- **Log timeout.** If the 10s budget is exceeded, an explicit \`WARNING: nginx did not drain within 10s; forcing exit\` hits stderr so operators see truncated requests with a reason rather than silence.
- **Integer sleep.** Using \`sleep 1\` instead of \`sleep 0.2\` so the loop is portable to BusyBox-coreutils bases (\`sleep 0.2\` becomes \`sleep 0\` there, producing a spin loop).
- **SSL_REQUIRED whitespace trim.** Values like \`"  true  "\` (common when pasted from \`.env\` files) are now accepted after ltrim/rtrim instead of hard-failing the container.

### docker-validate.yml
- **\`workflow_dispatch\`** trigger added so transient CI failures can be re-run without pushing an empty commit.
- **Smoke tests** added for both matrix rows:
  - \`Dockerfile\`: \`nginx -t\` verifies the default config parses.
  - \`Dockerfile.ssl\`: confirms \`tini\`, \`sphere-entrypoint\`, \`curl\`, and \`nginx\` are present and that the entrypoint script is syntactically valid bash. Catches entrypoint-path typos and shebang regressions that previously only surfaced on deploy.
- Switched \`load: false\` → \`load: true\` so the smoke steps can actually run the built image.

## Test plan (ran locally)

- [x] \`bash -n deploy/entrypoint.sh\` clean.
- [x] \`docker build -f Dockerfile.ssl\` succeeds.
- [x] \`SSL_REQUIRED="  true  "\` now boots (was: exit 1).
- [x] \`SSL_REQUIRED="bogus"\` still exits 1 with the clear error.
- [x] \`docker stop --time=15\` produces exit code 143 (signal-clean shutdown path).
- [x] Smoke command used in CI runs green against the locally-built image.
- [ ] CI on this PR: \`validate (Dockerfile)\` and \`validate (Dockerfile.ssl)\` both green — gate for merge.

## Outstanding (non-code)

- Enable branch protection on \`main\` and list \`validate (Dockerfile)\` + \`validate (Dockerfile.ssl)\` as required status checks. Requires GitHub Settings → Branches UI.