### PR TITLE
feat(layout): service-status banner for aggregator/IPFS/Nostr/market

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import { Header } from './Header';
+import { ServiceStatusBanner } from './ServiceStatusBanner';
 import { UxfBanner } from '../uxf';
 import { IS_UXF_BUILD } from '../../config/uxf';
 import { MiniChatBubbles } from '../chat/mini';
@@ -80,6 +81,7 @@ export function DashboardLayout() {
       <div className="relative z-10 flex flex-col h-full">
         <CallProvider>
         {IS_UXF_BUILD && <UxfBanner />}
+        {!isFullscreen && <ServiceStatusBanner />}
         {!isFullscreen && <Header />}
         <div className={`flex-1 min-h-0 flex relative ${!isAgentPage ? 'overflow-y-auto overflow-x-hidden' : ''}`}>
           <div className={`flex-1 w-full ${

--- a/src/components/layout/ServiceStatusBanner.tsx
+++ b/src/components/layout/ServiceStatusBanner.tsx
@@ -122,6 +122,14 @@ export function ServiceStatusBanner() {
   // green "all services back" message, and neither must transitions
   // out of `'unknown'` into `'ok'` on a fresh wallet.
   const previousHadIncidentRef = useRef(false);
+  // Steelman: snapshot of the failing-services set captured at the
+  // moment the user clicked dismiss. The dismissal only "covers" a
+  // failing set that is a SUBSET of this snapshot — i.e., adding a new
+  // failing service (e.g., user dismissed aggregator-only, then IPFS
+  // also fails) voids the dismissal so the user sees the new info.
+  // Severity changes WITHIN the dismissed set (down ↔ degraded for a
+  // service that was already failing) do not void the dismissal.
+  const dismissedAtFailingRef = useRef<Set<string> | null>(null);
 
   const rows: ServiceRow[] = useMemo(
     () => [
@@ -163,34 +171,77 @@ export function ServiceStatusBanner() {
   const degradedCount = severities.filter((s) => s === 'degraded').length;
   const hasIncident = overall === 'down' || overall === 'degraded';
 
+  // Current set of failing service keys. Memoized so the deps below
+  // are stable references when the set hasn't changed (useMemo returns
+  // the same Set instance across renders for the same severity tuple).
+  const failingServices = useMemo(() => {
+    const result = new Set<string>();
+    for (const row of rows) {
+      const sev = severityOf(row.status);
+      if (sev === 'down' || sev === 'degraded') result.add(row.key);
+    }
+    return result;
+  }, [rows]);
+
+  // Dismissal still "covers" the current state iff every currently-
+  // failing service was ALREADY in the snapshot at dismiss time. Adding
+  // a new failing service voids the dismissal — that's a new fault the
+  // user has not seen yet. Severity downgrade (down→degraded) within
+  // the same set does NOT void.
+  const dismissalStillCovers = useMemo(() => {
+    if (!manuallyDismissed) return false;
+    const snapshot = dismissedAtFailingRef.current;
+    if (snapshot === null) return false;
+    for (const k of failingServices) {
+      if (!snapshot.has(k)) return false;
+    }
+    return true;
+  }, [manuallyDismissed, failingServices]);
+
   // Open the recovery-confirmation window only on the bad→ok edge.
   // The ref captures whether the PRIOR render observed a live incident
   // so an initial mount with everything-already-up (or first probes
   // landing as `'ok'`) does NOT show the green "all services back"
   // message — there was nothing to recover from.
+  //
+  // Steelman: do NOT reset `manuallyDismissed` in the active-incident
+  // branch. The old behaviour cleared dismissal on every effect re-run
+  // with hasIncident=true, which meant any severity change during an
+  // incident (e.g., down→degraded as one service starts to recover)
+  // re-asserted the banner the user had explicitly dismissed. The new
+  // model relies on `dismissalStillCovers` — the dismissal naturally
+  // becomes void when a NEW service joins the failing set.
   useEffect(() => {
     if (hasIncident) {
-      // While incident is live keep the recovery window logically closed —
-      // re-arms it for the next bad→ok edge.
       setRecoveryWindowOpen(false);
-      // Any active incident also resets a prior manual dismissal so the
-      // banner re-asserts itself.
-      setManuallyDismissed(false);
       previousHadIncidentRef.current = true;
       return;
     }
-    // No live incident. Did the previous render have one? If yes,
-    // this is the bad→ok edge — open the confirmation window.
-    const wasIncident = previousHadIncidentRef.current;
+    // No live incident. Did the previous render have one? If yes AND
+    // we've fully recovered (overall === 'ok'), open the confirmation
+    // window. The ref is consumed ONLY when we actually fire the
+    // confirmation; a bad→'unknown' transient (e.g., sphere swap
+    // momentarily resets connectivity) keeps the ref armed so the
+    // eventual unknown→ok transition still shows confirmation.
+    if (!previousHadIncidentRef.current) return; // dormant
+    if (overall !== 'ok') return; // bad→'unknown' — keep ref armed
     previousHadIncidentRef.current = false;
-    if (!wasIncident) return; // dormant — fresh mount with all-up, or 'unknown'
-    if (overall !== 'ok') return; // ignore bad→'unknown' transitions
+    // If the user dismissed during the incident, don't pop a green
+    // confirmation banner — they explicitly asked for quiet. Just
+    // silently clear the dismissal state so a future incident is fresh.
+    if (manuallyDismissed) {
+      setManuallyDismissed(false);
+      dismissedAtFailingRef.current = null;
+      return;
+    }
     setRecoveryWindowOpen(true);
-    const t = setTimeout(() => setRecoveryWindowOpen(false), RECOVERY_CONFIRMATION_MS);
+    const t = setTimeout(() => {
+      setRecoveryWindowOpen(false);
+    }, RECOVERY_CONFIRMATION_MS);
     return () => clearTimeout(t);
-  }, [hasIncident, overall]);
+  }, [hasIncident, overall, manuallyDismissed]);
 
-  const visible = !manuallyDismissed && (hasIncident || recoveryWindowOpen);
+  const visible = !dismissalStillCovers && (hasIncident || recoveryWindowOpen);
 
   // Theme tokens for the container chrome, indexed by overall severity.
   const chrome = (() => {
@@ -284,7 +335,12 @@ export function ServiceStatusBanner() {
 
               <button
                 type="button"
-                onClick={() => setManuallyDismissed(true)}
+                onClick={() => {
+                  // Snapshot the currently-failing set; dismissal will
+                  // be voided automatically if any NEW service joins.
+                  dismissedAtFailingRef.current = new Set(failingServices);
+                  setManuallyDismissed(true);
+                }}
                 className="p-1 rounded-md hover:bg-black/10 dark:hover:bg-white/10 transition-colors flex-shrink-0"
                 aria-label="Dismiss service status banner"
               >

--- a/src/components/layout/ServiceStatusBanner.tsx
+++ b/src/components/layout/ServiceStatusBanner.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertTriangle, CheckCircle2, Cloud, MessageCircle, TrendingUp, Wifi, X } from 'lucide-react';
+import { useConnectivity, type ConnectivityBackendStatus } from '../../sdk/hooks/core/useConnectivity';
+import { useMarketStatus, type MarketStatus } from '../../sdk/hooks/core/useMarketStatus';
+
+/**
+ * Time (ms) the banner stays visible after the last service recovers,
+ * so users see the green "all services back" confirmation before it
+ * collapses. Matches the user-facing decision in issue #319's UI ask.
+ */
+const RECOVERY_CONFIRMATION_MS = 10_000;
+
+type Severity = 'ok' | 'degraded' | 'down' | 'unknown';
+
+interface ServiceRow {
+  key: 'aggregator' | 'ipfs' | 'nostr' | 'market';
+  label: string;
+  shortLabel: string; // shown on mobile when space is tight
+  icon: typeof Cloud;
+  status: ConnectivityBackendStatus | MarketStatus;
+}
+
+function severityOf(status: ConnectivityBackendStatus | MarketStatus): Severity {
+  switch (status) {
+    case 'up':
+      return 'ok';
+    case 'degraded':
+      return 'degraded';
+    case 'down':
+      return 'down';
+    case 'unknown':
+    default:
+      return 'unknown';
+  }
+}
+
+function dotClassFor(severity: Severity): string {
+  switch (severity) {
+    case 'ok':
+      return 'bg-green-500 dark:bg-green-400';
+    case 'degraded':
+      return 'bg-amber-500 dark:bg-amber-400';
+    case 'down':
+      return 'bg-red-500 dark:bg-red-400';
+    case 'unknown':
+    default:
+      return 'bg-neutral-400 dark:bg-neutral-500';
+  }
+}
+
+function statusLabelFor(status: ConnectivityBackendStatus | MarketStatus): string {
+  switch (status) {
+    case 'up':
+      return 'OK';
+    case 'degraded':
+      return 'Degraded';
+    case 'down':
+      return 'Down';
+    case 'unknown':
+    default:
+      return 'Checking…';
+  }
+}
+
+/**
+ * Aggregate the four severities into a single banner-level severity for
+ * the headline + container chrome. Worst-of-all (down > degraded > ok),
+ * with 'unknown' ignored so the banner doesn't shout while probes are
+ * still in flight.
+ */
+function rollupSeverity(severities: Severity[]): Severity {
+  if (severities.includes('down')) return 'down';
+  if (severities.includes('degraded')) return 'degraded';
+  if (severities.every((s) => s === 'unknown')) return 'unknown';
+  return 'ok';
+}
+
+function headlineFor(severity: Severity, downCount: number, degradedCount: number): string {
+  if (severity === 'down') {
+    const noun = downCount === 1 ? 'service is' : 'services are';
+    return `${downCount} ${noun} unreachable`;
+  }
+  if (severity === 'degraded') {
+    const noun = degradedCount === 1 ? 'service is' : 'services are';
+    return `${degradedCount} ${noun} degraded`;
+  }
+  if (severity === 'ok') {
+    return 'All services back online';
+  }
+  return 'Checking service status…';
+}
+
+/**
+ * Service-status banner.
+ *
+ * Behaviour (matches the chosen UX path in issue #319 follow-up):
+ *
+ *   - Hidden while every backend is `'up'` AND we are outside the
+ *     post-recovery confirmation window.
+ *   - Becomes visible the moment any backend transitions to `'down'`
+ *     or `'degraded'`.
+ *   - Stays visible for {@link RECOVERY_CONFIRMATION_MS} ms after the
+ *     last service comes back up (shows a green "all services back"
+ *     message), then collapses.
+ *   - User can dismiss manually via the X button — re-appears
+ *     immediately if any service goes down again.
+ *
+ * Responsive layout:
+ *   - Mobile: vertical stack (headline row + pills below), pills show
+ *     icons + short label so all four fit on a narrow screen.
+ *   - Desktop: horizontal row (headline at left, pills at right).
+ */
+export function ServiceStatusBanner() {
+  const connectivity = useConnectivity();
+  const market = useMarketStatus();
+  const [manuallyDismissed, setManuallyDismissed] = useState(false);
+  const [recoveryWindowOpen, setRecoveryWindowOpen] = useState(false);
+  // Tracks whether the PREVIOUS render had a live incident. Only the
+  // bad→ok transition opens the recovery-confirmation window — an
+  // initial mount with everything already up must NOT trigger the
+  // green "all services back" message, and neither must transitions
+  // out of `'unknown'` into `'ok'` on a fresh wallet.
+  const previousHadIncidentRef = useRef(false);
+
+  const rows: ServiceRow[] = useMemo(
+    () => [
+      {
+        key: 'aggregator',
+        label: 'Aggregator',
+        shortLabel: 'Agg',
+        icon: Cloud,
+        status: connectivity.aggregator,
+      },
+      {
+        key: 'ipfs',
+        label: 'IPFS',
+        shortLabel: 'IPFS',
+        icon: Cloud,
+        status: connectivity.ipfs,
+      },
+      {
+        key: 'nostr',
+        label: 'Nostr',
+        shortLabel: 'Nostr',
+        icon: MessageCircle,
+        status: connectivity.nostr,
+      },
+      {
+        key: 'market',
+        label: 'Market',
+        shortLabel: 'Market',
+        icon: TrendingUp,
+        status: market,
+      },
+    ],
+    [connectivity.aggregator, connectivity.ipfs, connectivity.nostr, market],
+  );
+
+  const severities = rows.map((r) => severityOf(r.status));
+  const overall = rollupSeverity(severities);
+  const downCount = severities.filter((s) => s === 'down').length;
+  const degradedCount = severities.filter((s) => s === 'degraded').length;
+  const hasIncident = overall === 'down' || overall === 'degraded';
+
+  // Open the recovery-confirmation window only on the bad→ok edge.
+  // The ref captures whether the PRIOR render observed a live incident
+  // so an initial mount with everything-already-up (or first probes
+  // landing as `'ok'`) does NOT show the green "all services back"
+  // message — there was nothing to recover from.
+  useEffect(() => {
+    if (hasIncident) {
+      // While incident is live keep the recovery window logically closed —
+      // re-arms it for the next bad→ok edge.
+      setRecoveryWindowOpen(false);
+      // Any active incident also resets a prior manual dismissal so the
+      // banner re-asserts itself.
+      setManuallyDismissed(false);
+      previousHadIncidentRef.current = true;
+      return;
+    }
+    // No live incident. Did the previous render have one? If yes,
+    // this is the bad→ok edge — open the confirmation window.
+    const wasIncident = previousHadIncidentRef.current;
+    previousHadIncidentRef.current = false;
+    if (!wasIncident) return; // dormant — fresh mount with all-up, or 'unknown'
+    if (overall !== 'ok') return; // ignore bad→'unknown' transitions
+    setRecoveryWindowOpen(true);
+    const t = setTimeout(() => setRecoveryWindowOpen(false), RECOVERY_CONFIRMATION_MS);
+    return () => clearTimeout(t);
+  }, [hasIncident, overall]);
+
+  const visible = !manuallyDismissed && (hasIncident || recoveryWindowOpen);
+
+  // Theme tokens for the container chrome, indexed by overall severity.
+  const chrome = (() => {
+    switch (overall) {
+      case 'down':
+        return {
+          bg: 'rgba(239, 68, 68, 0.10)',
+          border: 'rgba(239, 68, 68, 0.40)',
+          fg: '#dc2626',
+          Icon: AlertTriangle,
+        };
+      case 'degraded':
+        return {
+          bg: 'rgba(245, 158, 11, 0.10)',
+          border: 'rgba(245, 158, 11, 0.40)',
+          fg: '#d97706',
+          Icon: AlertTriangle,
+        };
+      case 'ok':
+        return {
+          bg: 'rgba(34, 197, 94, 0.10)',
+          border: 'rgba(34, 197, 94, 0.40)',
+          fg: '#16a34a',
+          Icon: CheckCircle2,
+        };
+      case 'unknown':
+      default:
+        return {
+          bg: 'rgba(115, 115, 115, 0.10)',
+          border: 'rgba(115, 115, 115, 0.30)',
+          fg: '#525252',
+          Icon: Wifi,
+        };
+    }
+  })();
+
+  return (
+    <AnimatePresence initial={false}>
+      {visible && (
+        <motion.div
+          key="service-status-banner"
+          role="status"
+          aria-live="polite"
+          aria-label="Service status"
+          initial={{ height: 0, opacity: 0 }}
+          animate={{ height: 'auto', opacity: 1 }}
+          exit={{ height: 0, opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          className="overflow-hidden"
+          style={{
+            background: chrome.bg,
+            borderBottom: `1px solid ${chrome.border}`,
+            color: chrome.fg,
+          }}
+        >
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 px-3 sm:px-4 py-2 text-xs font-medium">
+            {/* Headline */}
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <chrome.Icon className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+              <span className="truncate font-semibold">
+                {headlineFor(overall, downCount, degradedCount)}
+              </span>
+            </div>
+
+            {/* Pills row — flex-wraps to a 2x2 grid on narrow phones */}
+            <div className="flex items-center gap-1.5 flex-wrap justify-end">
+              {rows.map((row) => {
+                const sev = severityOf(row.status);
+                return (
+                  <div
+                    key={row.key}
+                    className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] whitespace-nowrap"
+                    style={{
+                      background:
+                        'color-mix(in srgb, currentColor 8%, transparent)',
+                    }}
+                    title={`${row.label}: ${statusLabelFor(row.status)}`}
+                    aria-label={`${row.label}: ${statusLabelFor(row.status)}`}
+                  >
+                    <span
+                      className={`w-2 h-2 rounded-full flex-shrink-0 ${dotClassFor(sev)}`}
+                      aria-hidden="true"
+                    />
+                    <row.icon className="w-3 h-3 hidden sm:inline-block" aria-hidden="true" />
+                    {/* Full label on >=sm, short label on mobile */}
+                    <span className="hidden sm:inline">{row.label}</span>
+                    <span className="sm:hidden">{row.shortLabel}</span>
+                  </div>
+                );
+              })}
+
+              <button
+                type="button"
+                onClick={() => setManuallyDismissed(true)}
+                className="p-1 rounded-md hover:bg-black/10 dark:hover:bg-white/10 transition-colors flex-shrink-0"
+                aria-label="Dismiss service status banner"
+              >
+                <X className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/sdk/hooks/core/useConnectivity.ts
+++ b/src/sdk/hooks/core/useConnectivity.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { useSphereContext } from './useSphere';
+
+/**
+ * Backend reachability state, mirroring the SDK's ConnectivityBackendStatus.
+ * `'unknown'` is the initial state before the first probe lands.
+ */
+export type ConnectivityBackendStatus = 'up' | 'down' | 'degraded' | 'unknown';
+
+/**
+ * Snapshot of the SDK's `sphere.connectivity.status()` for the three
+ * backends the SDK pings (issue #312): aggregator, IPFS, Nostr.
+ *
+ * `lastOnlineAt`  — ms-epoch of the most recent moment all three were `'up'`
+ * `lastChangedAt` — ms-epoch of the most recent backend transition
+ */
+export interface UseConnectivityReturn {
+  aggregator: ConnectivityBackendStatus;
+  ipfs: ConnectivityBackendStatus;
+  nostr: ConnectivityBackendStatus;
+  lastOnlineAt: number | null;
+  lastChangedAt: number;
+}
+
+const INITIAL: UseConnectivityReturn = {
+  aggregator: 'unknown',
+  ipfs: 'unknown',
+  nostr: 'unknown',
+  lastOnlineAt: null,
+  lastChangedAt: 0,
+};
+
+/**
+ * Hook that exposes the SDK's `sphere.connectivity` snapshot as reactive
+ * React state. Resubscribes when the Sphere instance changes (e.g. on
+ * wallet load / switch).
+ *
+ * The status is read synchronously on mount via `sphere.connectivity.status()`
+ * so the very first render reflects the latest known value (not always
+ * `'unknown'`) when the wallet has been alive for a while.
+ */
+export function useConnectivity(): UseConnectivityReturn {
+  const { sphere } = useSphereContext();
+  const [state, setState] = useState<UseConnectivityReturn>(INITIAL);
+
+  useEffect(() => {
+    if (!sphere) {
+      setState(INITIAL);
+      return;
+    }
+
+    // Capture current snapshot synchronously — avoids a flicker through
+    // 'unknown' when the wallet has been online for a while before this
+    // component mounted.
+    try {
+      const snapshot = sphere.connectivity.status();
+      setState({
+        aggregator: snapshot.aggregator,
+        ipfs: snapshot.ipfs,
+        nostr: snapshot.nostr,
+        lastOnlineAt: snapshot.lastOnlineAt,
+        lastChangedAt: snapshot.lastChangedAt,
+      });
+    } catch {
+      // sphere.connectivity may not be wired when the wallet is in the
+      // legacy / no-oracle configuration. Leave the INITIAL state.
+    }
+
+    const unsubscribe = sphere.connectivity.subscribe((snapshot) => {
+      setState({
+        aggregator: snapshot.aggregator,
+        ipfs: snapshot.ipfs,
+        nostr: snapshot.nostr,
+        lastOnlineAt: snapshot.lastOnlineAt,
+        lastChangedAt: snapshot.lastChangedAt,
+      });
+    });
+
+    return unsubscribe;
+  }, [sphere]);
+
+  return state;
+}

--- a/src/sdk/hooks/core/useMarketStatus.ts
+++ b/src/sdk/hooks/core/useMarketStatus.ts
@@ -44,14 +44,45 @@ export function useMarketStatus(): MarketStatus {
         PROBE_TIMEOUT_MS,
       );
 
-      let nextStatus: MarketStatus = 'down';
+      // 'preserve' is an internal signal that the public `status`
+      // should NOT change for this round (used for 429 rate-limit:
+      // the API is reachable, we just hit a quota cap — flipping to
+      // 'down' would be misleading).
+      let nextStatus: MarketStatus | 'preserve' = 'down';
       try {
         const res = await fetch(COINGECKO_PING_URL, {
           method: 'GET',
           signal: inflightController.signal,
-          // CoinGecko CORS is permissive; no special headers needed.
+          // Send no cookies / referrer — this is an unauthenticated
+          // public ping and the wallet origin is not relevant to it.
+          credentials: 'omit',
+          referrerPolicy: 'no-referrer',
         });
-        nextStatus = res.ok ? 'up' : 'down';
+        if (res.status === 429) {
+          // Rate-limited. The API is reachable; we just hit a quota.
+          // Preserve current status to avoid flapping to 'down' on
+          // every quota hit during shared-IP / multi-tab scenarios.
+          // The backoff still advances so we don't keep hammering.
+          nextStatus = 'preserve';
+        } else if (res.ok) {
+          // Steelman: HTTP 200 is not enough — captive portals and
+          // corporate proxies return 200 with an HTML login page.
+          // The real /ping response is JSON with a `gecko_says` string.
+          // Validate the body shape to defend against false-positive 'up'.
+          try {
+            const body = await res.json();
+            const looksValid =
+              body !== null &&
+              typeof body === 'object' &&
+              typeof (body as { gecko_says?: unknown }).gecko_says === 'string';
+            nextStatus = looksValid ? 'up' : 'down';
+          } catch {
+            // Body wasn't JSON (e.g. captive portal HTML).
+            nextStatus = 'down';
+          }
+        } else {
+          nextStatus = 'down';
+        }
       } catch {
         // Network error, abort, CORS — all treated as 'down'.
         nextStatus = 'down';
@@ -61,15 +92,24 @@ export function useMarketStatus(): MarketStatus {
 
       if (cancelled) return;
 
-      setStatus(nextStatus);
+      if (nextStatus !== 'preserve') {
+        setStatus(nextStatus);
+      }
 
-      // Reset backoff on success, advance on failure.
+      // Reset backoff on success, advance on failure (and on 'preserve'
+      // — a 429 should slow us down without flipping the status).
       stepRef.current =
         nextStatus === 'up'
           ? 0
           : Math.min(stepRef.current + 1, BACKOFF_SCHEDULE_MS.length - 1);
 
       const delay = BACKOFF_SCHEDULE_MS[stepRef.current];
+      // Defensive re-check before scheduling. Cleanup runs
+      // synchronously and JS is single-threaded, so an interleaved
+      // cleanup between the previous check and here is not generally
+      // observable, but the defensive guard documents intent and
+      // closes any future-refactor leak.
+      if (cancelled) return;
       timer = setTimeout(probe, delay);
     };
 

--- a/src/sdk/hooks/core/useMarketStatus.ts
+++ b/src/sdk/hooks/core/useMarketStatus.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState, useRef } from 'react';
+
+/**
+ * Market-data backend status (CoinGecko).
+ *
+ * The SDK's `sphere.connectivity` surface does not include CoinGecko in
+ * its probe set (issue #312 explicitly scopes to aggregator / IPFS /
+ * Nostr). This hook polls CoinGecko's free `/ping` endpoint directly so
+ * the service-status banner can show market alongside the other three.
+ */
+export type MarketStatus = 'up' | 'down' | 'unknown';
+
+const COINGECKO_PING_URL = 'https://api.coingecko.com/api/v3/ping';
+
+// Backoff: same schedule as the SDK's connectivity manager — 5s → 15s → 60s → 5m.
+// On success the schedule resets to step 0.
+const BACKOFF_SCHEDULE_MS = [5_000, 15_000, 60_000, 300_000] as const;
+
+// Per-probe timeout. Probes that exceed this resolve as 'down'.
+const PROBE_TIMEOUT_MS = 8_000;
+
+/**
+ * Hook that probes CoinGecko on a backoff schedule and exposes the
+ * current up/down/unknown status. The first probe is `'unknown'`
+ * until it settles.
+ *
+ * On unmount the pending probe is aborted and any pending timer is
+ * cleared — no work continues after the component is gone.
+ */
+export function useMarketStatus(): MarketStatus {
+  const [status, setStatus] = useState<MarketStatus>('unknown');
+  const stepRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let inflightController: AbortController | null = null;
+
+    const probe = async () => {
+      if (cancelled) return;
+      inflightController = new AbortController();
+      const timeoutTimer = setTimeout(
+        () => inflightController?.abort(),
+        PROBE_TIMEOUT_MS,
+      );
+
+      let nextStatus: MarketStatus = 'down';
+      try {
+        const res = await fetch(COINGECKO_PING_URL, {
+          method: 'GET',
+          signal: inflightController.signal,
+          // CoinGecko CORS is permissive; no special headers needed.
+        });
+        nextStatus = res.ok ? 'up' : 'down';
+      } catch {
+        // Network error, abort, CORS — all treated as 'down'.
+        nextStatus = 'down';
+      } finally {
+        clearTimeout(timeoutTimer);
+      }
+
+      if (cancelled) return;
+
+      setStatus(nextStatus);
+
+      // Reset backoff on success, advance on failure.
+      stepRef.current =
+        nextStatus === 'up'
+          ? 0
+          : Math.min(stepRef.current + 1, BACKOFF_SCHEDULE_MS.length - 1);
+
+      const delay = BACKOFF_SCHEDULE_MS[stepRef.current];
+      timer = setTimeout(probe, delay);
+    };
+
+    // Kick off the first probe asynchronously so the initial render
+    // doesn't fire the request synchronously.
+    timer = setTimeout(probe, 0);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (inflightController) inflightController.abort();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -9,6 +9,13 @@ export type { UseNametagReturn } from './core/useNametag';
 export { useSphereEvents } from './core/useSphereEvents';
 export { useIpfsSync } from './core/useIpfsSync';
 export type { IpfsSyncStatus, IpfsSyncState, UseIpfsSyncReturn } from './core/useIpfsSync';
+export { useConnectivity } from './core/useConnectivity';
+export type {
+  ConnectivityBackendStatus,
+  UseConnectivityReturn,
+} from './core/useConnectivity';
+export { useMarketStatus } from './core/useMarketStatus';
+export type { MarketStatus } from './core/useMarketStatus';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/tests/unit/components/ServiceStatusBanner.test.tsx
+++ b/tests/unit/components/ServiceStatusBanner.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * ServiceStatusBanner — visibility + headline behavior tests.
+ *
+ * The banner shows when any backend (aggregator, IPFS, Nostr, market)
+ * is `'down'` or `'degraded'` and stays visible for 10s after the last
+ * service recovers (the post-recovery confirmation window). A user
+ * dismiss collapses it immediately; a fresh incident clears the
+ * dismissal and re-asserts the banner.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { createElement, type ReactNode, type HTMLAttributes } from 'react';
+
+// Bypass framer-motion's enter/exit animations in tests so DOM
+// presence / absence tracks visibility directly (no animation lingering
+// the element in DOM after state goes to "hidden"). The banner's UX
+// chrome is still exercised via the production component in dev; what
+// we want to test here is the visibility state machine.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_target, tag: string) =>
+        ({ children, ...props }: HTMLAttributes<HTMLElement> & { children?: ReactNode }) =>
+          createElement(tag, props as Record<string, unknown>, children),
+    },
+  ),
+  AnimatePresence: ({ children }: { children?: ReactNode }) => children as JSX.Element,
+}));
+
+import { ServiceStatusBanner } from '../../../src/components/layout/ServiceStatusBanner';
+import type { UseConnectivityReturn } from '../../../src/sdk/hooks/core/useConnectivity';
+import type { MarketStatus } from '../../../src/sdk/hooks/core/useMarketStatus';
+
+// Mock the two hooks the banner consumes so each test can drive the
+// status independently of the SDK/CoinGecko probes.
+const connectivityMock = vi.fn<() => UseConnectivityReturn>();
+const marketMock = vi.fn<() => MarketStatus>();
+
+vi.mock('../../../src/sdk/hooks/core/useConnectivity', () => ({
+  useConnectivity: () => connectivityMock(),
+}));
+vi.mock('../../../src/sdk/hooks/core/useMarketStatus', () => ({
+  useMarketStatus: () => marketMock(),
+}));
+
+function allUp(): UseConnectivityReturn {
+  return {
+    aggregator: 'up',
+    ipfs: 'up',
+    nostr: 'up',
+    lastOnlineAt: Date.now(),
+    lastChangedAt: Date.now(),
+  };
+}
+
+function withOverrides(
+  base: UseConnectivityReturn,
+  overrides: Partial<UseConnectivityReturn>,
+): UseConnectivityReturn {
+  return { ...base, ...overrides };
+}
+
+beforeEach(() => {
+  connectivityMock.mockReset();
+  marketMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('ServiceStatusBanner — visibility gate', () => {
+  it('hides when all four services are up', () => {
+    connectivityMock.mockReturnValue(allUp());
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('hides when status is still unknown (probes haven\'t landed)', () => {
+    connectivityMock.mockReturnValue({
+      aggregator: 'unknown',
+      ipfs: 'unknown',
+      nostr: 'unknown',
+      lastOnlineAt: null,
+      lastChangedAt: 0,
+    });
+    marketMock.mockReturnValue('unknown');
+    render(<ServiceStatusBanner />);
+    // Banner stays dormant while everything is 'unknown' — surfaces
+    // would otherwise scream on every fresh wallet load.
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('shows when aggregator is down (issue #319 repro scenario)', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByRole('status')).toBeDefined();
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+  });
+
+  it('shows when IPFS is down', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { ipfs: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+  });
+
+  it('shows when Nostr is down', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { nostr: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+  });
+
+  it('shows when market is down (CoinGecko unreachable)', () => {
+    connectivityMock.mockReturnValue(allUp());
+    marketMock.mockReturnValue('down');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+  });
+
+  it('counts multiple down services in the headline', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down', ipfs: 'down' }),
+    );
+    marketMock.mockReturnValue('down');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByText(/3 services are unreachable/)).toBeDefined();
+  });
+
+  it('distinguishes degraded from down in the headline', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'degraded' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByText(/1 service is degraded/)).toBeDefined();
+  });
+
+  it('headline reflects worst severity (down beats degraded)', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down', ipfs: 'degraded' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+    expect(screen.queryByText(/degraded/)).toBeNull();
+  });
+});
+
+describe('ServiceStatusBanner — pills and labels', () => {
+  it('renders one pill per backend with the right aria-label', () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down', ipfs: 'degraded' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+
+    expect(screen.getByLabelText('Aggregator: Down')).toBeDefined();
+    expect(screen.getByLabelText('IPFS: Degraded')).toBeDefined();
+    expect(screen.getByLabelText('Nostr: OK')).toBeDefined();
+    expect(screen.getByLabelText('Market: OK')).toBeDefined();
+  });
+});
+
+describe('ServiceStatusBanner — recovery-confirmation window', () => {
+  it('stays visible after recovery and collapses after 10s', async () => {
+    vi.useFakeTimers();
+    // Start with an incident.
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    const { rerender } = render(<ServiceStatusBanner />);
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+
+    // Recovery: all services back up. The useEffect that opens the
+    // confirmation window runs after rerender; wrap in async act so
+    // pending state from the effect flushes.
+    connectivityMock.mockReturnValue(allUp());
+    marketMock.mockReturnValue('up');
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    expect(screen.getByText(/All services back online/)).toBeDefined();
+
+    // 9s later — still visible.
+    await act(async () => {
+      vi.advanceTimersByTime(9_000);
+    });
+    expect(screen.queryByText(/All services back online/)).not.toBeNull();
+
+    // Past 10s — timer fires, setState(recoveryWindowOpen=false),
+    // banner collapses. Async act flushes the state update from the
+    // setTimeout callback.
+    await act(async () => {
+      vi.advanceTimersByTime(2_000);
+    });
+    // Headline is gone — banner returned null (AnimatePresence exit
+    // started; with fake timers the exit animation also ran).
+    expect(screen.queryByText(/All services back online/)).toBeNull();
+  });
+
+  it('re-asserts itself if a new incident hits during the confirmation window', async () => {
+    vi.useFakeTimers();
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    const { rerender } = render(<ServiceStatusBanner />);
+
+    // Recover.
+    connectivityMock.mockReturnValue(allUp());
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    expect(screen.getByText(/All services back online/)).toBeDefined();
+
+    // Mid-window, a NEW incident hits. Headline must flip back to the
+    // incident headline; we're not stuck in a green "all back" message.
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { nostr: 'down' }),
+    );
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+    expect(screen.queryByText(/All services back online/)).toBeNull();
+  });
+});
+
+describe('ServiceStatusBanner — manual dismissal', () => {
+  it('collapses on click of the dismiss button', async () => {
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    render(<ServiceStatusBanner />);
+    expect(screen.getByRole('status')).toBeDefined();
+
+    const dismissBtn = screen.getByRole('button', {
+      name: 'Dismiss service status banner',
+    });
+    await act(async () => {
+      fireEvent.click(dismissBtn);
+    });
+    // Headline gone (banner collapsed to null via AnimatePresence).
+    expect(screen.queryByText(/1 service is unreachable/)).toBeNull();
+  });
+
+  it('re-asserts the banner when a fresh bad→ok→bad cycle hits after dismissal', async () => {
+    // Dismissal is sticky for the CURRENT incident — the user told
+    // us they don't want to see it. But once everything recovers and
+    // a new fault appears, the banner re-asserts because that is a
+    // fundamentally new incident the user has not seen yet.
+    vi.useFakeTimers();
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    const { rerender } = render(<ServiceStatusBanner />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Dismiss service status banner' }),
+      );
+    });
+    expect(screen.queryByText(/1 service is unreachable/)).toBeNull();
+
+    // Recovery — full ok state. The post-recovery 10s window stays
+    // hidden because the user dismissed; no green confirmation needed.
+    connectivityMock.mockReturnValue(allUp());
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+
+    // Drain the recovery confirmation window so we're back in the
+    // dormant all-ok state with no banner active.
+    await act(async () => {
+      vi.advanceTimersByTime(11_000);
+    });
+
+    // A NEW incident arrives. Banner re-asserts because the bad→ok→bad
+    // transition resets the dismissal (the previous fault is over).
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { ipfs: 'down' }),
+    );
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    expect(screen.getByText(/1 service is unreachable/)).toBeDefined();
+  });
+});

--- a/tests/unit/components/ServiceStatusBanner.test.tsx
+++ b/tests/unit/components/ServiceStatusBanner.test.tsx
@@ -259,6 +259,95 @@ describe('ServiceStatusBanner — manual dismissal', () => {
     expect(screen.queryByText(/1 service is unreachable/)).toBeNull();
   });
 
+  it('re-asserts the banner when a SECOND service fails during a dismissed incident', async () => {
+    // Steelman finding: previously the effect deps were too narrow
+    // ([hasIncident, overall]), so a second backend going down while
+    // the user had already dismissed an aggregator-only incident did
+    // NOT re-show the banner — the user missed the new fault entirely.
+    // With the failing-set snapshot model, the dismissal is voided
+    // automatically when a new service joins the failing set.
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    const { rerender } = render(<ServiceStatusBanner />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Dismiss service status banner' }),
+      );
+    });
+    expect(screen.queryByText(/1 service is unreachable/)).toBeNull();
+
+    // IPFS ALSO goes down — same incident period, but a new fault.
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down', ipfs: 'down' }),
+    );
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    // Banner re-asserts with the new headline.
+    expect(screen.getByText(/2 services are unreachable/)).toBeDefined();
+  });
+
+  it('keeps the banner dismissed when severity changes WITHIN the dismissed set (down→degraded)', async () => {
+    // Steelman finding: previously the effect's hasIncident=true branch
+    // unconditionally called setManuallyDismissed(false) on every
+    // re-run, so a severity change (down → degraded for a service that
+    // was ALREADY failing and dismissed) re-asserted the banner — even
+    // though the situation actually improved. Now the dismissal sticks
+    // because the failing-set is unchanged (only severity moved).
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    const { rerender } = render(<ServiceStatusBanner />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Dismiss service status banner' }),
+      );
+    });
+    expect(screen.queryByText(/unreachable/)).toBeNull();
+
+    // Aggregator improves down→degraded. Same service, less severe.
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'degraded' }),
+    );
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    // Banner STAYS dismissed — no new information for the user.
+    expect(screen.queryByText(/unreachable/)).toBeNull();
+    expect(screen.queryByText(/degraded/)).toBeNull();
+  });
+
+  it('does NOT pop the green recovery confirmation when the user had dismissed the incident', async () => {
+    // Steelman: the user explicitly said "be quiet" by dismissing the
+    // warning banner. Popping a green "all services back" message a
+    // few seconds later is just as intrusive — they don't want it.
+    vi.useFakeTimers();
+    connectivityMock.mockReturnValue(
+      withOverrides(allUp(), { aggregator: 'down' }),
+    );
+    marketMock.mockReturnValue('up');
+    const { rerender } = render(<ServiceStatusBanner />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Dismiss service status banner' }),
+      );
+    });
+
+    // Full recovery.
+    connectivityMock.mockReturnValue(allUp());
+    await act(async () => {
+      rerender(<ServiceStatusBanner />);
+    });
+    // No green confirmation — the user was already informed and dismissed.
+    expect(screen.queryByText(/All services back online/)).toBeNull();
+  });
+
   it('re-asserts the banner when a fresh bad→ok→bad cycle hits after dismissal', async () => {
     // Dismissal is sticky for the CURRENT incident — the user told
     // us they don't want to see it. But once everything recovers and


### PR DESCRIPTION
Companion UI for [sphere-sdk#319](https://github.com/unicity-sphere/sphere-sdk/issues/319): users should know explicitly when a backend is degraded or down, rather than guessing why operations are slow or failing.

## Summary

- Full-width banner above the Header, responsive for desktop and mobile.
- Tracks all four backends the user asked about: aggregator, IPFS, Nostr, and market.
- Hidden when everything is up; appears the moment any service is down/degraded; stays visible for 10s after the last service recovers (green \"all services back online\" confirmation), then collapses.
- Manual dismiss button collapses immediately. Dismissal is sticky for the CURRENT incident but resets on a fresh bad→ok→bad cycle so users see new faults.

## Changes

- `src/sdk/hooks/core/useConnectivity.ts` — reactive wrapper around `sphere.connectivity` (sphere-sdk issue #312), exposing aggregator/IPFS/Nostr status with synchronous snapshot on mount to avoid a flicker through `'unknown'`.
- `src/sdk/hooks/core/useMarketStatus.ts` — direct CoinGecko `/ping` probe on the same backoff schedule as the SDK's connectivity manager (5s → 15s → 60s → 5m). The SDK's connectivity surface does not include CoinGecko, so we ping it ourselves.
- `src/components/layout/ServiceStatusBanner.tsx` — the banner component. Color-codes severity (red=down, amber=degraded, green=ok, neutral=unknown), renders one pill per service with icon + label (label hidden on narrow mobile, short label shown). `role=\"status\"` + `aria-live=\"polite\"` so screen readers announce transitions.
- `src/sdk/hooks/index.ts` — exports the new hooks.
- `src/components/layout/DashboardLayout.tsx` — mounts the banner above the Header in the same slot as `UxfBanner`.

## Visibility state machine

|                           | Banner |
|---------------------------|:------:|
| All up, fresh mount       |   ✗    |
| Any down/degraded         |   ✓    |
| All up, within 10s of recovery |  ✓ (green)  |
| All up, >10s after recovery    |  ✗    |
| User dismissed             |   ✗    |
| User dismissed, then bad→ok→bad | ✓ (re-asserts) |

## Test plan

- [x] Unit tests: 14 cases covering visibility gate (all four backends individually), headline counting/severity worst-of-all, pill aria-labels, recovery confirmation window timing, dismiss behavior, and dismiss + recovery + new-incident cycle.
- [x] Existing tests: all 74 tests pass; lint + tsc clean.
- [ ] Manual: run \`npm run dev\`, observe the banner with the dev tools network panel disabling CoinGecko / blocking the aggregator host.

## PR base note

Targeting `feat/telco-webrtc-calls` because that is the active development branch where recent vendor bumps land. The banner is self-contained (new files plus a 2-line edit to `DashboardLayout.tsx`) so it can be cherry-picked elsewhere if a different merge target is preferred.