### PR TITLE
fix(layout): direct IPFS gateway probe (bypass SDK IpfsPinger)

### DIFF
--- a/src/components/layout/ServiceStatusBanner.tsx
+++ b/src/components/layout/ServiceStatusBanner.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { AlertTriangle, CheckCircle2, Cloud, MessageCircle, TrendingUp, Wifi, X } from 'lucide-react';
 import { useConnectivity, type ConnectivityBackendStatus } from '../../sdk/hooks/core/useConnectivity';
 import { useMarketStatus, type MarketStatus } from '../../sdk/hooks/core/useMarketStatus';
+import { useIpfsGatewayStatus, type IpfsGatewayStatus } from '../../sdk/hooks/core/useIpfsGatewayStatus';
 
 /**
  * Time (ms) the banner stays visible after the last service recovers,
@@ -18,10 +19,12 @@ interface ServiceRow {
   label: string;
   shortLabel: string; // shown on mobile when space is tight
   icon: typeof Cloud;
-  status: ConnectivityBackendStatus | MarketStatus;
+  status: ConnectivityBackendStatus | MarketStatus | IpfsGatewayStatus;
 }
 
-function severityOf(status: ConnectivityBackendStatus | MarketStatus): Severity {
+function severityOf(
+  status: ConnectivityBackendStatus | MarketStatus | IpfsGatewayStatus,
+): Severity {
   switch (status) {
     case 'up':
       return 'ok';
@@ -49,7 +52,9 @@ function dotClassFor(severity: Severity): string {
   }
 }
 
-function statusLabelFor(status: ConnectivityBackendStatus | MarketStatus): string {
+function statusLabelFor(
+  status: ConnectivityBackendStatus | MarketStatus | IpfsGatewayStatus,
+): string {
   switch (status) {
     case 'up':
       return 'OK';
@@ -114,6 +119,12 @@ function headlineFor(severity: Severity, downCount: number, degradedCount: numbe
 export function ServiceStatusBanner() {
   const connectivity = useConnectivity();
   const market = useMarketStatus();
+  // Production-observed: the SDK's `IpfsPinger` reports `'down'` even
+  // when the data path (`[IPFS-HTTP] Fetched`, `[IPNS-WS] connected`)
+  // is clearly functional. We bypass `connectivity.ipfs` and use a
+  // direct same-CID probe to the canonical Unicity IPFS gateway —
+  // matching the truth users actually experience.
+  const ipfsGateway = useIpfsGatewayStatus();
   const [manuallyDismissed, setManuallyDismissed] = useState(false);
   const [recoveryWindowOpen, setRecoveryWindowOpen] = useState(false);
   // Tracks whether the PREVIOUS render had a live incident. Only the
@@ -145,7 +156,8 @@ export function ServiceStatusBanner() {
         label: 'IPFS',
         shortLabel: 'IPFS',
         icon: Cloud,
-        status: connectivity.ipfs,
+        // Direct gateway probe — see comment on `ipfsGateway` above.
+        status: ipfsGateway,
       },
       {
         key: 'nostr',
@@ -162,7 +174,7 @@ export function ServiceStatusBanner() {
         status: market,
       },
     ],
-    [connectivity.aggregator, connectivity.ipfs, connectivity.nostr, market],
+    [connectivity.aggregator, connectivity.nostr, ipfsGateway, market],
   );
 
   const severities = rows.map((r) => severityOf(r.status));

--- a/src/sdk/hooks/core/useIpfsGatewayStatus.ts
+++ b/src/sdk/hooks/core/useIpfsGatewayStatus.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState, useRef } from 'react';
+
+/**
+ * IPFS gateway reachability — direct probe.
+ *
+ * Background: the SDK's `sphere.connectivity.ipfs` is fed by an internal
+ * `IpfsPinger` that HEADs `<gateway>/ipfs/bafyaabakaieac` against the
+ * configured gateway list. In production we observed the SDK reading
+ * 'down' for IPFS even when the actual data path (`/api/feed/recent`-
+ * adjacent IPFS storage logs show `1 healthy gateway(s) found` and
+ * `[IPFS-HTTP] Fetched from ...`) was working fine. Rather than chase
+ * the SDK bug, this hook does an independent same-CID probe and
+ * exposes the result so the banner can show the truth users actually
+ * experience.
+ *
+ * The probe URL mirrors the SDK's: empty-unixfs CID `bafyaabakaieac`
+ * against the BUILTIN_IPFS_GATEWAYS default. If the wallet was
+ * configured with a different gateway, the SDK still pings its own
+ * list — but the banner's IPFS pill will reflect THIS hook's verdict
+ * since the data path universally targets the unicity-managed gateway
+ * for testnet/mainnet.
+ */
+export type IpfsGatewayStatus = 'up' | 'down' | 'unknown';
+
+const IPFS_PROBE_URL = 'https://unicity-ipfs1.dyndns.org/ipfs/bafyaabakaieac';
+
+// Backoff: same schedule as the SDK's connectivity manager.
+const BACKOFF_SCHEDULE_MS = [5_000, 15_000, 60_000, 300_000] as const;
+const PROBE_TIMEOUT_MS = 8_000;
+
+/**
+ * Hook that probes the IPFS gateway on a backoff schedule and exposes
+ * the current up/down/unknown status. Independent from
+ * `sphere.connectivity.ipfs` so the banner reads accurately even when
+ * the SDK's internal probe is misbehaving.
+ */
+export function useIpfsGatewayStatus(): IpfsGatewayStatus {
+  const [status, setStatus] = useState<IpfsGatewayStatus>('unknown');
+  const stepRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let inflightController: AbortController | null = null;
+
+    const probe = async () => {
+      if (cancelled) return;
+      inflightController = new AbortController();
+      const timeoutTimer = setTimeout(
+        () => inflightController?.abort(),
+        PROBE_TIMEOUT_MS,
+      );
+
+      let nextStatus: IpfsGatewayStatus = 'down';
+      try {
+        // GET (not HEAD) — `bafyaabakaieac` is the empty unixfs
+        // directory (~10 bytes) so GET-vs-HEAD is the same cost in
+        // practice, and some gateways serve HEAD redirects oddly.
+        // The CORS preflight requirement is identical for both
+        // (simple methods, no custom headers).
+        const res = await fetch(IPFS_PROBE_URL, {
+          method: 'GET',
+          signal: inflightController.signal,
+          credentials: 'omit',
+          referrerPolicy: 'no-referrer',
+          cache: 'no-cache',
+        });
+        // Treat 2xx OR 3xx as 'up' — some gateways redirect from
+        // `/ipfs/<cid>` to `/ipfs/<cid>/` (HTTP 301), which fetch
+        // would normally follow automatically, but if redirect
+        // handling glitches we still know the edge is alive.
+        // res.ok covers 200-299; status < 400 is the wider net.
+        nextStatus = res.status < 400 ? 'up' : 'down';
+      } catch {
+        // Network error, DNS failure, abort/timeout, CORS rejection.
+        nextStatus = 'down';
+      } finally {
+        clearTimeout(timeoutTimer);
+      }
+
+      if (cancelled) return;
+
+      setStatus(nextStatus);
+
+      stepRef.current =
+        nextStatus === 'up'
+          ? 0
+          : Math.min(stepRef.current + 1, BACKOFF_SCHEDULE_MS.length - 1);
+
+      const delay = BACKOFF_SCHEDULE_MS[stepRef.current];
+      if (cancelled) return;
+      timer = setTimeout(probe, delay);
+    };
+
+    timer = setTimeout(probe, 0);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (inflightController) inflightController.abort();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -16,6 +16,8 @@ export type {
 } from './core/useConnectivity';
 export { useMarketStatus } from './core/useMarketStatus';
 export type { MarketStatus } from './core/useMarketStatus';
+export { useIpfsGatewayStatus } from './core/useIpfsGatewayStatus';
+export type { IpfsGatewayStatus } from './core/useIpfsGatewayStatus';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/tests/unit/components/ServiceStatusBanner.test.tsx
+++ b/tests/unit/components/ServiceStatusBanner.test.tsx
@@ -33,16 +33,20 @@ import { ServiceStatusBanner } from '../../../src/components/layout/ServiceStatu
 import type { UseConnectivityReturn } from '../../../src/sdk/hooks/core/useConnectivity';
 import type { MarketStatus } from '../../../src/sdk/hooks/core/useMarketStatus';
 
-// Mock the two hooks the banner consumes so each test can drive the
-// status independently of the SDK/CoinGecko probes.
+// Mock the hooks the banner consumes so each test can drive the
+// status independently of the SDK / market-api / IPFS gateway probes.
 const connectivityMock = vi.fn<() => UseConnectivityReturn>();
 const marketMock = vi.fn<() => MarketStatus>();
+const ipfsGatewayMock = vi.fn<() => 'up' | 'down' | 'unknown'>();
 
 vi.mock('../../../src/sdk/hooks/core/useConnectivity', () => ({
   useConnectivity: () => connectivityMock(),
 }));
 vi.mock('../../../src/sdk/hooks/core/useMarketStatus', () => ({
   useMarketStatus: () => marketMock(),
+}));
+vi.mock('../../../src/sdk/hooks/core/useIpfsGatewayStatus', () => ({
+  useIpfsGatewayStatus: () => ipfsGatewayMock(),
 }));
 
 function allUp(): UseConnectivityReturn {
@@ -65,6 +69,18 @@ function withOverrides(
 beforeEach(() => {
   connectivityMock.mockReset();
   marketMock.mockReset();
+  ipfsGatewayMock.mockReset();
+  // Default ipfsGateway mock: mirror connectivity.ipfs so existing
+  // tests written before the direct-probe split (which drove IPFS via
+  // `connectivity.ipfs`) continue to express the SAME IPFS state.
+  // Individual tests can override with `ipfsGatewayMock.mockReturnValue(...)`.
+  ipfsGatewayMock.mockImplementation(() => {
+    try {
+      return connectivityMock().ipfs as 'up' | 'down' | 'unknown';
+    } catch {
+      return 'unknown';
+    }
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
Production observation after PR #318: with Aggregator at 503 and the Market REST endpoint reachable, the banner correctly showed Market 'up' but kept reporting IPFS 'down' even though the data path (\`[IPFS-HTTP] Fetched\`, \`[IPFS-Storage] 1 healthy gateway(s) found\`, \`[IPNS-WS] WebSocket connected\`) was clearly functional.

## Root cause

\`sphere.connectivity.ipfs\` is fed by the SDK's internal \`IpfsPinger\` which HEADs \`<gateway>/ipfs/bafyaabakaieac\`. Curl-equivalent HEAD to that URL succeeds (301 → 200 with \`access-control-allow-origin: *\`), so the gateway is reachable and CORS is allowed. The 'down' verdict appears to come from a SDK-side probe bug that is not worth chasing across the vendored boundary.

## Fix

Swap \`connectivity.ipfs\` for a direct same-CID **GET** probe in the banner. GET is preferred because (a) the empty-unixfs CID is ~10 bytes so HEAD-vs-GET cost is identical in practice and (b) some gateways serve HEAD redirects oddly. CORS preflight semantics are identical (simple methods, no custom headers). The probe runs on the same 5s → 15s → 60s → 5m backoff as the SDK connectivity manager.

Aggregator and Nostr continue to read from \`sphere.connectivity\` — those probes are working correctly.

## Test plan

- [x] 91 app tests pass (banner's IPFS hook is mocked to mirror \`connectivity.ipfs\` by default so existing inputs map cleanly).
- [x] tsc + eslint clean.
- [x] Rebuilt + redeployed to \`sphere-telco-test.dyndns.org\` for live verification.

Follow-up to PR #318.