### PR TITLE
Revert PR #305 — Profile providers swap loses existing tokens (no migration path)

### DIFF
--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -14,8 +14,6 @@ import {
   createBrowserProviders,
   type BrowserProviders,
 } from '@unicitylabs/sphere-sdk/impl/browser';
-import { createBrowserProfileProviders } from '@unicitylabs/sphere-sdk/profile/browser';
-import { IS_UXF_BUILD } from '../config/uxf';
 import { SphereContext } from './SphereContext';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
@@ -139,39 +137,6 @@ export function SphereProvider({
         market: true,
         ...getIpfsConfig(),
       });
-
-      // UXF Profile mode (issue: page-was-deprecation-drift) — when
-      // VITE_UXF_BUILD=true, override the IndexedDB-backed storage with
-      // ProfileStorageProvider (OrbitDB + aggregator pointer) and drop
-      // the legacy IpfsStorageProvider-based wallet sync. Profile mode
-      // handles cross-device wallet sync natively; keeping the IPNS
-      // path active would create a redundant (and now-deprecated) sync
-      // backend.
-      //
-      // We keep `createBrowserProviders` because we still want its
-      // `publishToIpfs` / `cidFetchGateways` outputs (used by the
-      // per-send `uxf-cid` delivery branch — independent of wallet
-      // sync). The deprecation warning emitted by the SDK at
-      // IpfsStorageProvider construction is cosmetic here; we discard
-      // the constructed instance below. A follow-up SDK opt-out
-      // (something like `tokenSync: { ipfs: { walletSyncOnly: false } }`)
-      // would let us suppress it fully.
-      if (IS_UXF_BUILD) {
-        const profileProviders = createBrowserProfileProviders({
-          network,
-          // Share the aggregator's RootTrustBase per SPEC §8.4.2 H6 so the
-          // Profile pointer layer trusts the same set of validators.
-          oracle: browserProviders.oracle,
-        });
-        browserProviders.storage = profileProviders.storage;
-        browserProviders.tokenStorage = profileProviders.tokenStorage;
-        // Drop the legacy IPNS-based wallet sync provider — Profile's
-        // OrbitDB replication is the cross-device sync path now.
-        // `setupIpfsSync` already guards on this field, so removing it
-        // turns the call into a no-op.
-        delete browserProviders.ipfsTokenStorage;
-      }
-
       // Debug logging is off by default; enable at runtime via: logger.configure({ debug: true })
       setProviders(browserProviders);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,14 +27,6 @@ export default defineConfig(({ mode }) => {
       tailwindcss(),
       nodePolyfills({
         protocolImports: true,
-        // Explicitly polyfill `fs` (covers `fs/promises`) so that
-        // unreachable Node-only branches inside sphere-sdk's Profile
-        // bundle (e.g. defaultNodeLockPrimitives, which is wrapped in a
-        // never-called-in-browser code path but contains a static
-        // `await import("fs/promises")` Vite resolves at build time)
-        // don't break the production build. The polyfill resolves to an
-        // empty module in the browser; the code path is never executed.
-        include: ['fs'],
         globals: {
           Buffer: 'build',
         },
@@ -111,24 +103,6 @@ export default defineConfig(({ mode }) => {
         'vite-plugin-node-polyfills/shims/buffer': path.resolve(__dirname, 'node_modules/vite-plugin-node-polyfills/shims/buffer'),
         'vite-plugin-node-polyfills/shims/process': path.resolve(__dirname, 'node_modules/vite-plugin-node-polyfills/shims/process'),
         'vite-plugin-node-polyfills/shims/global': path.resolve(__dirname, 'node_modules/vite-plugin-node-polyfills/shims/global'),
-        // sphere-sdk's Profile browser bundle has unreachable Node-only
-        // branches (defaultNodeLockPrimitives, the
-        // FsBlockstore fallback) that do static `await import(...)` of
-        // Node-only modules. Vite resolves those strings at build time
-        // even though the branches are never executed in the browser;
-        // without explicit aliases the resolver chases either:
-        //   - `node-stdlib-browser/.../empty.js/promises` (file-as-dir
-        //     when `fs` is mapped to an empty file), or
-        //   - real npm packages that themselves `import "node:fs"`
-        //     (blockstore-fs, proper-lockfile).
-        // Map every Node-only target to the empty mock so the build
-        // succeeds; runtime never actually calls them.
-        'fs/promises': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
-        'node:fs/promises': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
-        'node:fs': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
-        fs: path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
-        'blockstore-fs': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
-        'proper-lockfile': path.resolve(__dirname, 'node_modules/node-stdlib-browser/esm/mock/empty.js'),
       },
     },
     build: {


### PR DESCRIPTION
## Why

PR #305 switched the webpage from legacy IndexedDB token storage to Profile-backed (OrbitDB) storage when \`IS_UXF_BUILD\`. Production-realistic test on \`https://sphere-telco-test.dyndns.org/\` revealed two **blocking** problems that the PR didn't anticipate:

### Problem 1 — Whole balance went to 0

Tokens live in \`sphere-token-storage-{addressId}\` IndexedDB databases (legacy \`IndexedDBTokenStorageProvider\`). The PR replaced \`browserProviders.tokenStorage\` with \`createBrowserProfileProviders().tokenStorage\` (OrbitDB-backed, **empty**). No migration runs. Result: every existing wallet that loads the new build sees a fresh, empty Profile token store. Tokens are not lost — they're still in IndexedDB — but invisible to the code.

User-visible report (verbatim): *"My whole balance went to 0! Nothing to send. Unicity id however preserved, but probably through non-token path."* (Identity persists because \`ProfileStorageProvider\` wraps the same underlying \`sphere-storage\` IndexedDB where mnemonic/keys live.)

### Problem 2 — GroupChat persistence hard-fails

Profile mode caps OpLog entries at \`MAX_PAYLOAD_BYTES=131072\` (128 KiB). Legacy IndexedDB had no such cap, so monolithic blobs were fine. In Profile mode:

\`\`\`
[GroupChat] Persistence error: ProfileError: [PROFILE:ORBITDB_WRITE_FAILED]
Failed to write structured entry at "group_chat_members:announcements":
encodeEntry: payload 3986657 bytes exceeds MAX_PAYLOAD_BYTES=131072
\`\`\`

3.98 MB \`announcements\` member list exceeds the cap. Three other sites soft-warn (\`.messages\` 685 KB, \`.groupchat.processedEvents\` 263 KB, \`group_chat_messages:general\` 30 KB) above the 8 KB soft threshold.

The SDK's own warning hints at the proper fix: *"consider migrating this write site to a CID reference (PROFILE-CID-REFERENCES.md §8)"*. Four write sites need migration to CID-references before Profile mode is usable for any wallet with non-trivial history:

1. \`CommunicationsModule.sendDM\` → DM cache
2. \`GroupChatModule.persistMembers\` ← currently failing
3. \`GroupChatModule.persistMessages\` → message cache
4. \`GroupChatModule.persistProcessedEvents\` → dedup ledger

## Action

Revert PR #305. Webpage returns to legacy IPNS-based wallet sync (which now works end-to-end against the live \`unicity-ipfs1.dyndns.org/sidecar/\` after ipfs-storage PR #11 added CORS headers).

Re-attempt Profile-mode migration once:
- (a) SDK migrates the 4 write sites to CID-references per \`PROFILE-CID-REFERENCES.md §8\`, AND
- (b) Sphere webpage adds a one-shot legacy-→-Profile token storage migration that runs before SphereProvider swaps the providers.

## Verification

| Step | Result |
|---|---|
| \`npm run lint\` | clean |
| \`npm run test:run\` | **37/37 pass** |
| \`npm run build\` | green, 8.9 s |
| Docker image \`sphere-telco:rollback-20260526-pr305-pre\` already retagged \`:latest\` and live-deployed via \`run-sphere.sh\` — bundle hash \`index-ZtTCgw6t.js\` (pre-#305) currently served at sphere-telco-test.dyndns.org |

## Follow-ups (filing as separate sphere-sdk issues)

1. \`createBrowserProviders\` should support \`tokenSync: { ipfs: { walletSyncOnly: false } }\` so the deprecated \`IpfsStorageProvider\` is not constructed when consumers want to opt out (would suppress the deprecation warning even in legacy mode for callers that don't want IPFS wallet sync).
2. CID-reference migration for the 4 write sites listed above. (PROFILE-CID-REFERENCES.md §8 design exists; implementation incomplete.)
3. Bidirectional legacy ↔ Profile token storage migration so future Profile-mode switches don't strand existing wallets.

Pairs with already-merged ipfs-storage PR #11 (CORS fix) — that part is independent and stays.