### PR TITLE
fix(uxf): surface SDK migration errors instead of collapsed Array(2)

### DIFF
--- a/src/sdk/uxfProfileMigration.ts
+++ b/src/sdk/uxfProfileMigration.ts
@@ -282,9 +282,20 @@ export async function runProfileMigration(
     // for THIS session we keep the legacy providers active so the user
     // sees their full balance.
     if (!result.success) {
-      logger.error('SphereProvider', 'UXF migration failed; falling back to legacy mode', {
-        errors: result.errors,
-      });
+      // Serialize each error inline so the browser console doesn't collapse
+      // them to "Array(2)" — without this the operator has no idea which
+      // phase failed. The SDK reports `{phase, error}` entries.
+      const errorSummary = (result.errors ?? [])
+        .map((e, i) => `#${i + 1} [${e.phase}] ${e.error}`)
+        .join(' | ');
+      logger.error(
+        'SphereProvider',
+        `UXF migration failed; falling back to legacy mode — ${errorSummary || '(no error details from SDK)'}`,
+        {
+          errorCount: result.errors?.length ?? 0,
+          errors: result.errors,
+        },
+      );
       // Best-effort cleanup: disconnect the half-initialized Profile
       // providers the helper built so we don't leak handles.
       try { await result.profileProviders.tokenStorage.disconnect(); } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- User clicked **Migrate Legacy → UXF** after PR #309 (vendor-bump to sphere-sdk fdd8db6) deployed.
- The empty-hex `RangeError` is gone, but the migration still fails — and the browser console only shows `{errors: Array(2)}`, collapsing the actual `{phase, error}` entries.
- This patch formats each error inline in the `logger.error` message so the failing phase + message is visible at a glance.

## Behaviour change
- Old: `[SphereProvider] UXF migration failed; falling back to legacy mode {errors: Array(2)}`
- New: `[SphereProvider] UXF migration failed; falling back to legacy mode — #1 [check-marker] marker read failed: ... | #2 [target-save] ...`

## Test plan
- [x] `npm run build` succeeds (14s)
- [x] No type errors
- [ ] After deploy, user retries Migrate and reports the now-visible error strings so we can chase the root cause