### PR TITLE
fix(uxf): switch UXF build to Profile-backed providers + Vite Node-stub aliases

### DIFF
--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -14,6 +14,8 @@ import {
   createBrowserProviders,
   type BrowserProviders,
 } from '@unicitylabs/sphere-sdk/impl/browser';
+import { createBrowserProfileProviders } from '@unicitylabs/sphere-sdk/profile/browser';
+import { IS_UXF_BUILD } from '../config/uxf';
 import { SphereContext } from './SphereContext';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
@@ -137,6 +139,39 @@ export function SphereProvider({
         market: true,
         ...getIpfsConfig(),
       });
+
+      // UXF Profile mode (issue: page-was-deprecation-drift) — when
+      // VITE_UXF_BUILD=true, override the IndexedDB-backed storage with
+      // ProfileStorageProvider (OrbitDB + aggregator pointer) and drop
+      // the legacy IpfsStorageProvider-based wallet sync. Profile mode
+      // handles cross-device wallet sync natively; keeping the IPNS
+      // path active would create a redundant (and now-deprecated) sync
+      // backend.
+      //
+      // We keep `createBrowserProviders` because we still want its
+      // `publishToIpfs` / `cidFetchGateways` outputs (used by the
+      // per-send `uxf-cid` delivery branch — independent of wallet
+      // sync). The deprecation warning emitted by the SDK at
+      // IpfsStorageProvider construction is cosmetic here; we discard
+      // the constructed instance below. A follow-up SDK opt-out
+      // (something like `tokenSync: { ipfs: { walletSyncOnly: false } }`)
+      // would let us suppress it fully.
+      if (IS_UXF_BUILD) {
+        const profileProviders = createBrowserProfileProviders({
+          network,
+          // Share the aggregator's RootTrustBase per SPEC §8.4.2 H6 so the
+          // Profile pointer layer trusts the same set of validators.
+          oracle: browserProviders.oracle,
+        });
+        browserProviders.storage = profileProviders.storage;
+        browserProviders.tokenStorage = profileProviders.tokenStorage;
+        // Drop the legacy IPNS-based wallet sync provider — Profile's
+        // OrbitDB replication is the cross-device sync path now.
+        // `setupIpfsSync` already guards on this field, so removing it
+        // turns the call into a no-op.
+        delete browserProviders.ipfsTokenStorage;
+      }
+
       // Debug logging is off by default; enable at runtime via: logger.configure({ debug: true })
       setProviders(browserProviders);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,14 @@ export default defineConfig(({ mode }) => {
       tailwindcss(),
       nodePolyfills({
         protocolImports: true,
+        // Explicitly polyfill `fs` (covers `fs/promises`) so that
+        // unreachable Node-only branches inside sphere-sdk's Profile
+        // bundle (e.g. defaultNodeLockPrimitives, which is wrapped in a
+        // never-called-in-browser code path but contains a static
+        // `await import("fs/promises")` Vite resolves at build time)
+        // don't break the production build. The polyfill resolves to an
+        // empty module in the browser; the code path is never executed.
+        include: ['fs'],
         globals: {
           Buffer: 'build',
         },
@@ -103,6 +111,24 @@ export default defineConfig(({ mode }) => {
         'vite-plugin-node-polyfills/shims/buffer': path.resolve(__dirname, 'node_modules/vite-plugin-node-polyfills/shims/buffer'),
         'vite-plugin-node-polyfills/shims/process': path.resolve(__dirname, 'node_modules/vite-plugin-node-polyfills/shims/process'),
         'vite-plugin-node-polyfills/shims/global': path.resolve(__dirname, 'node_modules/vite-plugin-node-polyfills/shims/global'),
+        // sphere-sdk's Profile browser bundle has unreachable Node-only
+        // branches (defaultNodeLockPrimitives, the
+        // FsBlockstore fallback) that do static `await import(...)` of
+        // Node-only modules. Vite resolves those strings at build time
+        // even though the branches are never executed in the browser;
+        // without explicit aliases the resolver chases either:
+        //   - `node-stdlib-browser/.../empty.js/promises` (file-as-dir
+        //     when `fs` is mapped to an empty file), or
+        //   - real npm packages that themselves `import "node:fs"`
+        //     (blockstore-fs, proper-lockfile).
+        // Map every Node-only target to the empty mock so the build
+        // succeeds; runtime never actually calls them.
+        'fs/promises': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
+        'node:fs/promises': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
+        'node:fs': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
+        fs: path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
+        'blockstore-fs': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
+        'proper-lockfile': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
       },
     },
     build: {


### PR DESCRIPTION
## Summary

Pairs with ipfs-storage PR #11 (CORS on /sidecar/) to fix the cross-wallet send flow reported via browser console:

1. Browser CORS-blocked POSTs to `https://unicity-ipfs1.dyndns.org/sidecar/submit?cid=...` from origin `https://sphere-telco-test.dyndns.org` → silent send failure. Fixed server-side in ipfs-storage PR #11 (live + PR open).
2. Deprecation drift: page advertised "UXF" via `VITE_UXF_BUILD=true` (banner / green theme / migration prompt all gated on it) but SphereProvider still wired the legacy IPNS-based `IpfsStorageProvider` as the cross-device wallet sync backend. The Profile factory introduced by sphere-sdk PR #277/#279/#281 was imported into `vendor-sphere-sdk/` but never called. **This PR fixes #2.**

## SphereProvider.tsx

`createBrowserProviders` stays the entry point — it gives us transport / oracle / price / `publishToIpfs` / `cidFetchGateways` / groupChat / market for free, and `publishToIpfs` is still required for the per-send `uxf-cid` Nostr delivery branch (independent of wallet sync).

When `IS_UXF_BUILD`:

1. Call `createBrowserProfileProviders({ network, oracle })`. Share the same oracle instance so the embedded RootTrustBase matches (SPEC §8.4.2 H6).
2. Overwrite `browserProviders.storage` and `.tokenStorage` with the Profile-backed versions.
3. `delete browserProviders.ipfsTokenStorage` so `setupIpfsSync` (which already guards on the field) becomes a no-op. Profile's OrbitDB replication is the wallet-sync path now; adding the IPFS provider on top would create a redundant + deprecated sync backend.

In legacy (non-UXF) mode the call site is unchanged.

**Known cosmetic:** the deprecation warning still fires once at boot because `createBrowserProviders` unconditionally constructs the IpfsStorageProvider before tokenSync resolution. The instance is discarded. A follow-up SDK opt-out (e.g. `tokenSync: { ipfs: { walletSyncOnly: false } }`) would suppress it fully.

## vite.config.ts

`vendor-sphere-sdk/dist/profile/browser.js` contains unreachable Node-only branches:

- `defaultNodeLockPrimitives` does `await import("fs/promises")` and `await import("proper-lockfile")`
- The Helia constructor's `FsBlockstore` fallback dynamically imports `blockstore-fs`, which in turn imports `node:fs/promises`

Vite's static analyzer resolves those strings at build time even though the branches never execute in the browser. Without aliases, the resolver chases `node-stdlib-browser/.../empty.js/promises` (file-as-directory) and the build aborts.

Mapped to the empty mock:

- `fs`, `fs/promises`
- `node:fs`, `node:fs/promises`
- `blockstore-fs`
- `proper-lockfile`

All branches that reach these modules are dead in the browser. Runtime never hits them.

## Verification

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm run test:run` | **37/37 pass** in 416ms |
| `npx tsc -b --noEmit` | clean |
| `npm run build` | green, 12.7s, chunk sizes consistent with prior bundle |

## Test plan

- [x] Lint + tests + typecheck + build all pass
- [ ] Pages-branch auto-deploy fires on push (will check after merge)
- [ ] End-to-end: re-run the "send ETH between two UXF wallets" flow — this PR fixes the deprecated-provider drift; ipfs-storage PR #11 (live patch applied + PR awaiting merge) fixes the CORS half. Both required for the original repro to succeed.

## Follow-ups (out of scope)

- SDK should support a config option to skip `createBrowserIpfsStorageProvider` while keeping `publishToIpfs` / `cidFetchGateways`. Today they're coupled to `tokenSync.ipfs.enabled`.
- SDK Profile browser bundle should either split out the Node-only `defaultNodeLockPrimitives` into a separate entry, or wrap the static `import()` calls in `/* @vite-ignore */` so consumers don't need per-app aliases. (Filing as a sphere-sdk follow-up issue.)

Refs sphere-sdk #275/#278/#280, ipfs-storage #11.