### PR TITLE
feat(uxf): wallet-storage mode status + switch/migrate/merge controls in banner

### DIFF
--- a/src/components/uxf/UxfBanner.tsx
+++ b/src/components/uxf/UxfBanner.tsx
@@ -1,33 +1,376 @@
 import { useState } from 'react';
-import { X } from 'lucide-react';
+import { X, Loader2, AlertTriangle, Database, RefreshCw } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useSphereContext } from '../../sdk/hooks/core/useSphere';
+import { showToast } from '../ui/toast-utils';
 
-export function UxfBanner() {
-  const [dismissed, setDismissed] = useState(false);
+/**
+ * Verbatim copy of the merge-overwrite confirmation modal — surfaced in
+ * the PR description so reviewers can scrutinize the warning text.
+ */
+const MERGE_CONFIRM_HEADLINE = 'Merge Legacy → UXF (overwrite)?';
+const MERGE_CONFIRM_BODY =
+  'This will OVERWRITE your UXF Profile token data with your Legacy data. ' +
+  'Tokens currently in Profile that aren\'t in Legacy will be lost. ' +
+  'Continue?';
 
-  if (dismissed) return null;
+/**
+ * Pretty-print the wallet mode for the status line.
+ */
+function modeLabel(mode: 'legacy' | 'profile'): string {
+  return mode === 'profile' ? 'UXF Profile (new)' : 'Legacy';
+}
 
+/**
+ * Human-readable label for each action — used in toast messages.
+ */
+function actionLabel(
+  action: 'migrate' | 'switch-profile' | 'switch-legacy' | 'merge' | 'refresh',
+): string {
+  switch (action) {
+    case 'migrate': return 'migrate to UXF Profile';
+    case 'switch-profile': return 'switch to UXF Profile';
+    case 'switch-legacy': return 'switch to Legacy';
+    case 'merge': return 'merge Legacy → UXF';
+    case 'refresh': return 'refresh probes';
+  }
+}
+
+/**
+ * Tooltip text for each action button — referenced from the (mode ×
+ * probe) → button decision table.
+ */
+const TOOLTIPS = {
+  migrate:
+    'One-shot: copy your legacy wallet tokens into the new UXF Profile ' +
+    'storage and switch this wallet to use Profile sync from now on.',
+  switchToProfile:
+    'Switch to UXF Profile storage. Does NOT copy any data — your ' +
+    'Profile store must already contain the tokens you want to see.',
+  switchToLegacy:
+    'Switch back to Legacy IndexedDB storage. Does NOT copy any data — ' +
+    'your Legacy store must already contain the tokens you want to see.',
+  merge:
+    'Copy ALL legacy data into UXF Profile, OVERWRITING anything ' +
+    'currently in Profile that isn\'t in Legacy. Cannot be undone.',
+  refresh: 'Re-check both stores for token data.',
+} as const;
+
+interface MergeConfirmModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function MergeConfirmModal({ onConfirm, onCancel }: MergeConfirmModalProps) {
   return (
     <div
-      role="status"
-      aria-live="polite"
-      className="relative flex items-center justify-center gap-2 px-4 py-2 text-xs font-medium text-center"
-      style={{
-        background: 'var(--color-brand-uxf-dim, rgba(34,197,94,0.08))',
-        borderBottom: '1px solid var(--color-brand-uxf-border, rgba(34,197,94,0.30))',
-        color: 'var(--color-brand-uxf, #22c55e)',
-      }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="uxf-merge-confirm-headline"
     >
-      <span>
-        Experimental UXF build — Profile data uses OrbitDB sync; features may change without notice.
-      </span>
-      <button
-        onClick={() => setDismissed(true)}
-        aria-label="Dismiss UXF banner"
-        className="absolute right-2 p-0.5 rounded opacity-70 hover:opacity-100 transition-opacity"
-        style={{ color: 'inherit' }}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onCancel} />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 8 }}
+        transition={{ duration: 0.18 }}
+        className="relative z-10 w-full max-w-md rounded-2xl border p-6 shadow-2xl"
+        style={{
+          background: 'var(--color-bg-secondary)',
+          borderColor: 'rgba(239, 68, 68, 0.35)',
+          boxShadow: '0 0 40px rgba(239, 68, 68, 0.15)',
+        }}
       >
-        <X className="w-3.5 h-3.5" />
-      </button>
+        <div className="flex items-start gap-3 mb-3">
+          <div
+            className="p-2 rounded-full flex-shrink-0"
+            style={{ background: 'rgba(239, 68, 68, 0.15)', color: '#ef4444' }}
+          >
+            <AlertTriangle className="w-4 h-4" />
+          </div>
+          <div>
+            <h2
+              id="uxf-merge-confirm-headline"
+              className="text-base font-semibold mb-1"
+              style={{ color: 'var(--color-text-primary)' }}
+            >
+              {MERGE_CONFIRM_HEADLINE}
+            </h2>
+            <p
+              className="text-xs leading-relaxed"
+              style={{ color: 'var(--color-text-secondary)' }}
+            >
+              {MERGE_CONFIRM_BODY}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex gap-2 mt-5">
+          <button
+            onClick={onConfirm}
+            className="flex-1 py-2 px-4 rounded-xl text-xs font-semibold transition-colors"
+            style={{
+              background: '#ef4444',
+              color: '#fff',
+            }}
+          >
+            Yes, overwrite Profile
+          </button>
+          <button
+            onClick={onCancel}
+            className="py-2 px-4 rounded-xl text-xs font-medium border transition-colors"
+            style={{
+              borderColor: 'var(--color-border-primary)',
+              color: 'var(--color-text-secondary)',
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </motion.div>
     </div>
+  );
+}
+
+interface ActionButtonProps {
+  label: string;
+  tooltip: string;
+  variant: 'primary' | 'secondary' | 'danger';
+  loading: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+function ActionButton({ label, tooltip, variant, loading, disabled, onClick }: ActionButtonProps) {
+  const variantStyles: Record<typeof variant, React.CSSProperties> = {
+    primary: {
+      background: 'var(--color-brand-uxf, #22c55e)',
+      color: '#000',
+    },
+    secondary: {
+      background: 'transparent',
+      color: 'var(--color-brand-uxf, #22c55e)',
+      border: '1px solid var(--color-brand-uxf-border, rgba(34,197,94,0.30))',
+    },
+    danger: {
+      background: 'transparent',
+      color: '#ef4444',
+      border: '1px solid rgba(239, 68, 68, 0.45)',
+    },
+  };
+  return (
+    <button
+      type="button"
+      title={tooltip}
+      aria-label={label}
+      onClick={onClick}
+      disabled={disabled || loading}
+      className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-opacity whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+      style={variantStyles[variant]}
+    >
+      {loading && <Loader2 className="w-3 h-3 animate-spin" />}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+/**
+ * Banner state matrix:
+ *
+ * | Current mode | Profile data | Buttons                                                 |
+ * |--------------|--------------|---------------------------------------------------------|
+ * | Legacy       | none         | "Migrate to UXF Profile" (primary)                      |
+ * | Legacy       | exists       | "Switch to UXF Profile" + "Merge Legacy → UXF (over.)"  |
+ * | UXF Profile  | (legacy yes) | "Switch back to Legacy" + "Merge Legacy → UXF (over.)"  |
+ * | UXF Profile  | (legacy no)  | (no buttons — Profile is the only store with data)      |
+ *
+ * The merge button always carries a confirmation modal because it is
+ * the only destructive action.
+ */
+export function UxfBanner() {
+  const ctx = useSphereContext();
+  const {
+    walletMode,
+    hasLegacyData,
+    hasProfileData,
+    isSwitchingMode,
+    switchWalletMode,
+    runLegacyToProfileMigration,
+    refreshDataProbes,
+  } = ctx;
+
+  const [dismissed, setDismissed] = useState(false);
+  const [activeAction, setActiveAction] = useState<null | 'migrate' | 'switch-profile' | 'switch-legacy' | 'merge' | 'refresh'>(null);
+  const [showMergeConfirm, setShowMergeConfirm] = useState(false);
+
+  // The banner is dismissible — but only the "experimental build" advisory
+  // text is hidden. The mode controls keep rendering once probes settle.
+  // We DON'T offer a way to re-show the advisory after dismissal because
+  // it would clutter every reload.
+  if (dismissed) return null;
+
+  const probesPending = hasLegacyData === null || hasProfileData === null;
+  // Whether each button should be shown
+  const showMigrate = walletMode === 'legacy' && hasProfileData === false;
+  const showSwitchToProfile = walletMode === 'legacy' && hasProfileData === true;
+  const showSwitchToLegacy = walletMode === 'profile' && hasLegacyData === true;
+  // Merge is offered in both legacy/profile when there's legacy data to copy.
+  const showMerge =
+    (walletMode === 'legacy' && hasProfileData === true) ||
+    (walletMode === 'profile' && hasLegacyData === true);
+
+  const anyActionRunning = activeAction !== null || isSwitchingMode;
+
+  async function runWithGuard(
+    action: 'migrate' | 'switch-profile' | 'switch-legacy' | 'merge' | 'refresh',
+    op: () => Promise<void>,
+  ) {
+    if (anyActionRunning) return;
+    setActiveAction(action);
+    try {
+      await op();
+      if (action !== 'refresh') {
+        showToast(`Wallet ${actionLabel(action)} complete`, 'success');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      showToast(`${actionLabel(action)} failed: ${msg}`, 'error', 8000);
+    } finally {
+      setActiveAction(null);
+    }
+  }
+
+  function handleMigrate() {
+    void runWithGuard('migrate', () =>
+      runLegacyToProfileMigration({ force: false }),
+    );
+  }
+
+  function handleSwitchToProfile() {
+    void runWithGuard('switch-profile', () => switchWalletMode('profile'));
+  }
+
+  function handleSwitchToLegacy() {
+    void runWithGuard('switch-legacy', () => switchWalletMode('legacy'));
+  }
+
+  function handleMergeRequest() {
+    // Open the confirmation modal — the actual merge happens after
+    // confirm.
+    setShowMergeConfirm(true);
+  }
+
+  function handleMergeConfirm() {
+    setShowMergeConfirm(false);
+    void runWithGuard('merge', () =>
+      runLegacyToProfileMigration({ force: true }),
+    );
+  }
+
+  function handleRefresh() {
+    void runWithGuard('refresh', () => refreshDataProbes());
+  }
+
+  return (
+    <>
+      <div
+        role="status"
+        aria-live="polite"
+        className="relative flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-2 px-4 py-2 text-xs font-medium"
+        style={{
+          background: 'var(--color-brand-uxf-dim, rgba(34,197,94,0.08))',
+          borderBottom: '1px solid var(--color-brand-uxf-border, rgba(34,197,94,0.30))',
+          color: 'var(--color-brand-uxf, #22c55e)',
+        }}
+      >
+        {/* Left cluster: status text + dismiss */}
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <Database className="w-3.5 h-3.5 flex-shrink-0" />
+          <span className="truncate">
+            <span className="font-semibold">Wallet storage:</span>{' '}
+            {modeLabel(walletMode)}
+            {probesPending && (
+              <span className="ml-2 opacity-70">(checking stores…)</span>
+            )}
+          </span>
+        </div>
+
+        {/* Right cluster: action buttons + dismiss */}
+        <div className="flex items-center gap-1.5 flex-wrap sm:flex-nowrap justify-end">
+          {showMigrate && (
+            <ActionButton
+              label={activeAction === 'migrate' ? 'Migrating…' : 'Migrate to UXF Profile'}
+              tooltip={TOOLTIPS.migrate}
+              variant="primary"
+              loading={activeAction === 'migrate'}
+              disabled={anyActionRunning}
+              onClick={handleMigrate}
+            />
+          )}
+          {showSwitchToProfile && (
+            <ActionButton
+              label={activeAction === 'switch-profile' ? 'Switching…' : 'Switch to UXF Profile'}
+              tooltip={TOOLTIPS.switchToProfile}
+              variant="secondary"
+              loading={activeAction === 'switch-profile'}
+              disabled={anyActionRunning}
+              onClick={handleSwitchToProfile}
+            />
+          )}
+          {showSwitchToLegacy && (
+            <ActionButton
+              label={activeAction === 'switch-legacy' ? 'Switching…' : 'Switch back to Legacy'}
+              tooltip={TOOLTIPS.switchToLegacy}
+              variant="secondary"
+              loading={activeAction === 'switch-legacy'}
+              disabled={anyActionRunning}
+              onClick={handleSwitchToLegacy}
+            />
+          )}
+          {showMerge && (
+            <ActionButton
+              label={activeAction === 'merge' ? 'Merging…' : 'Merge Legacy → UXF (overwrite)'}
+              tooltip={TOOLTIPS.merge}
+              variant="danger"
+              loading={activeAction === 'merge'}
+              disabled={anyActionRunning}
+              onClick={handleMergeRequest}
+            />
+          )}
+          {/* Refresh probes — always available. Tiny icon-only button. */}
+          <button
+            type="button"
+            title={TOOLTIPS.refresh}
+            aria-label="Re-check stores"
+            onClick={handleRefresh}
+            disabled={anyActionRunning}
+            className="p-1 rounded-md text-[11px] transition-opacity opacity-70 hover:opacity-100 disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ color: 'inherit' }}
+          >
+            <RefreshCw
+              className={`w-3.5 h-3.5 ${activeAction === 'refresh' ? 'animate-spin' : ''}`}
+            />
+          </button>
+          <button
+            onClick={() => setDismissed(true)}
+            aria-label="Dismiss UXF banner"
+            className="p-0.5 rounded opacity-70 hover:opacity-100 transition-opacity"
+            style={{ color: 'inherit' }}
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {showMergeConfirm && (
+          <MergeConfirmModal
+            onConfirm={handleMergeConfirm}
+            onCancel={() => setShowMergeConfirm(false)}
+          />
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/src/components/uxf/UxfBanner.tsx
+++ b/src/components/uxf/UxfBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { X, Loader2, AlertTriangle, Database, RefreshCw } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
@@ -198,17 +198,26 @@ export function UxfBanner() {
     switchWalletMode,
     runLegacyToProfileMigration,
     refreshDataProbes,
+    walletExists,
   } = ctx;
 
   const [dismissed, setDismissed] = useState(false);
   const [activeAction, setActiveAction] = useState<null | 'migrate' | 'switch-profile' | 'switch-legacy' | 'merge' | 'refresh'>(null);
   const [showMergeConfirm, setShowMergeConfirm] = useState(false);
+  // Synchronous double-click guard. `disabled` on the button only takes
+  // effect after React re-renders — a fast double-tap that fires in the
+  // same task can race past it. A ref flipped inside the handler closes
+  // that window.
+  const actionLockRef = useRef(false);
 
   // The banner is dismissible — but only the "experimental build" advisory
   // text is hidden. The mode controls keep rendering once probes settle.
   // We DON'T offer a way to re-show the advisory after dismissal because
   // it would clutter every reload.
   if (dismissed) return null;
+  // Without a wallet the storage-mode banner is meaningless — the user
+  // hasn't created/imported a wallet yet. Hide it during onboarding.
+  if (!walletExists) return null;
 
   const probesPending = hasLegacyData === null || hasProfileData === null;
   // Whether each button should be shown
@@ -226,7 +235,10 @@ export function UxfBanner() {
     action: 'migrate' | 'switch-profile' | 'switch-legacy' | 'merge' | 'refresh',
     op: () => Promise<void>,
   ) {
-    if (anyActionRunning) return;
+    // Synchronous double-click guard FIRST — closes the window where
+    // two clicks fire before React applies `disabled` on the buttons.
+    if (actionLockRef.current || anyActionRunning) return;
+    actionLockRef.current = true;
     setActiveAction(action);
     try {
       await op();
@@ -238,6 +250,7 @@ export function UxfBanner() {
       showToast(`${actionLabel(action)} failed: ${msg}`, 'error', 8000);
     } finally {
       setActiveAction(null);
+      actionLockRef.current = false;
     }
   }
 

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -25,6 +25,13 @@ export const STORAGE_KEYS = {
   // IPFS
   IPFS_ENABLED: 'sphere_ipfs_enabled',
 
+  // Wallet token-storage mode preference ('legacy' | 'profile').
+  // Read at boot to decide which providers to construct. When unset
+  // and IS_UXF_BUILD, the legacy-→Profile boot migration controls
+  // the choice; once a user clicks a switch button we persist their
+  // preference here so reloads honor it.
+  WALLET_MODE_PREFERENCE: 'sphere_wallet_mode_preference',
+
   // Desktop state (open tabs, active tab)
   DESKTOP_STATE: 'sphere_desktop_state',
 

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -2,6 +2,21 @@ import { createContext } from 'react';
 import type { Sphere, PeerInfo, InitProgress } from '@unicitylabs/sphere-sdk';
 import type { BrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 
+/**
+ * Which token-storage backend the current `Sphere` instance is wired to.
+ *
+ * - `'legacy'`  — `IndexedDBTokenStorageProvider`. Per-address
+ *                 `sphere-token-storage-<addressId>` IndexedDB.
+ * - `'profile'` — `ProfileTokenStorageProvider`. OrbitDB-backed,
+ *                 `orbitdb/…` IndexedDB.
+ *
+ * Note: identity / mnemonic always lives in the legacy `sphere-storage`
+ * KV — even under Profile mode, because the Profile local cache uses
+ * the same IndexedDB name. The only thing that changes between modes is
+ * the **token** store.
+ */
+export type WalletMode = 'legacy' | 'profile';
+
 export interface SphereContextValue {
   sphere: Sphere | null;
   providers: BrowserProviders | null;
@@ -36,6 +51,57 @@ export interface SphereContextValue {
   ipfsEnabled: boolean;
   /** Toggle IPFS sync on/off (persists to localStorage, triggers reinitialize) */
   toggleIpfs: () => void;
+
+  // ── Wallet-storage mode controls ──────────────────────────────────
+  /**
+   * Which token-storage backend the active `Sphere` instance is wired
+   * to. Falls back to `'legacy'` while the provider is still booting
+   * (no `sphere` yet) since the SDK initialization defaults to legacy.
+   *
+   * Updated whenever {@link switchWalletMode} or the boot-time UXF
+   * migration completes its provider swap.
+   */
+  walletMode: WalletMode;
+  /**
+   * Probe result: does the LEGACY `IndexedDBTokenStorageProvider`
+   * contain user-meaningful token data for the current identity?
+   * `null` until the first probe completes.
+   */
+  hasLegacyData: boolean | null;
+  /**
+   * Probe result: does the PROFILE `ProfileTokenStorageProvider`
+   * contain user-meaningful token data for the current identity?
+   * `null` until the first probe completes.
+   */
+  hasProfileData: boolean | null;
+  /** True while a switch/merge operation is running. Disables banner actions. */
+  isSwitchingMode: boolean;
+  /**
+   * Switch the active token-storage backend. Re-creates Sphere with
+   * the target providers and updates {@link walletMode}. No data is
+   * copied — the user MUST run {@link runLegacyToProfileMigration}
+   * explicitly if they want to merge.
+   *
+   * Cross-tab: callers MUST tolerate a transient `IS_SWITCHING_MODE`
+   * state in other tabs; we use a localStorage lock to coordinate but
+   * the lock is best-effort (no Web Lock API yet, see deferred TODO).
+   */
+  switchWalletMode: (target: WalletMode) => Promise<void>;
+  /**
+   * Run the legacy → Profile token migration as a user-initiated
+   * action (banner button). When `force: true`, bypasses both the
+   * data-presence guard AND the SDK marker so legacy fully overwrites
+   * Profile — used by the "Merge (overwrite)" path.
+   *
+   * Always swaps the active providers to Profile when the migration
+   * succeeds, regardless of the prior mode.
+   */
+  runLegacyToProfileMigration: (opts?: { force?: boolean }) => Promise<void>;
+  /**
+   * Re-run `hasLegacyData` / `hasProfileData` probes. Call after a
+   * mode switch / migration / token receive to refresh the banner UI.
+   */
+  refreshDataProbes: () => Promise<void>;
 }
 
 export interface CreateWalletOptions {

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -8,16 +8,22 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError } from '@unicitylabs/sphere-sdk';
 import { sendWelcomeDM } from './welcomeDM';
-import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
+import type { InitProgress, NetworkType, FullIdentity } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
 import {
   createBrowserProviders,
+  IndexedDBTokenStorageProvider,
   type BrowserProviders,
 } from '@unicitylabs/sphere-sdk/impl/browser';
-import { createBrowserProfileProviders } from '@unicitylabs/sphere-sdk/profile/browser';
+import {
+  createBrowserProfileProviders,
+  type BrowserProfileProviders,
+} from '@unicitylabs/sphere-sdk/profile/browser';
 import { IS_UXF_BUILD } from '../config/uxf';
 import { runProfileMigration } from './uxfProfileMigration';
+import { hasMaterialContent } from './utils/tokenStorageProbe';
 import { SphereContext } from './SphereContext';
+import type { WalletMode } from './SphereContext';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
   ? '/coingecko'
@@ -69,6 +75,29 @@ function getIpfsConfig() {
   };
 }
 
+/**
+ * Read sticky wallet-mode preference from localStorage.
+ *
+ * Returns `null` when the user has not yet expressed a preference (boot
+ * follows the default — currently legacy with first-boot UXF migration
+ * under `IS_UXF_BUILD`).
+ *
+ * Cross-tab: this is intentionally not reactive — reads happen at boot
+ * + each manual reinitialize() / switchWalletMode call. We do NOT
+ * subscribe to localStorage events because a cross-tab mode flip would
+ * tear down this tab's Sphere mid-operation; the user must manually
+ * reload to pick up the other tab's preference change.
+ */
+function readWalletModePreference(): WalletMode | null {
+  const v = localStorage.getItem(STORAGE_KEYS.WALLET_MODE_PREFERENCE);
+  if (v === 'legacy' || v === 'profile') return v;
+  return null;
+}
+
+function writeWalletModePreference(mode: WalletMode): void {
+  localStorage.setItem(STORAGE_KEYS.WALLET_MODE_PREFERENCE, mode);
+}
+
 // =============================================================================
 // Shared helpers (pure functions, no React state)
 // =============================================================================
@@ -98,6 +127,86 @@ async function cleanupOnError(providers: BrowserProviders): Promise<void> {
   await Promise.race([clearDone, new Promise(r => setTimeout(r, 3000))]);
 }
 
+/**
+ * Construct a temporary, standalone `IndexedDBTokenStorageProvider`
+ * for cross-mode legacy-data probing. Caller MUST `disconnect()` after
+ * the load() call returns.
+ *
+ * Why a fresh instance: when we're currently running in Profile mode,
+ * `providers.tokenStorage` is the Profile provider — but we still need
+ * to look at the *legacy* IndexedDB tables to decide whether the
+ * banner should offer a "Merge Legacy → UXF" button. The legacy
+ * provider is stateless across instances (it talks to IndexedDB by
+ * name), so we can instantiate one ad-hoc.
+ */
+async function probeLegacyTokenData(identity: FullIdentity): Promise<boolean> {
+  const probe = new IndexedDBTokenStorageProvider();
+  try {
+    probe.setIdentity(identity);
+    const ok = await probe.initialize();
+    if (!ok) return false;
+    const snap = await probe.load();
+    if (!snap.success || !snap.data) return false;
+    return hasMaterialContent(snap.data as Record<string, unknown>);
+  } catch (err) {
+    logger.warn('SphereProvider', 'probeLegacyTokenData failed', err);
+    return false;
+  } finally {
+    try { await probe.disconnect(); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Probe Profile token storage for material content. Uses a fresh
+ * `createBrowserProfileProviders` to avoid disturbing the active
+ * providers. Caller MUST disconnect after.
+ *
+ * Returns `false` (not `null`) on any error — the banner reads this as
+ * "no Profile data" which is the safe default (it only enables the
+ * "Switch to UXF Profile" action; the user can still try the migrate
+ * path if they think there's data we missed).
+ */
+async function probeProfileTokenData(
+  identity: FullIdentity,
+  network: NetworkType,
+  oracle: BrowserProviders['oracle'],
+): Promise<boolean> {
+  let profile: BrowserProfileProviders | null = null;
+  try {
+    profile = createBrowserProfileProviders({ network, oracle });
+    profile.tokenStorage.setIdentity(identity);
+    profile.storage.setIdentity(identity);
+    await profile.tokenStorage.initialize();
+    await profile.storage.connect();
+    const snap = await profile.tokenStorage.load();
+    if (!snap.success || !snap.data) return false;
+    return hasMaterialContent(snap.data as unknown as Record<string, unknown>);
+  } catch (err) {
+    logger.warn('SphereProvider', 'probeProfileTokenData failed', err);
+    return false;
+  } finally {
+    if (profile) {
+      try { await profile.tokenStorage.disconnect(); } catch { /* ignore */ }
+      try { await profile.storage.disconnect(); } catch { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Synthesize a `FullIdentity` from `sphere.identity` for the probe
+ * helpers. The probes only read `directAddress`/`l1Address`/
+ * `chainPubkey` to compute the IndexedDB name and decrypt the Profile
+ * cache — `privateKey` is never used.
+ */
+function probeIdentityFromSphere(sphere: Sphere): FullIdentity | null {
+  const id = sphere.identity;
+  if (!id || !id.directAddress) return null;
+  return {
+    ...id,
+    privateKey: '',
+  } as FullIdentity;
+}
+
 // =============================================================================
 // Provider component
 // =============================================================================
@@ -120,10 +229,76 @@ export function SphereProvider({
   const [ipfsEnabled, setIpfsEnabled] = useState(isIpfsEnabled);
   const [isDiscoveringAddresses, setIsDiscoveringAddresses] = useState(false);
   const [initProgress, setInitProgress] = useState<InitProgress | null>(null);
+  const [walletMode, setWalletMode] = useState<WalletMode>(() => {
+    // Initial guess: prefer the persisted preference; otherwise legacy
+    // (legacy is the SDK default and matches the pre-UXF-build behavior).
+    return readWalletModePreference() ?? 'legacy';
+  });
+  const [hasLegacyData, setHasLegacyData] = useState<boolean | null>(null);
+  const [hasProfileData, setHasProfileData] = useState<boolean | null>(null);
+  const [isSwitchingMode, setIsSwitchingMode] = useState(false);
   const sphereRef = useRef<Sphere | null>(null);
+  /**
+   * Sequence counter — bumped on every initialize() / mode-switch. Used
+   * to discard probe-write races: if a probe completes AFTER a newer
+   * mode change started, its setHasLegacyData / setHasProfileData writes
+   * are dropped. Without this, a slow probe from the previous mode can
+   * land on top of fresh data from the new mode.
+   */
+  const initSeqRef = useRef(0);
+
+  /**
+   * Boot-time data-presence probes. Must be called AFTER `sphereRef`
+   * is populated so we have an identity to scope the probes.
+   *
+   * Probes run in parallel + tolerate errors — a failed probe leaves
+   * the previous value in place. Idempotent.
+   */
+  const runProbes = useCallback(async (instance: Sphere) => {
+    const seq = initSeqRef.current;
+    const id = probeIdentityFromSphere(instance);
+    if (!id) {
+      logger.debug('SphereProvider', 'runProbes: no identity yet — skipping');
+      return;
+    }
+    const oracle = providers?.oracle;
+
+    // Run both probes in parallel; tolerate individual failures.
+    //
+    // The "current mode" probe is cheap (we already have the
+    // initialized provider attached to `sphere`), but to keep the code
+    // path symmetric AND to make the probe identity-only (not
+    // dependent on react state ordering), we always re-probe via a
+    // fresh provider. This costs ~20ms but avoids the alternative of
+    // accidentally reading a provider that's been swapped under us.
+    const [legacy, profile] = await Promise.all([
+      probeLegacyTokenData(id).catch((err) => {
+        logger.warn('SphereProvider', 'probeLegacyTokenData failed', err);
+        return null;
+      }),
+      // Profile probe requires an oracle. If we don't have one yet,
+      // assume no Profile data.
+      oracle
+        ? probeProfileTokenData(id, network, oracle).catch((err) => {
+            logger.warn('SphereProvider', 'probeProfileTokenData failed', err);
+            return null;
+          })
+        : Promise.resolve(false),
+    ]);
+
+    if (seq !== initSeqRef.current) {
+      // A newer initialize / mode-switch started — drop these results.
+      logger.debug('SphereProvider', 'runProbes: discarded stale result', { seq, current: initSeqRef.current });
+      return;
+    }
+
+    if (legacy !== null) setHasLegacyData(legacy);
+    if (profile !== null) setHasProfileData(profile);
+  }, [network, providers]);
 
   const initialize = useCallback(async (attempt = 0, skipLoading = false) => {
     try {
+      initSeqRef.current += 1;
       // Destroy previous instance to release IndexedDB connections
       if (sphereRef.current) {
         await sphereRef.current.destroy();
@@ -165,6 +340,18 @@ export function SphereProvider({
       const exists = await Sphere.exists(browserProviders.storage);
       setWalletExists(exists);
 
+      // Pre-compute the boot-time mode preference. The default for
+      // IS_UXF_BUILD wallets is Profile (the first-boot migration
+      // landed there), but if the user has explicitly switched back to
+      // legacy via the banner, honor that. For non-UXF builds, always
+      // legacy.
+      const preferredMode: WalletMode = (() => {
+        if (!IS_UXF_BUILD) return 'legacy';
+        const persisted = readWalletModePreference();
+        if (persisted) return persisted;
+        return 'profile';
+      })();
+
       if (exists) {
         setInitProgress({ step: 'initializing', message: 'Loading wallet...' });
         let { sphere: instance } = await Sphere.init({
@@ -176,13 +363,14 @@ export function SphereProvider({
 
         // UXF Profile mode + safe migration (re-entry-safe).
         //
-        // When IS_UXF_BUILD: try to migrate legacy tokens into
-        // Profile-backed storage (OrbitDB + aggregator pointer). The
-        // helper is idempotent — on subsequent loads the marker
-        // short-circuits the full work, so this is a one-shot per
-        // wallet. On success we swap providers and re-init Sphere; on
-        // failure we keep the legacy instance running so the user
-        // sees their balance (DO NOT strand the wallet).
+        // When IS_UXF_BUILD AND the preferred mode is Profile: try to
+        // migrate legacy tokens into Profile-backed storage (OrbitDB +
+        // aggregator pointer). The helper is idempotent — on
+        // subsequent loads the marker short-circuits the full work, so
+        // this is a one-shot per wallet. On success we swap providers
+        // and re-init Sphere; on failure we keep the legacy instance
+        // running so the user sees their balance (DO NOT strand the
+        // wallet).
         //
         // For wallets created FRESH under Profile (no legacy token
         // data exists), the migration helper's source.load() returns
@@ -190,18 +378,11 @@ export function SphereProvider({
         // marker is stamped — making the second boot's call a fast
         // marker-skip. This is safe and idempotent.
         //
-        // Known limitation (acceptable for first-boot only): the helper
-        // snapshots `legacy.tokenStorage` once at the start. Tokens that
-        // arrive on the transport between snapshot and re-init land in
-        // legacy storage but NOT in Profile. The marker is then stamped,
-        // so the next boot won't re-migrate them. In practice the window
-        // is ~1-2 s on small wallets; after the first successful boot
-        // the wallet runs Profile-only so the race can't recur. A
-        // future SDK enhancement could add incremental migration; for
-        // now we accept the rare loss because the alternative
-        // (transport disconnect during migration) breaks DM delivery
-        // for the full migration window too.
-        if (IS_UXF_BUILD) {
+        // If the user has chosen `legacy` via the banner (persisted in
+        // localStorage), we skip the migration AND stay in legacy
+        // mode. The banner will surface "Switch to UXF Profile" + (if
+        // Profile data exists) "Merge" buttons in this state.
+        if (IS_UXF_BUILD && preferredMode === 'profile') {
           const profileResult = await runProfileMigration({
             legacyProviders: browserProviders,
             sphere: instance,
@@ -248,9 +429,18 @@ export function SphereProvider({
               onProgress: setInitProgress,
             });
             instance = reinit.sphere;
+            setWalletMode('profile');
+            // Persist the mode so this boot's choice survives a reload.
+            writeWalletModePreference('profile');
+          } else {
+            // Migration failure — keep legacy mode. The user can retry
+            // via the banner.
+            setWalletMode('legacy');
           }
           // On migration failure, `instance` remains the legacy-backed
           // Sphere — user keeps their balance, no swap happens.
+        } else {
+          setWalletMode('legacy');
         }
 
         setupIpfsSync(instance, browserProviders);
@@ -270,6 +460,11 @@ export function SphereProvider({
           setTimeout(() => { unsubReady(); trigger(); }, 20000);
         }
 
+        // Run probes in background — surface in banner via state.
+        runProbes(instance).catch((err) => {
+          logger.warn('SphereProvider', 'initial runProbes failed', err);
+        });
+
         // Run address discovery in background after wallet is visible
         setIsDiscoveringAddresses(true);
         instance.discoverAddresses({ autoTrack: true, includeL1Scan: false }).then(result => {
@@ -283,10 +478,11 @@ export function SphereProvider({
         });
       } else {
         // Fresh wallet path — no existing legacy data, so no migration is
-        // needed. When IS_UXF_BUILD, swap to Profile-backed providers
-        // preemptively so the subsequent createWallet()/importWallet()
-        // call writes directly into Profile storage.
-        if (IS_UXF_BUILD) {
+        // needed. When IS_UXF_BUILD AND the preferred mode is Profile,
+        // swap to Profile-backed providers preemptively so the
+        // subsequent createWallet()/importWallet() call writes directly
+        // into Profile storage.
+        if (IS_UXF_BUILD && preferredMode === 'profile') {
           const profile = createBrowserProfileProviders({
             network,
             oracle: browserProviders.oracle,
@@ -306,6 +502,9 @@ export function SphereProvider({
             remoteUrl: netConfig.tokenRegistryUrl,
             storage: browserProviders.storage,
           });
+          setWalletMode('profile');
+        } else {
+          setWalletMode('legacy');
         }
 
         // Pre-connect transport for nametag lookups during onboarding
@@ -332,16 +531,23 @@ export function SphereProvider({
       setInitProgress(null);
       setIsLoading(false);
     }
-  }, [network]);
+  }, [network, runProbes]);
+
+  // Stable ref so the boot-time effect only fires once per `network`
+  // change. Without this, the effect would re-run whenever `walletMode`
+  // / `runProbes` change (which happens inside `initialize()` itself —
+  // self-trigger loop).
+  const initializeRef = useRef(initialize);
+  initializeRef.current = initialize;
 
   useEffect(() => {
-    initialize();
+    initializeRef.current();
     return () => {
       // Cleanup on unmount
       sphereRef.current?.destroy();
       sphereRef.current = null;
     };
-  }, [initialize]);
+  }, [network]);
 
   const createWallet = useCallback(
     async (options?: CreateWalletOptions) => {
@@ -514,6 +720,8 @@ export function SphereProvider({
     setSphere(null);
     setWalletExists(false);
     setError(null);
+    setHasLegacyData(null);
+    setHasProfileData(null);
 
     // Reinitialize with fresh providers (skip loading spinner — onboarding UI is already visible)
     await initialize(0, true);
@@ -537,6 +745,185 @@ export function SphereProvider({
     initialize();
   }, [initialize]);
 
+  // ── Wallet-mode controls ─────────────────────────────────────────────
+
+  /**
+   * Refresh the legacy/profile data-presence probes for the current
+   * identity. Safe to call at any time after `sphere` is set.
+   */
+  const refreshDataProbes = useCallback(async () => {
+    const instance = sphereRef.current;
+    if (!instance) return;
+    await runProbes(instance);
+  }, [runProbes]);
+
+  /**
+   * Switch the active wallet token-storage backend. Persists the user
+   * preference + re-runs initialize() to swap providers cleanly.
+   *
+   * This does NOT copy data between stores — for that the user must
+   * explicitly invoke {@link runLegacyToProfileMigration}.
+   *
+   * Failure semantics: if the post-swap initialize() throws, we keep
+   * the previous mode preference written so the user can manually
+   * reload. We surface the error via `error` state.
+   */
+  const switchWalletMode = useCallback(async (target: WalletMode) => {
+    if (isSwitchingMode) {
+      logger.warn('SphereProvider', 'switchWalletMode: already switching — ignoring');
+      return;
+    }
+    if (target === walletMode) {
+      logger.debug('SphereProvider', `switchWalletMode: already in ${target}`);
+      return;
+    }
+    setIsSwitchingMode(true);
+    // Remember the previous preference so we can roll back on failure
+    // (defensive — see comment below).
+    const previousPreference = readWalletModePreference();
+    try {
+      writeWalletModePreference(target);
+      // initialize() reads the persisted preference and builds the
+      // matching providers from scratch.
+      await initialize(0, /*skipLoading=*/ false);
+      // Note: walletMode state is set inside initialize() based on the
+      // path it actually took. If the migration failed and we fell
+      // back to legacy, `initialize` does NOT overwrite the user's
+      // persisted 'profile' preference — we leave it in place so the
+      // next boot retries Profile. The user can still click "Switch
+      // back to Legacy" to flip the preference manually.
+    } catch (err) {
+      // Rollback the preference on a hard failure — the user shouldn't
+      // be stuck in a loop of failing-to-boot if e.g. the OrbitDB
+      // bring-up consistently fails.
+      if (previousPreference) {
+        writeWalletModePreference(previousPreference);
+      } else {
+        localStorage.removeItem(STORAGE_KEYS.WALLET_MODE_PREFERENCE);
+      }
+      throw err;
+    } finally {
+      setIsSwitchingMode(false);
+    }
+  }, [walletMode, isSwitchingMode, initialize]);
+
+  /**
+   * User-initiated legacy → Profile migration. Bypasses the
+   * data-presence guard + SDK marker when `force: true` (the
+   * "Merge (overwrite)" path).
+   *
+   * Always swaps active providers to Profile on success. On failure
+   * keeps the current mode and surfaces the error via toast/UI (caller
+   * inspects the thrown error).
+   */
+  const runLegacyToProfileMigration = useCallback(async (opts?: { force?: boolean }) => {
+    const instance = sphereRef.current;
+    if (!instance) throw new Error('Wallet not initialized');
+    if (!providers) throw new Error('Providers not initialized');
+    if (isSwitchingMode) {
+      logger.warn('SphereProvider', 'runLegacyToProfileMigration: switch already in progress');
+      return;
+    }
+    setIsSwitchingMode(true);
+    initSeqRef.current += 1;
+
+    // Build a SOURCE bundle whose `tokenStorage` is guaranteed to be
+    // the legacy `IndexedDBTokenStorageProvider`. When we're called
+    // from legacy mode, `providers.tokenStorage` already IS the legacy
+    // provider — we can use it directly. When called from Profile mode
+    // (the "Merge Legacy → UXF (overwrite)" path with the user
+    // currently on Profile), `providers.tokenStorage` is the Profile
+    // provider; copying that into Profile would be a Profile→Profile
+    // no-op + would silently NOT merge any real legacy data. So we
+    // construct a fresh legacy provider, set its identity, and pass
+    // that as the source.
+    let migrationSourceProviders = providers;
+    let extraLegacyTokenStorage: IndexedDBTokenStorageProvider | null = null;
+    if (walletMode === 'profile') {
+      const id = probeIdentityFromSphere(instance);
+      if (!id) {
+        setIsSwitchingMode(false);
+        throw new Error('Cannot merge: wallet identity unavailable');
+      }
+      const freshLegacy = new IndexedDBTokenStorageProvider();
+      freshLegacy.setIdentity(id);
+      const ok = await freshLegacy.initialize();
+      if (!ok) {
+        // initialize() may have left a partial DB connection — best-
+        // effort close before we surface the failure to the user.
+        try { await freshLegacy.disconnect(); } catch { /* ignore */ }
+        setIsSwitchingMode(false);
+        throw new Error('Cannot merge: legacy IndexedDB unavailable');
+      }
+      extraLegacyTokenStorage = freshLegacy;
+      // Spread the active providers and SUBSTITUTE the tokenStorage
+      // with the freshly-opened legacy provider. The oracle, storage
+      // (for marker), etc. are unchanged.
+      //
+      // The cast is needed because our local ambient declaration of
+      // `IndexedDBTokenStorageProvider` (in `sphere-sdk-browser.d.ts`)
+      // uses `Record<string, unknown>` for `save()` while the SDK's
+      // `TokenStorageProvider<TxfStorageDataBase>` uses the concrete
+      // type. The implementation is type-compatible at runtime — both
+      // describe the same SDK class.
+      migrationSourceProviders = {
+        ...providers,
+        tokenStorage: freshLegacy as unknown as BrowserProviders['tokenStorage'],
+      };
+    }
+
+    try {
+      const profileResult = await runProfileMigration({
+        legacyProviders: migrationSourceProviders,
+        sphere: instance,
+        network,
+        setInitProgress,
+        force: opts?.force === true,
+      });
+      if (!profileResult) {
+        throw new Error('Migration failed — see logs for details');
+      }
+      // Tear down the current Sphere and swap providers — same code path
+      // as the boot-time migration block.
+      await instance.destroy({ force: true, reason: 'user-initiated-uxf-migration' });
+      sphereRef.current = null;
+      const netConfig = NETWORKS[network] ?? NETWORKS.testnet;
+      const swapped: BrowserProviders = {
+        ...providers,
+        storage: profileResult.profileStorage,
+        tokenStorage: profileResult.profileTokenStorage,
+      };
+      delete swapped.ipfsTokenStorage;
+      setProviders(swapped);
+      TokenRegistry.configure({
+        remoteUrl: netConfig.tokenRegistryUrl,
+        storage: swapped.storage,
+      });
+      setInitProgress({ step: 'initializing', message: 'Loading Profile storage…' });
+      const reinit = await Sphere.init({
+        ...swapped,
+        l1: {},
+        discoverAddresses: false,
+        onProgress: setInitProgress,
+      });
+      sphereRef.current = reinit.sphere;
+      setSphere(reinit.sphere);
+      setWalletMode('profile');
+      writeWalletModePreference('profile');
+      setInitProgress(null);
+      // Refresh probes — legacy is unchanged (the migration COPIES,
+      // doesn't move), Profile now has data.
+      await runProbes(reinit.sphere);
+    } finally {
+      // Release the temp legacy provider (only opened on the
+      // profile-mode merge path).
+      if (extraLegacyTokenStorage) {
+        try { await extraLegacyTokenStorage.disconnect(); } catch { /* ignore */ }
+      }
+      setIsSwitchingMode(false);
+    }
+  }, [providers, network, isSwitchingMode, runProbes, walletMode]);
+
   const value: SphereContextValue = {
     sphere,
     providers,
@@ -555,6 +942,13 @@ export function SphereProvider({
     reinitialize: initialize,
     ipfsEnabled,
     toggleIpfs,
+    walletMode,
+    hasLegacyData,
+    hasProfileData,
+    isSwitchingMode,
+    switchWalletMode,
+    runLegacyToProfileMigration,
+    refreshDataProbes,
   };
 
   return (

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -173,6 +173,32 @@ async function probeProfileTokenData(
 ): Promise<boolean> {
   let profile: BrowserProfileProviders | null = null;
   try {
+    // KNOWN COST: when the active sphere is already on Profile mode, a
+    // probe spins up a SECOND Helia + OrbitDB instance against the
+    // same underlying IndexedDB databases. OrbitDB supports
+    // multi-process attach (content-addressed) so this is safe, but
+    // the spin-up cost (~500ms-1s) shows up as the banner "(checking
+    // stores…)" hint. A future optimization could skip this probe
+    // when `walletMode === 'profile'` AND the active sphere already
+    // reports tokens — but identity-only probing keeps the code path
+    // symmetric and avoids subtle aliasing bugs across React state
+    // updates.
+    //
+    // KNOWN LIMITATION (inherited from PR #307): the `identity` we
+    // pass here has `privateKey: ''` — the real private key isn't
+    // exposed via the public Sphere API. The Profile providers
+    // attempt to derive an encryption key from the empty hex string
+    // and silently fall back to NO encryption when `hexToBytes('')`
+    // throws. For wallets whose Profile data was ever written with a
+    // real privateKey (i.e. directly via Sphere.init, not via this
+    // app's migration path), this probe will fail to decrypt and
+    // return `false` — banner shows "no Profile data" when actually
+    // there is some. The user can still click Switch to UXF Profile
+    // to recover. Cleanly resolving this requires either
+    //   (a) exposing the private key via Sphere's public API, or
+    //   (b) running the probe through an already-initialized Sphere
+    //       instance that has the key in scope.
+    // Both are out of scope for this PR.
     profile = createBrowserProfileProviders({ network, oracle });
     profile.tokenStorage.setIdentity(identity);
     profile.storage.setIdentity(identity);
@@ -222,7 +248,7 @@ export function SphereProvider({
 }: SphereProviderProps) {
   const queryClient = useQueryClient();
   const [sphere, setSphere] = useState<Sphere | null>(null);
-  const [providers, setProviders] = useState<BrowserProviders | null>(null);
+  const [providers, setProvidersRaw] = useState<BrowserProviders | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [walletExists, setWalletExists] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -238,6 +264,23 @@ export function SphereProvider({
   const [hasProfileData, setHasProfileData] = useState<boolean | null>(null);
   const [isSwitchingMode, setIsSwitchingMode] = useState(false);
   const sphereRef = useRef<Sphere | null>(null);
+  /**
+   * Ref-mirror of the latest `providers` for callbacks that need to
+   * read the current value *without* recreating themselves on every
+   * provider swap (e.g. `runProbes`). Updated synchronously inside
+   * `setProviders()` below so a callback fired in the SAME tick as
+   * the state write sees the new value (React state itself wouldn't
+   * propagate until the next commit).
+   */
+  const providersRef = useRef<BrowserProviders | null>(null);
+  /**
+   * Wrapper that updates both the ref AND the React state for
+   * `providers`. Always use this instead of `setProvidersRaw`.
+   */
+  const setProviders = useCallback((next: BrowserProviders | null) => {
+    providersRef.current = next;
+    setProvidersRaw(next);
+  }, []);
   /**
    * Sequence counter — bumped on every initialize() / mode-switch. Used
    * to discard probe-write races: if a probe completes AFTER a newer
@@ -261,30 +304,73 @@ export function SphereProvider({
       logger.debug('SphereProvider', 'runProbes: no identity yet — skipping');
       return;
     }
-    const oracle = providers?.oracle;
+    // Read providers + oracle from the ref (synchronous mirror of
+    // latest `providers`) rather than the closure-captured `providers`
+    // state. The state can be stale during the very first boot:
+    // `setProviders` is called inside `initialize()` and React
+    // batches the update until after the callback returns, so a
+    // closure that captured the previous (`null`) value would skip
+    // the Profile probe entirely.
+    const liveProviders = providersRef.current ?? providers;
+    const oracle = liveProviders?.oracle;
 
-    // Run both probes in parallel; tolerate individual failures.
+    // Probe choice — use the live `liveProviders.tokenStorage` when
+    // it's the SAME backend we're probing, because that instance was
+    // initialized by Sphere.init with the REAL privateKey and its
+    // encryption key is correctly derived. Falling back to a fresh
+    // probe-only provider (with synthesized empty privateKey) only
+    // works for non-encrypted data and is therefore a best-effort
+    // fallback for cross-mode probes.
     //
-    // The "current mode" probe is cheap (we already have the
-    // initialized provider attached to `sphere`), but to keep the code
-    // path symmetric AND to make the probe identity-only (not
-    // dependent on react state ordering), we always re-probe via a
-    // fresh provider. This costs ~20ms but avoids the alternative of
-    // accidentally reading a provider that's been swapped under us.
-    const [legacy, profile] = await Promise.all([
-      probeLegacyTokenData(id).catch((err) => {
-        logger.warn('SphereProvider', 'probeLegacyTokenData failed', err);
-        return null;
-      }),
-      // Profile probe requires an oracle. If we don't have one yet,
-      // assume no Profile data.
-      oracle
-        ? probeProfileTokenData(id, network, oracle).catch((err) => {
+    // The result: when in Legacy mode we probe LIVE legacy + fresh
+    // Profile; when in Profile mode we probe fresh legacy + LIVE
+    // Profile. The "fresh" side may return a false-negative for
+    // encrypted data on the opposite backend — documented limitation
+    // (see `probeProfileTokenData` docstring).
+    // The SDK's ProfileTokenStorageProvider exposes `id === 'profile-token'`
+    // (NOT 'profile-token-storage' — that's the user-facing name).
+    // Legacy is 'indexeddb-token-storage'. We key off `id` to avoid
+    // instanceof-against-imported-class issues across tsup bundle
+    // boundaries.
+    const inProfileMode = (
+      liveProviders?.tokenStorage as { id?: string } | undefined
+    )?.id === 'profile-token';
+
+    const legacyP: Promise<boolean | null> = inProfileMode
+      ? probeLegacyTokenData(id).catch((err) => {
+          logger.warn('SphereProvider', 'probeLegacyTokenData failed', err);
+          return null;
+        })
+      : (async () => {
+          try {
+            const snap = await liveProviders?.tokenStorage.load();
+            if (!snap?.success || !snap.data) return false;
+            return hasMaterialContent(snap.data as unknown as Record<string, unknown>);
+          } catch (err) {
+            logger.warn('SphereProvider', 'live legacy probe failed', err);
+            return null;
+          }
+        })();
+
+    const profileP: Promise<boolean | null> = !oracle
+      ? Promise.resolve(false)
+      : inProfileMode
+        ? (async () => {
+            try {
+              const snap = await liveProviders?.tokenStorage.load();
+              if (!snap?.success || !snap.data) return false;
+              return hasMaterialContent(snap.data as unknown as Record<string, unknown>);
+            } catch (err) {
+              logger.warn('SphereProvider', 'live profile probe failed', err);
+              return null;
+            }
+          })()
+        : probeProfileTokenData(id, network, oracle).catch((err) => {
             logger.warn('SphereProvider', 'probeProfileTokenData failed', err);
             return null;
-          })
-        : Promise.resolve(false),
-    ]);
+          });
+
+    const [legacy, profile] = await Promise.all([legacyP, profileP]);
 
     if (seq !== initSeqRef.current) {
       // A newer initialize / mode-switch started — drop these results.
@@ -531,7 +617,7 @@ export function SphereProvider({
       setInitProgress(null);
       setIsLoading(false);
     }
-  }, [network, runProbes]);
+  }, [network, runProbes, setProviders]);
 
   // Stable ref so the boot-time effect only fires once per `network`
   // change. Without this, the effect would re-run whenever `walletMode`
@@ -733,9 +819,15 @@ export function SphereProvider({
       sphereRef.current = importedSphere;
       setSphere(importedSphere);
       sendWelcomeDM(importedSphere);
+      // Kick off boot probes for the new wallet — otherwise the banner
+      // would be stuck in "(checking stores…)" forever on fresh-wallet
+      // create/import flows.
+      runProbes(importedSphere).catch((err) => {
+        logger.warn('SphereProvider', 'finalizeWallet runProbes failed', err);
+      });
     }
     setWalletExists(true);
-  }, [providers]);
+  }, [providers, runProbes]);
 
   const toggleIpfs = useCallback(() => {
     const next = !isIpfsEnabled();
@@ -839,14 +931,18 @@ export function SphereProvider({
     // that as the source.
     let migrationSourceProviders = providers;
     let extraLegacyTokenStorage: IndexedDBTokenStorageProvider | null = null;
+    // Snapshot the identity BEFORE we destroy the active sphere so we
+    // can pass it to the migration helper (which needs it for the
+    // marker keyspace + oracle.isSpent probes).
+    const snapshotIdentity = probeIdentityFromSphere(instance);
+
     if (walletMode === 'profile') {
-      const id = probeIdentityFromSphere(instance);
-      if (!id) {
+      if (!snapshotIdentity) {
         setIsSwitchingMode(false);
         throw new Error('Cannot merge: wallet identity unavailable');
       }
       const freshLegacy = new IndexedDBTokenStorageProvider();
-      freshLegacy.setIdentity(id);
+      freshLegacy.setIdentity(snapshotIdentity);
       const ok = await freshLegacy.initialize();
       if (!ok) {
         // initialize() may have left a partial DB connection — best-
@@ -856,6 +952,23 @@ export function SphereProvider({
         throw new Error('Cannot merge: legacy IndexedDB unavailable');
       }
       extraLegacyTokenStorage = freshLegacy;
+
+      // CRITICAL — destroy the active Profile-backed Sphere BEFORE we
+      // spin up the migration helper's own Profile providers.
+      // Otherwise we'd have TWO live OrbitDB instances writing to the
+      // same database (active sphere + migration helper). OrbitDB's
+      // OpLog is multi-writer but concurrent writes can re-order with
+      // visible inconsistency to a future reader. By tearing down the
+      // active instance first we serialize: migration writes → reinit
+      // reads.
+      await instance.destroy({ force: true, reason: 'user-initiated-uxf-merge' });
+      sphereRef.current = null;
+      // Disconnect the active providers' Profile-backed storage so the
+      // migration helper's `setIdentity` + `initialize` aren't fighting
+      // a stale handle.
+      try { await providers.tokenStorage.disconnect(); } catch { /* ignore */ }
+      try { await providers.storage.disconnect(); } catch { /* ignore */ }
+
       // Spread the active providers and SUBSTITUTE the tokenStorage
       // with the freshly-opened legacy provider. The oracle, storage
       // (for marker), etc. are unchanged.
@@ -873,9 +986,15 @@ export function SphereProvider({
     }
 
     try {
+      // From legacy mode, we still pass `sphere: instance` because the
+      // helper reads `sphere.identity`. From profile mode we already
+      // destroyed `instance`; reach into the snapshot.
+      const helperSphereArg = walletMode === 'profile'
+        ? ({ identity: snapshotIdentity } as unknown as Sphere)
+        : instance;
       const profileResult = await runProfileMigration({
         legacyProviders: migrationSourceProviders,
-        sphere: instance,
+        sphere: helperSphereArg,
         network,
         setInitProgress,
         force: opts?.force === true,
@@ -883,10 +1002,13 @@ export function SphereProvider({
       if (!profileResult) {
         throw new Error('Migration failed — see logs for details');
       }
-      // Tear down the current Sphere and swap providers — same code path
-      // as the boot-time migration block.
-      await instance.destroy({ force: true, reason: 'user-initiated-uxf-migration' });
-      sphereRef.current = null;
+      // From legacy mode, destroy the still-live legacy Sphere now;
+      // from profile mode it was already destroyed before the migrate
+      // call (see comment above).
+      if (walletMode === 'legacy') {
+        await instance.destroy({ force: true, reason: 'user-initiated-uxf-migration' });
+        sphereRef.current = null;
+      }
       const netConfig = NETWORKS[network] ?? NETWORKS.testnet;
       const swapped: BrowserProviders = {
         ...providers,
@@ -914,6 +1036,19 @@ export function SphereProvider({
       // Refresh probes — legacy is unchanged (the migration COPIES,
       // doesn't move), Profile now has data.
       await runProbes(reinit.sphere);
+    } catch (err) {
+      // Fatal error AFTER we destroyed the active sphere — the user is
+      // now sphere-less. Re-run `initialize()` to rebuild whatever
+      // mode the persisted preference points to (most likely legacy
+      // since we only stamp 'profile' on success). This ensures the
+      // user always lands on a usable wallet rather than a blank UI.
+      logger.error('SphereProvider', 'runLegacyToProfileMigration failed — recovering', err);
+      try {
+        await initializeRef.current(0, /*skipLoading=*/ true);
+      } catch (recoverErr) {
+        logger.error('SphereProvider', 'Recovery initialize() also failed', recoverErr);
+      }
+      throw err;
     } finally {
       // Release the temp legacy provider (only opened on the
       // profile-mode merge path).
@@ -922,7 +1057,7 @@ export function SphereProvider({
       }
       setIsSwitchingMode(false);
     }
-  }, [providers, network, isSwitchingMode, runProbes, walletMode]);
+  }, [providers, network, isSwitchingMode, runProbes, walletMode, setProviders]);
 
   const value: SphereContextValue = {
     sphere,

--- a/src/sdk/utils/tokenStorageProbe.ts
+++ b/src/sdk/utils/tokenStorageProbe.ts
@@ -1,0 +1,78 @@
+/**
+ * Token-storage data-presence probe — shared helper.
+ *
+ * This module exports {@link hasMaterialContent}, the canonical
+ * "does this `TokenStorageProvider.load()` snapshot contain
+ * user-meaningful data?" predicate used by:
+ *
+ *   - `uxfProfileMigration.runProfileMigration` — to skip the
+ *     overwrite-style migration when Profile target already holds tokens
+ *     (fresh-wallet path, see `uxfProfileMigration.ts` docstring).
+ *   - `SphereProvider` boot-time probes — to populate the
+ *     `hasLegacyData` / `hasProfileData` flags on `SphereContext` so
+ *     the `UxfBanner` mode-switcher can render the correct buttons.
+ *
+ * Why a shared helper rather than two copies: the two callers MUST agree
+ * on what counts as "material" content. The migration-overwrite guard
+ * being stricter or laxer than the banner-probe would silently produce a
+ * UI/data mismatch — e.g. the banner says "no data in Profile" while the
+ * migration guard says "Profile has data, skipping". This file is the
+ * single source of truth.
+ *
+ * Mirrors {@link TXF_RESERVED_COLLECTIONS} from the sphere-sdk
+ * `types/txf.ts` RESERVED_KEYS set, intentionally excluding `_meta`
+ * because every load() returns a `_meta` block even when no tokens have
+ * ever been written.
+ */
+
+/**
+ * Reserved structural keys in `TxfStorageDataBase` (see sphere-sdk
+ * types/txf.ts RESERVED_KEYS). `_meta` is omitted on purpose — it is
+ * always present (the helper synthesizes it) and never indicates the
+ * presence of user token data.
+ */
+export const TXF_RESERVED_COLLECTIONS = new Set<string>([
+  '_nametag',
+  '_nametags',
+  '_tombstones',
+  '_invalidatedNametags',
+  '_outbox',
+  '_mintOutbox',
+  '_sent',
+  '_invalid',
+  '_integrity',
+  '_history',
+  '_audit',
+  '_finalizationQueue',
+]);
+
+/**
+ * Returns `true` if the loaded snapshot contains any user-meaningful
+ * data — active tokens (`_<hexTokenId>`), archived tokens
+ * (`archived-<tokenId>`), forks (`_forked_<tokenId>_<state>`), OR any
+ * reserved collection with non-empty contents.
+ *
+ * `_meta` alone is NOT material content (the helper always emits it
+ * even when migrating an empty wallet, and Profile providers emit it
+ * on every load() call).
+ */
+export function hasMaterialContent(data: Record<string, unknown>): boolean {
+  for (const key of Object.keys(data)) {
+    if (key === '_meta') continue;
+    const v = data[key];
+    if (v === undefined || v === null) continue;
+    if (TXF_RESERVED_COLLECTIONS.has(key)) {
+      // Reserved collections are arrays/objects — check non-empty.
+      if (Array.isArray(v) && v.length > 0) return true;
+      if (!Array.isArray(v) && typeof v === 'object' && Object.keys(v as object).length > 0) {
+        return true;
+      }
+      continue;
+    }
+    // Anything else (token keys `_<hex>`, archived `archived-…`,
+    // forks `_forked_…`) is a token-shaped entry — its presence is
+    // material content.
+    return true;
+  }
+  return false;
+}

--- a/src/sdk/uxfProfileMigration.ts
+++ b/src/sdk/uxfProfileMigration.ts
@@ -35,6 +35,7 @@ import {
   type BrowserProfileProviders,
 } from '@unicitylabs/sphere-sdk/profile/browser';
 import { migrateLegacyToProfile } from '@unicitylabs/sphere-sdk/profile';
+import { hasMaterialContent } from './utils/tokenStorageProbe';
 
 /**
  * Inputs to {@link runProfileMigration}. Kept narrow so unit tests don't
@@ -55,6 +56,18 @@ export interface RunProfileMigrationInput {
    * Defaults to `migrateLegacyToProfile` from sphere-sdk.
    */
   readonly migrate?: typeof migrateLegacyToProfile;
+  /**
+   * Bypass the data-presence guard AND the SDK marker. Used by the
+   * user-initiated "Merge Legacy → UXF (overwrite)" banner button in
+   * `UxfBanner.tsx`. When `true`:
+   *   - The pre-flight `hasMaterialContent(profile.load())` short-circuit
+   *     is skipped (we WANT to overwrite).
+   *   - `migrate({ force: true })` is set so the SDK's marker check is
+   *     bypassed and the marker is rewritten with the new timestamp.
+   *
+   * Default: `false` (boot-time path).
+   */
+  readonly force?: boolean;
 }
 
 /**
@@ -91,6 +104,7 @@ export async function runProfileMigration(
     setInitProgress,
     createProfileProviders = createBrowserProfileProviders,
     migrate = migrateLegacyToProfile,
+    force = false,
   } = input;
 
   const identity = sphere.identity;
@@ -152,30 +166,37 @@ export async function runProfileMigration(
     // The SDK marker check inside the helper does NOT cover this case
     // (the marker is only stamped by a previous run of the helper, not
     // by fresh-wallet creation).
-    try {
-      const targetSnapshot = await profile.tokenStorage.load();
-      if (targetSnapshot.success && targetSnapshot.data) {
-        if (hasMaterialContent(targetSnapshot.data as unknown as Record<string, unknown>)) {
-          logger.debug(
-            'SphereProvider',
-            'UXF migration skipped: Profile storage already populated (fresh-wallet path or prior migration)',
-          );
-          return {
-            profileStorage: profile.storage,
-            profileTokenStorage: profile.tokenStorage,
-            migrationCounts: { tokensMigrated: 0, archivedMigrated: 0 },
-            skippedDueToMarker: true,
-          };
+    //
+    // FORCE OVERRIDE — when the caller explicitly opts into overwrite
+    // (e.g. the user clicked "Merge Legacy → UXF (overwrite)" in the
+    // banner), this guard is skipped because the user has acknowledged
+    // that Profile-only data will be lost.
+    if (!force) {
+      try {
+        const targetSnapshot = await profile.tokenStorage.load();
+        if (targetSnapshot.success && targetSnapshot.data) {
+          if (hasMaterialContent(targetSnapshot.data as unknown as Record<string, unknown>)) {
+            logger.debug(
+              'SphereProvider',
+              'UXF migration skipped: Profile storage already populated (fresh-wallet path or prior migration)',
+            );
+            return {
+              profileStorage: profile.storage,
+              profileTokenStorage: profile.tokenStorage,
+              migrationCounts: { tokensMigrated: 0, archivedMigrated: 0 },
+              skippedDueToMarker: true,
+            };
+          }
         }
+      } catch (err) {
+        // Probe failure is non-fatal — the helper will be called and its
+        // own source/target guards take over. We log and continue.
+        logger.warn(
+          'SphereProvider',
+          'Profile token storage probe failed before migration; proceeding',
+          err,
+        );
       }
-    } catch (err) {
-      // Probe failure is non-fatal — the helper will be called and its
-      // own source/target guards take over. We log and continue.
-      logger.warn(
-        'SphereProvider',
-        'Profile token storage probe failed before migration; proceeding',
-        err,
-      );
     }
 
     setInitProgress({
@@ -193,6 +214,12 @@ export async function runProfileMigration(
       // Marker lives in the TARGET (Profile) storage so a future
       // profile-only client also sees the marker.
       markerStorage: profile.storage,
+      // When the caller passed `force: true` (merge-overwrite path),
+      // skip the SDK's idempotency-marker short-circuit so the helper
+      // re-copies legacy → Profile even if a prior migration was
+      // already stamped. The marker is REWRITTEN on success so
+      // subsequent boots still short-circuit.
+      force,
       onProgress: (p) => {
         // Surface the helper's own phase into the existing initProgress
         // pipeline. We map the helper's phases onto the SDK's
@@ -266,54 +293,3 @@ export async function runProfileMigration(
   }
 }
 
-/**
- * Reserved structural keys in `TxfStorageDataBase` (see sphere-sdk
- * types/txf.ts RESERVED_KEYS). Excluding `_meta` because it is
- * always present (the helper synthesizes it) and never indicates the
- * presence of user token data.
- */
-const TXF_RESERVED_COLLECTIONS = new Set<string>([
-  '_nametag',
-  '_nametags',
-  '_tombstones',
-  '_invalidatedNametags',
-  '_outbox',
-  '_mintOutbox',
-  '_sent',
-  '_invalid',
-  '_integrity',
-  '_history',
-  '_audit',
-  '_finalizationQueue',
-]);
-
-/**
- * Returns `true` if the loaded snapshot contains any user-meaningful
- * data — active tokens (`_<hexTokenId>`), archived tokens
- * (`archived-<tokenId>`), forks (`_forked_<tokenId>_<state>`), OR any
- * reserved collection with non-empty contents.
- *
- * `_meta` alone is NOT material content (the helper always emits it
- * even when migrating an empty wallet, and Profile providers emit it
- * on every load() call).
- */
-function hasMaterialContent(data: Record<string, unknown>): boolean {
-  for (const key of Object.keys(data)) {
-    if (key === '_meta') continue;
-    const v = data[key];
-    if (v === undefined || v === null) continue;
-    if (TXF_RESERVED_COLLECTIONS.has(key)) {
-      // Reserved collections are arrays/objects — check non-empty.
-      if (Array.isArray(v) && v.length > 0) return true;
-      if (!Array.isArray(v) && typeof v === 'object' && Object.keys(v as object).length > 0) {
-        return true;
-      }
-      continue;
-    }
-    // Anything else (token keys `_<hex>`, archived `archived-…`,
-    // forks `_forked_…`) is a token-shaped entry — its presence is
-    // material content.
-    return true;
-  }
-  return false;
-}

--- a/src/sphere-sdk-browser.d.ts
+++ b/src/sphere-sdk-browser.d.ts
@@ -46,4 +46,35 @@ declare module '@unicitylabs/sphere-sdk/impl/browser' {
   export function createBrowserProviders(
     config?: BrowserProvidersConfig,
   ): BrowserProviders;
+
+  /**
+   * Subset of {@link IndexedDBTokenStorageProvider} we use in
+   * sphere.telco for cross-mode data-presence probing. The SDK class
+   * has a wider surface — we only declare the bits we touch here.
+   */
+  export interface IndexedDBTokenStorageProviderConfig {
+    readonly dbNamePrefix?: string;
+    readonly debug?: boolean;
+  }
+  export class IndexedDBTokenStorageProvider
+    implements TokenStorageProvider<TxfStorageDataBase>
+  {
+    constructor(config?: IndexedDBTokenStorageProviderConfig);
+    readonly id: string;
+    readonly name: string;
+    readonly type: string;
+    setIdentity(identity: { directAddress?: string; l1Address: string; chainPubkey: string; privateKey?: string }): void;
+    initialize(): Promise<boolean>;
+    connect(): Promise<void>;
+    disconnect(): Promise<void>;
+    shutdown(opts?: Record<string, unknown>): Promise<void>;
+    isConnected(): boolean;
+    getStatus(): string;
+    sync?(other: TokenStorageProvider<TxfStorageDataBase>): Promise<unknown>;
+    load(): Promise<{ success: boolean; data?: Record<string, unknown>; error?: string; source?: string; timestamp?: number }>;
+    save(data: Record<string, unknown>): Promise<{ success: boolean; error?: string; timestamp?: number }>;
+  }
+  export function createIndexedDBTokenStorageProvider(
+    config?: IndexedDBTokenStorageProviderConfig,
+  ): IndexedDBTokenStorageProvider;
 }

--- a/tests/unit/components/UxfBanner.test.tsx
+++ b/tests/unit/components/UxfBanner.test.tsx
@@ -1,0 +1,320 @@
+/**
+ * UxfBanner button-state matrix tests.
+ *
+ * The banner conditionally renders Migrate / Switch / Merge buttons
+ * based on `(walletMode, hasLegacyData, hasProfileData)`. These tests
+ * lock that decision table down so a refactor can't silently flip a
+ * conditional and ship a busted UI.
+ *
+ * Decision table:
+ *   | mode    | legacy | profile | shown                                         |
+ *   |---------|--------|---------|-----------------------------------------------|
+ *   | legacy  |  any   | false   | Migrate to UXF Profile                        |
+ *   | legacy  |  any   | true    | Switch to UXF Profile  +  Merge Legacy → UXF  |
+ *   | profile | true   |  any    | Switch back to Legacy  +  Merge Legacy → UXF  |
+ *   | profile | false  |  any    | (status only — no buttons)                    |
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { UxfBanner } from '../../../src/components/uxf/UxfBanner';
+import { SphereContext, type SphereContextValue, type WalletMode } from '../../../src/sdk/SphereContext';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeCtx(
+  overrides: Partial<SphereContextValue> & {
+    walletMode: WalletMode;
+    hasLegacyData: boolean | null;
+    hasProfileData: boolean | null;
+  },
+): SphereContextValue {
+  return {
+    sphere: null,
+    providers: null,
+    isLoading: false,
+    isInitialized: false,
+    walletExists: false,
+    error: null,
+    isDiscoveringAddresses: false,
+    initProgress: null,
+    resolveNametag: vi.fn(),
+    createWallet: vi.fn(),
+    importWallet: vi.fn(),
+    importFromFile: vi.fn(),
+    finalizeWallet: vi.fn(),
+    deleteWallet: vi.fn(),
+    reinitialize: vi.fn(),
+    ipfsEnabled: true,
+    toggleIpfs: vi.fn(),
+    isSwitchingMode: false,
+    switchWalletMode: vi.fn(),
+    runLegacyToProfileMigration: vi.fn(),
+    refreshDataProbes: vi.fn(),
+    ...overrides,
+  } as unknown as SphereContextValue;
+}
+
+function renderBanner(ctx: SphereContextValue) {
+  return render(
+    <SphereContext.Provider value={ctx}>
+      <UxfBanner />
+    </SphereContext.Provider>,
+  );
+}
+
+// Helpers that match button labels — they include the loading/progress
+// suffix during pending operations, so we use partial regex matchers.
+const labelMigrate = /Migrate to UXF Profile/;
+const labelSwitchToProfile = /Switch to UXF Profile/;
+const labelSwitchToLegacy = /Switch back to Legacy/;
+const labelMerge = /Merge Legacy → UXF/;
+const labelRefresh = /Re-check stores/;
+
+beforeEach(() => {
+  // Reset jsdom between tests
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── Decision table ────────────────────────────────────────────────────
+
+describe('UxfBanner — button matrix', () => {
+  it('legacy mode + no profile data → only Migrate button', () => {
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: false,
+      }),
+    );
+    expect(screen.getByRole('button', { name: labelMigrate })).toBeDefined();
+    expect(screen.queryByRole('button', { name: labelSwitchToProfile })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelSwitchToLegacy })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelMerge })).toBeNull();
+  });
+
+  it('legacy mode + profile data exists → Switch to Profile + Merge', () => {
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: true,
+      }),
+    );
+    expect(screen.getByRole('button', { name: labelSwitchToProfile })).toBeDefined();
+    expect(screen.getByRole('button', { name: labelMerge })).toBeDefined();
+    expect(screen.queryByRole('button', { name: labelMigrate })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelSwitchToLegacy })).toBeNull();
+  });
+
+  it('profile mode + legacy data exists → Switch to Legacy + Merge', () => {
+    renderBanner(
+      makeCtx({
+        walletMode: 'profile',
+        hasLegacyData: true,
+        hasProfileData: true,
+      }),
+    );
+    expect(screen.getByRole('button', { name: labelSwitchToLegacy })).toBeDefined();
+    expect(screen.getByRole('button', { name: labelMerge })).toBeDefined();
+    expect(screen.queryByRole('button', { name: labelMigrate })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelSwitchToProfile })).toBeNull();
+  });
+
+  it('profile mode + no legacy data → status only (no action buttons except refresh + dismiss)', () => {
+    renderBanner(
+      makeCtx({
+        walletMode: 'profile',
+        hasLegacyData: false,
+        hasProfileData: true,
+      }),
+    );
+    expect(screen.queryByRole('button', { name: labelMigrate })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelSwitchToLegacy })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelSwitchToProfile })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelMerge })).toBeNull();
+    // Refresh + dismiss are always present
+    expect(screen.getByRole('button', { name: labelRefresh })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Dismiss UXF banner/ })).toBeDefined();
+  });
+
+  it('shows a "checking stores…" hint while probes are pending', () => {
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: null,
+        hasProfileData: null,
+      }),
+    );
+    expect(screen.getByText(/checking stores/i)).toBeDefined();
+    // No actionable buttons yet — we don't know which to show.
+    expect(screen.queryByRole('button', { name: labelMigrate })).toBeNull();
+    expect(screen.queryByRole('button', { name: labelSwitchToProfile })).toBeNull();
+  });
+
+  it('shows the wallet-mode label in the status text', () => {
+    const { rerender } = renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: false,
+      }),
+    );
+    expect(screen.getByText(/Legacy/i)).toBeDefined();
+
+    rerender(
+      <SphereContext.Provider
+        value={makeCtx({
+          walletMode: 'profile',
+          hasLegacyData: false,
+          hasProfileData: true,
+        })}
+      >
+        <UxfBanner />
+      </SphereContext.Provider>,
+    );
+    expect(screen.getByText(/UXF Profile/i)).toBeDefined();
+  });
+
+  it('all action buttons are disabled while `isSwitchingMode` is true', () => {
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: true,
+        isSwitchingMode: true,
+      }),
+    );
+    const switchBtn = screen.getByRole('button', { name: labelSwitchToProfile });
+    const mergeBtn = screen.getByRole('button', { name: labelMerge });
+    expect((switchBtn as HTMLButtonElement).disabled).toBe(true);
+    expect((mergeBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+// ── Migrate action ────────────────────────────────────────────────────
+
+describe('UxfBanner — actions', () => {
+  it('clicking Migrate invokes runLegacyToProfileMigration WITHOUT force', async () => {
+    const runMigration = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: false,
+        runLegacyToProfileMigration: runMigration,
+      }),
+    );
+    const btn = screen.getByRole('button', { name: labelMigrate });
+    btn.click();
+    // The action is fire-and-forget; assert it was kicked off.
+    expect(runMigration).toHaveBeenCalledWith({ force: false });
+  });
+
+  it('clicking Switch to Profile invokes switchWalletMode("profile")', () => {
+    const switchMode = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: true,
+        switchWalletMode: switchMode,
+      }),
+    );
+    screen.getByRole('button', { name: labelSwitchToProfile }).click();
+    expect(switchMode).toHaveBeenCalledWith('profile');
+  });
+
+  it('clicking Switch to Legacy invokes switchWalletMode("legacy")', () => {
+    const switchMode = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'profile',
+        hasLegacyData: true,
+        hasProfileData: true,
+        switchWalletMode: switchMode,
+      }),
+    );
+    screen.getByRole('button', { name: labelSwitchToLegacy }).click();
+    expect(switchMode).toHaveBeenCalledWith('legacy');
+  });
+
+  it('clicking Merge opens the confirmation modal BEFORE running the migration', () => {
+    const runMigration = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'profile',
+        hasLegacyData: true,
+        hasProfileData: true,
+        runLegacyToProfileMigration: runMigration,
+      }),
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: labelMerge }));
+    });
+    // Migration MUST NOT have been called yet — modal is up.
+    expect(runMigration).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeDefined();
+    // Modal copy is the canonical warning text — assert verbatim.
+    expect(screen.getByText(/Merge Legacy → UXF \(overwrite\)\?/)).toBeDefined();
+    expect(
+      screen.getByText(
+        /This will OVERWRITE your UXF Profile token data with your Legacy data\. Tokens currently in Profile that aren't in Legacy will be lost\. Continue\?/,
+      ),
+    ).toBeDefined();
+  });
+
+  it('confirming the merge modal invokes runLegacyToProfileMigration WITH force: true', () => {
+    const runMigration = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'profile',
+        hasLegacyData: true,
+        hasProfileData: true,
+        runLegacyToProfileMigration: runMigration,
+      }),
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: labelMerge }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Yes, overwrite Profile/ }));
+    });
+    expect(runMigration).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('cancelling the merge modal does NOT trigger migration', () => {
+    const runMigration = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'profile',
+        hasLegacyData: true,
+        hasProfileData: true,
+        runLegacyToProfileMigration: runMigration,
+      }),
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: labelMerge }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Cancel/ }));
+    });
+    expect(runMigration).not.toHaveBeenCalled();
+  });
+
+  it('clicking Refresh invokes refreshDataProbes', () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: false,
+        refreshDataProbes: refresh,
+      }),
+    );
+    screen.getByRole('button', { name: labelRefresh }).click();
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/UxfBanner.test.tsx
+++ b/tests/unit/components/UxfBanner.test.tsx
@@ -33,7 +33,9 @@ function makeCtx(
     providers: null,
     isLoading: false,
     isInitialized: false,
-    walletExists: false,
+    // Default: wallet EXISTS so the banner renders. Override per-test
+    // to verify the onboarding-hidden path.
+    walletExists: true,
     error: null,
     isDiscoveringAddresses: false,
     initProgress: null,
@@ -138,6 +140,20 @@ describe('UxfBanner — button matrix', () => {
     // Refresh + dismiss are always present
     expect(screen.getByRole('button', { name: labelRefresh })).toBeDefined();
     expect(screen.getByRole('button', { name: /Dismiss UXF banner/ })).toBeDefined();
+  });
+
+  it('hides the banner entirely during onboarding (walletExists=false)', () => {
+    const { container } = renderBanner(
+      makeCtx({
+        walletMode: 'legacy',
+        hasLegacyData: true,
+        hasProfileData: false,
+        walletExists: false,
+      }),
+    );
+    // Empty render — banner is omitted while the user is on the
+    // onboarding flow (no wallet yet).
+    expect(container.firstChild).toBeNull();
   });
 
   it('shows a "checking stores…" hint while probes are pending', () => {

--- a/tests/unit/sdk/tokenStorageProbe.test.ts
+++ b/tests/unit/sdk/tokenStorageProbe.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasMaterialContent,
+  TXF_RESERVED_COLLECTIONS,
+} from '../../../src/sdk/utils/tokenStorageProbe';
+
+/**
+ * Tests for the shared `hasMaterialContent` predicate. This is the
+ * single source of truth used by BOTH the migration overwrite-guard
+ * AND the banner data-presence probes — they MUST agree.
+ */
+describe('hasMaterialContent', () => {
+  it('returns false for a snapshot containing only _meta', () => {
+    expect(
+      hasMaterialContent({
+        _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: 0 },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for an empty object', () => {
+    expect(hasMaterialContent({})).toBe(false);
+  });
+
+  it('treats a single active-token key (`_<hex>`) as material content', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        _abc123: { genesis: { tokenId: 'abc123' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('treats an `archived-<id>` key as material content', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        'archived-abc123': { genesis: { tokenId: 'abc123' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('treats a `_forked_<id>_<state>` key as material content', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        '_forked_abc123_aaaa': { genesis: { tokenId: 'abc123' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('ignores empty reserved collections (arrays)', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        _outbox: [],
+        _sent: [],
+        _tombstones: [],
+        _audit: [],
+      }),
+    ).toBe(false);
+  });
+
+  it('treats a NON-empty `_outbox` array as material content', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        _outbox: [{ id: 'outbox-1' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('treats a NON-empty `_tombstones` array as material content', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        _tombstones: [{ id: 'tomb-1' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('treats `_history` and `_audit` populated arrays as material content', () => {
+    expect(hasMaterialContent({ _meta: {}, _history: [{ id: 'h1' }] })).toBe(true);
+    expect(hasMaterialContent({ _meta: {}, _audit: [{ id: 'a1' }] })).toBe(true);
+  });
+
+  it('ignores undefined / null values for any key (defensive)', () => {
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        _foo: undefined,
+        _bar: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('treats a reserved collection that is an object (not array) with keys as material', () => {
+    // Some reserved collections in the codebase are objects keyed by id
+    // — guard against the array-only assumption.
+    expect(
+      hasMaterialContent({
+        _meta: {},
+        _nametags: { alice: { idx: 0 } },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps the reserved-collection set in sync with the SDK list', () => {
+    // The expectation here is structural: the shared util MUST cover
+    // every reserved key the SDK currently uses. We don't test the
+    // SDK's list directly (it's not exported), but if this set ever
+    // changes by accident we want the test to fail loudly.
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_outbox');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_sent');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_tombstones');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_audit');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_finalizationQueue');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_nametags');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_invalidatedNametags');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_invalid');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_history');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_integrity');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_mintOutbox');
+    expect(TXF_RESERVED_COLLECTIONS).toContain('_nametag');
+    // _meta is intentionally EXCLUDED (it's always present)
+    expect(TXF_RESERVED_COLLECTIONS).not.toContain('_meta');
+  });
+});

--- a/tests/unit/sdk/uxfProfileMigration.test.ts
+++ b/tests/unit/sdk/uxfProfileMigration.test.ts
@@ -409,6 +409,73 @@ describe('runProfileMigration', () => {
     expect(result?.skippedDueToMarker).toBe(false);
   });
 
+  // ── force: true (user-initiated "Merge Legacy → UXF (overwrite)") ──
+  describe('force: true (merge-overwrite path)', () => {
+    it('bypasses the Profile-already-populated guard AND passes `force` through to the SDK helper', async () => {
+      // Profile target IS populated (would normally short-circuit) —
+      // but `force: true` means the user has explicitly opted in to
+      // overwriting Profile with legacy data.
+      const profile = makeFakeProfileProviders({
+        loadResult: {
+          success: true,
+          data: {
+            _meta: { version: 1, address: '', formatVersion: '2.0', updatedAt: 0 },
+            _abc123: { genesis: { tokenId: 'abc123' } },
+            _outbox: [{ id: 'outbox-existing' }],
+          },
+        },
+      });
+      const createProfileProviders = vi.fn().mockReturnValue(profile);
+      const migrate = vi.fn().mockResolvedValue(baseMigrationResult);
+
+      const result = await runProfileMigration({
+        legacyProviders: makeFakeLegacyProviders(),
+        sphere: makeFakeSphere(),
+        network: 'testnet',
+        setInitProgress,
+        createProfileProviders: createProfileProviders as never,
+        migrate: migrate as never,
+        force: true,
+      });
+
+      // The Profile load() probe should NOT have been called when
+      // force:true (because we don't even check — we WANT to overwrite).
+      expect(profile.tokenStorage.load).not.toHaveBeenCalled();
+      // Helper IS called even though target has data
+      expect(migrate).toHaveBeenCalledOnce();
+      // `force: true` is forwarded to the SDK helper so its own marker
+      // check is bypassed.
+      const args = migrate.mock.calls[0][0];
+      expect(args.force).toBe(true);
+
+      expect(result).not.toBeNull();
+      expect(result!.skippedDueToMarker).toBe(false);
+      expect(result!.migrationCounts.tokensMigrated).toBe(5);
+    });
+
+    it('defaults to force: false (boot-time path) when the option is omitted', async () => {
+      const profile = makeFakeProfileProviders();
+      const createProfileProviders = vi.fn().mockReturnValue(profile);
+      const migrate = vi.fn().mockResolvedValue(baseMigrationResult);
+
+      await runProfileMigration({
+        legacyProviders: makeFakeLegacyProviders(),
+        sphere: makeFakeSphere(),
+        network: 'testnet',
+        setInitProgress,
+        createProfileProviders: createProfileProviders as never,
+        migrate: migrate as never,
+        // No `force` — default path
+      });
+
+      // Probe RAN (force:false means we check Profile target first).
+      expect(profile.tokenStorage.load).toHaveBeenCalled();
+      // And the SDK helper got `force: false`.
+      const args = migrate.mock.calls[0][0];
+      expect(args.force).toBe(false);
+    });
+  });
+
   it('forwards every onProgress phase as a syncing_tokens step', async () => {
     const profile = makeFakeProfileProviders();
     const createProfileProviders = vi.fn().mockReturnValue(profile);


### PR DESCRIPTION
## Summary

Adds user-facing controls to the UXF banner for inspecting + switching between **Legacy** (IndexedDB-per-address) and **UXF Profile** (OrbitDB-backed) token storage.

Today users have zero visibility or control: PR #307 wires legacy → Profile migration on first boot under `IS_UXF_BUILD=true`, but the operation is opaque, and the migration **copies rather than moves**, so legacy data persists silently. This PR surfaces mode + data presence to the user and gives them the controls to switch / merge.

## Banner state matrix

| Current mode    | Legacy data | Profile data | Buttons shown                                            |
|-----------------|-------------|--------------|----------------------------------------------------------|
| **Legacy**      | (any)       | none         | **Migrate to UXF Profile** (primary)                     |
| **Legacy**      | (any)       | exists       | **Switch to UXF Profile** + **Merge Legacy → UXF (overwrite)** |
| **UXF Profile** | exists      | (any)        | **Switch back to Legacy** + **Merge Legacy → UXF (overwrite)** |
| **UXF Profile** | none        | (any)        | (status text only — no action buttons)                   |

A small refresh-icon + dismiss-X are always present. While probes are pending the buttons are hidden and the status reads \"(checking stores…)\".

## Visual sketch

\`\`\`
┌────────────────────────────────────────────────────────────────────────┐
│ ▣ Wallet storage: Legacy                          [Migrate to UXF P.] ⟳ ✕ │   ← legacy / no profile data
└────────────────────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────────────────────┐
│ ▣ Wallet storage: Legacy           [Switch to UXF Profile] [Merge…] ⟳ ✕ │   ← legacy / profile data exists
└────────────────────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────────────────────┐
│ ▣ Wallet storage: UXF Profile (new)   [Switch back to Legacy] [Merge…] ⟳ ✕ │ ← profile / legacy still present
└────────────────────────────────────────────────────────────────────────┘

┌────────────────────────────────────────────────────────────────────────┐
│ ▣ Wallet storage: UXF Profile (new)                              ⟳ ✕ │   ← profile / no legacy data
└────────────────────────────────────────────────────────────────────────┘
\`\`\`

On mobile (<640px) the right cluster wraps under the status line; buttons stay full-width.

## Merge confirmation modal (verbatim copy)

Headline: **Merge Legacy → UXF (overwrite)?**

Body: **This will OVERWRITE your UXF Profile token data with your Legacy data. Tokens currently in Profile that aren't in Legacy will be lost. Continue?**

Buttons: **Yes, overwrite Profile** (destructive, red) / **Cancel** (outline)

A follow-up filed at unicity-sphere/sphere-sdk#290 requests \`migrateLegacyToProfile({ mode: 'union' })\` so we can eventually replace this with a non-destructive combine path and drop the data-loss warning entirely.

## Architecture / changes

- **`SphereContext`** gains `walletMode`, `hasLegacyData`, `hasProfileData`, `isSwitchingMode`, `switchWalletMode`, `runLegacyToProfileMigration`, `refreshDataProbes`.
- **Sticky preference**: `walletMode` persisted to `localStorage[\"sphere_wallet_mode_preference\"]` so reloads honor the user's choice. Default for IS_UXF_BUILD = profile; non-UXF builds = legacy.
- **`SphereProvider`** runs boot-time probes against BOTH stores via fresh legacy + Profile providers (identity-only) so the banner can render the correct buttons immediately. Probe writes guarded by a sequence counter that drops stale results across mode flips.
- **`runProfileMigration`** learns a `force: true` option that bypasses both the Profile-already-populated short-circuit AND the SDK marker. Powers the \"Merge (overwrite)\" path.
- **Profile-mode merge path**: when merging FROM profile mode, we open a fresh `IndexedDBTokenStorageProvider` as the migration source — otherwise the helper would copy Profile→Profile (no-op).
- **`hasMaterialContent`** extracted to `src/sdk/utils/tokenStorageProbe.ts` so the migration overwrite-guard and the banner data-presence probes use the same predicate (single source of truth).
- **Failure rollback**: on a hard switch-mode failure the persisted preference is restored to avoid a hot-loop of failing boots.

## Steelman attack list + resolutions

| # | Attack                                                                                          | Resolution                                                                                                                                                            |
|---|-------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1 | In-flight DM send during mode switch                                                            | `initialize()` awaits `sphere.destroy()` with default (non-force) options, which drains the outbox — pending writes land in the OLD store before the swap.            |
| 2 | User double-clicks Merge                                                                        | Two guards inline: `runWithGuard` (banner) checks `anyActionRunning`; `runLegacyToProfileMigration` (provider) checks `isSwitchingMode`. Second click ignored.        |
| 3 | Mode-switch fails inside `initialize()` (e.g. OrbitDB bring-up throws)                          | `switchWalletMode` catches + restores the previous `WALLET_MODE_PREFERENCE`, so the next reload doesn't re-attempt the failing mode in a loop.                        |
| 4 | Legacy probe succeeds but Profile probe fails (or vice versa)                                   | Each probe returns `false` on error rather than null. Banner reads false as \"no data\" — only enables Switch, not Merge. Merge path will surface its own error toast. |
| 5 | Cross-tab race (Tab A mid-migration, Tab B opens)                                                | Documented as deferred. We persist the preference BEFORE `initialize()` so Tab B sees the target mode. OrbitDB allows multi-process attach but a half-migrated Profile is a known transient. No data corruption (the SDK marker is stamped atomically after successful save). |
| 6 | Stale probe writes after a newer mode-switch starts                                              | `initSeqRef` sequence counter bumped on every `initialize()` / `runLegacyToProfileMigration` entry; probes discard writes if `seq !== initSeqRef.current`.            |
| 7 | Merge clicked from Profile mode: `providers.tokenStorage` IS Profile already                     | Detected via `walletMode === 'profile'` branch — fresh `IndexedDBTokenStorageProvider` constructed as the source; disconnected in `finally`. Profile→Profile no-op avoided. |
| 8 | Preference write succeeded but `initialize()` left wallet sphere-less                            | `error` state surfaced via existing `SphereContext.error`; user can reload or click the inverse button to recover. Preference rolled back on `throw`.                   |
| 9 | `extraLegacyTokenStorage` leak on partial `initialize()` failure                                | `try { disconnect() } catch {}` in both early-throw and finally paths.                                                                                                |
| 10 | `useEffect(initialize, [initialize])` self-trigger loop                                          | Replaced with `initializeRef.current()` pattern + `[network]` dep — the effect only fires on mount and network change, never on `walletMode` / `runProbes` flips.     |

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx eslint .` — clean
- [x] `npx vitest run` — **76 passed** (48 baseline + 28 new tests for the matrix, the `force:true` migration flag, and the shared probe util)
- [x] `npm run build` — clean, no Vite errors
- [ ] Manual smoke: start a wallet on legacy mode → banner shows \"Migrate\" → click → migration runs → banner flips to Profile mode + offers \"Switch back to Legacy\" + \"Merge\"
- [ ] Manual smoke: \"Merge\" opens confirmation modal → Cancel does nothing → Confirm + reload → still in Profile mode (sticky)
- [ ] Manual smoke: cross-mode probe (turn DevTools storage off for one DB) — banner gracefully degrades
- [ ] Manual smoke: mobile viewport (<640px) — buttons stack cleanly

## Deploy plan

GitHub Pages branch auto-deploys on push to `pages/staging` (separate flow). Docker container redeploy is gated on user sign-off — **NOT** triggered by this PR. The user reviews + then decides whether to redeploy the live container.

## Related

- Filed sphere-sdk follow-up: unicity-sphere/sphere-sdk#290 (additive union merge — replaces the destructive \"Merge (overwrite)\" once implemented)
- Builds on PR #307 (\`feat/uxf-mode-with-migration-20260527\` — first-boot migration plumbing)