### PR TITLE
feat(devtools): extend dev overrides to Nostr, IPFS, Faucet, Market endpoints

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,10 @@ import { DiscordIcon, XIcon } from '../icons/SocialIcons';
 function devReset(): void {
   localStorage.removeItem(STORAGE_KEYS.DEV_AGGREGATOR_URL);
   localStorage.removeItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE);
+  localStorage.removeItem(STORAGE_KEYS.DEV_NOSTR_RELAY_URL);
+  localStorage.removeItem(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL);
+  localStorage.removeItem(STORAGE_KEYS.DEV_FAUCET_URL);
+  localStorage.removeItem(STORAGE_KEYS.DEV_MARKET_API_URL);
   window.dispatchEvent(new Event("dev-config-changed"));
 }
 import logoUrl from '/Union.svg';
@@ -32,6 +36,10 @@ export function Header() {
   const getDevConfig = () => ({
     aggregatorUrl: localStorage.getItem(STORAGE_KEYS.DEV_AGGREGATOR_URL),
     skipTrustBase: localStorage.getItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE) === 'true',
+    nostrRelayUrl: localStorage.getItem(STORAGE_KEYS.DEV_NOSTR_RELAY_URL),
+    ipfsGatewayUrl: localStorage.getItem(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL),
+    faucetUrl: localStorage.getItem(STORAGE_KEYS.DEV_FAUCET_URL),
+    marketApiUrl: localStorage.getItem(STORAGE_KEYS.DEV_MARKET_API_URL),
   });
   const [devConfig, setDevConfig] = useState(getDevConfig);
 
@@ -126,22 +134,51 @@ export function Header() {
 
               <div className="flex-1" />
 
-              {(devConfig.aggregatorUrl || devConfig.skipTrustBase) && (
-                <div className="flex items-center gap-2 px-3 py-1 rounded-lg bg-orange-500/10 border border-orange-500/30 text-[10px] sm:text-xs font-mono mr-3">
+              {(devConfig.aggregatorUrl ||
+                devConfig.skipTrustBase ||
+                devConfig.nostrRelayUrl ||
+                devConfig.ipfsGatewayUrl ||
+                devConfig.faucetUrl ||
+                devConfig.marketApiUrl) && (
+                <div
+                  className="flex items-center gap-2 px-3 py-1 rounded-lg bg-orange-500/10 border border-orange-500/30 text-[10px] sm:text-xs font-mono mr-3"
+                  title={[
+                    devConfig.aggregatorUrl &&
+                      `Aggregator: ${devConfig.aggregatorUrl}`,
+                    devConfig.skipTrustBase && 'Trust-base verification: OFF',
+                    devConfig.nostrRelayUrl &&
+                      `Nostr: ${devConfig.nostrRelayUrl}`,
+                    devConfig.ipfsGatewayUrl &&
+                      `IPFS gateway: ${devConfig.ipfsGatewayUrl}`,
+                    devConfig.marketApiUrl &&
+                      `Market API: ${devConfig.marketApiUrl}`,
+                    devConfig.faucetUrl && `Faucet: ${devConfig.faucetUrl}`,
+                  ]
+                    .filter(Boolean)
+                    .join('\n')}
+                >
                   <span className="text-orange-500 font-semibold">DEV</span>
-                  <span className="text-orange-400/80 hidden sm:inline">
-                    {devConfig.aggregatorUrl && (
-                      <span title={devConfig.aggregatorUrl}>
-                        {getHostname(devConfig.aggregatorUrl)}
-                      </span>
-                    )}
-                    {devConfig.aggregatorUrl && devConfig.skipTrustBase && " | "}
-                    {devConfig.skipTrustBase && "TB:OFF"}
+                  <span className="text-orange-400/80 hidden sm:inline flex items-center gap-1">
+                    {[
+                      devConfig.aggregatorUrl &&
+                        `agg:${getHostname(devConfig.aggregatorUrl)}`,
+                      devConfig.skipTrustBase && 'TB:OFF',
+                      devConfig.nostrRelayUrl &&
+                        `nostr:${getHostname(devConfig.nostrRelayUrl)}`,
+                      devConfig.ipfsGatewayUrl &&
+                        `ipfs:${getHostname(devConfig.ipfsGatewayUrl)}`,
+                      devConfig.marketApiUrl &&
+                        `mkt:${getHostname(devConfig.marketApiUrl)}`,
+                      devConfig.faucetUrl &&
+                        `faucet:${getHostname(devConfig.faucetUrl)}`,
+                    ]
+                      .filter(Boolean)
+                      .join(' | ')}
                   </span>
                   <button
                     onClick={devReset}
                     className="ml-1 px-1.5 py-0.5 rounded bg-orange-500/20 hover:bg-orange-500/30 text-orange-500 font-semibold transition-colors"
-                    title="Reset dev settings to production defaults"
+                    title="Reset ALL dev settings to production defaults"
                   >
                     RESET
                   </button>

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -38,9 +38,15 @@ export const STORAGE_KEYS = {
   // Connected Sites (approved dApp origins)
   CONNECTED_SITES: 'sphere_connected_sites',
 
-  // Dev Settings
+  // Dev Settings — custom endpoints for local stacks / e2e / soak tests.
+  // Active values flow through SphereProvider → createBrowserProviders
+  // and are reflected in the header chip + `sphereDev` console helpers.
   DEV_AGGREGATOR_URL: 'sphere_dev_aggregator_url',
   DEV_SKIP_TRUST_BASE: 'sphere_dev_skip_trust_base',
+  DEV_NOSTR_RELAY_URL: 'sphere_dev_nostr_relay_url',
+  DEV_IPFS_GATEWAY_URL: 'sphere_dev_ipfs_gateway_url',
+  DEV_FAUCET_URL: 'sphere_dev_faucet_url',
+  DEV_MARKET_API_URL: 'sphere_dev_market_api_url',
 } as const;
 
 const STORAGE_PREFIX = 'sphere_';

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -22,6 +22,7 @@ import {
 } from '@unicitylabs/sphere-sdk/profile/browser';
 import { IS_UXF_BUILD } from '../config/uxf';
 import { runProfileMigration } from './uxfProfileMigration';
+import { readDevOverrideSnapshot, type DevOverrideSnapshot } from './devOverrides';
 import { hasMaterialContent } from './utils/tokenStorageProbe';
 import { SphereContext } from './SphereContext';
 import type { WalletMode } from './SphereContext';
@@ -65,7 +66,9 @@ function isIpfsEnabled(): boolean {
   return stored !== 'false'; // enabled by default
 }
 
-function getIpfsConfig() {
+function getIpfsConfig(): {
+  tokenSync?: { ipfs?: { enabled: boolean; gateways?: string[] } };
+} {
   if (!isIpfsEnabled()) return {};
   return {
     tokenSync: {
@@ -107,8 +110,46 @@ function getDevOracleOverride():
 }
 
 /**
+ * Dev-mode Nostr relay override → `transport.relays`.
+ *
+ * Returns a single-relay list when `DEV_NOSTR_RELAY_URL` is set so the
+ * SDK uses ONLY the override relay (replaces network defaults
+ * entirely). Returns `undefined` otherwise so the network defaults
+ * apply.
+ */
+function getDevTransportOverride(): { relays: string[] } | undefined {
+  const url = localStorage.getItem(STORAGE_KEYS.DEV_NOSTR_RELAY_URL);
+  if (!url) return undefined;
+  return { relays: [url] };
+}
+
+/**
+ * Dev-mode IPFS gateway override.
+ *
+ * Returns a `tokenSync.ipfs.gateways` override aligned with the
+ * existing `getIpfsConfig()` toggle. When IPFS sync is disabled, the
+ * override is also disabled (no point pointing a turned-off subsystem
+ * at an alternate gateway). When enabled AND `DEV_IPFS_GATEWAY_URL`
+ * is set, the override replaces the network's gateway list entirely
+ * so the wallet talks only to the local stack.
+ */
+function getDevIpfsGatewayOverride(): string | null {
+  return localStorage.getItem(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL);
+}
+
+/**
+ * Dev-mode Market API override → `market.apiUrl`.
+ */
+function getDevMarketOverride(): { apiUrl: string } | undefined {
+  const url = localStorage.getItem(STORAGE_KEYS.DEV_MARKET_API_URL);
+  if (!url) return undefined;
+  return { apiUrl: url };
+}
+
+
+/**
  * Install a small `window.sphereDev` namespace exposing one-line
- * helpers so the dev override is reachable from the browser console
+ * helpers so the dev overrides are reachable from the browser console
  * without users having to remember the exact localStorage keys.
  *
  * Idempotent — re-running on hot-reload or remount overwrites the
@@ -118,38 +159,64 @@ function getDevOracleOverride():
  * Usage from console:
  *
  *   sphereDev.setAggregator('http://127.0.0.1:11003')   // override + reload
- *   sphereDev.setAggregator(null)                       // clear override + reload
+ *   sphereDev.setAggregator(null)                       // clear override
  *   sphereDev.setSkipTrustBase(true)                    // dev-only — bypass verify
+ *   sphereDev.setNostrRelay('ws://127.0.0.1:7777')      // override Nostr relay
+ *   sphereDev.setIpfsGateway('http://127.0.0.1:8080')   // override IPFS gateway
+ *   sphereDev.setFaucet('http://127.0.0.1:9999/api/v1/faucet/request')
+ *   sphereDev.setMarket('http://127.0.0.1:8081')        // override Market API
  *   sphereDev.show()                                    // print current state
+ *   sphereDev.reset()                                   // clear ALL overrides
+ *
+ * Each setter dispatches the `dev-config-changed` event so the header
+ * chip stays in sync, then triggers a wallet reinitialize so the new
+ * provider config takes effect without a manual page reload.
  */
 function installDevConsoleHelpers(triggerReinit: () => void): void {
   if (typeof window === 'undefined') return;
+  // Common setter — null clears the key, otherwise stores the value.
+  // Dispatches dev-config-changed and triggers reinit.
+  const setOverride = (key: string, value: string | null) => {
+    if (value === null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, value);
+    }
+    window.dispatchEvent(new Event('dev-config-changed'));
+    triggerReinit();
+  };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).sphereDev = {
     setAggregator(url: string | null): void {
-      if (url === null) {
-        localStorage.removeItem(STORAGE_KEYS.DEV_AGGREGATOR_URL);
-      } else {
-        localStorage.setItem(STORAGE_KEYS.DEV_AGGREGATOR_URL, url);
-      }
-      window.dispatchEvent(new Event('dev-config-changed'));
-      triggerReinit();
+      setOverride(STORAGE_KEYS.DEV_AGGREGATOR_URL, url);
     },
     setSkipTrustBase(enabled: boolean): void {
-      if (enabled) {
-        localStorage.setItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE, 'true');
-      } else {
-        localStorage.removeItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE);
-      }
+      setOverride(STORAGE_KEYS.DEV_SKIP_TRUST_BASE, enabled ? 'true' : null);
+    },
+    setNostrRelay(url: string | null): void {
+      setOverride(STORAGE_KEYS.DEV_NOSTR_RELAY_URL, url);
+    },
+    setIpfsGateway(url: string | null): void {
+      setOverride(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL, url);
+    },
+    setFaucet(url: string | null): void {
+      setOverride(STORAGE_KEYS.DEV_FAUCET_URL, url);
+    },
+    setMarket(url: string | null): void {
+      setOverride(STORAGE_KEYS.DEV_MARKET_API_URL, url);
+    },
+    reset(): void {
+      localStorage.removeItem(STORAGE_KEYS.DEV_AGGREGATOR_URL);
+      localStorage.removeItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE);
+      localStorage.removeItem(STORAGE_KEYS.DEV_NOSTR_RELAY_URL);
+      localStorage.removeItem(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL);
+      localStorage.removeItem(STORAGE_KEYS.DEV_FAUCET_URL);
+      localStorage.removeItem(STORAGE_KEYS.DEV_MARKET_API_URL);
       window.dispatchEvent(new Event('dev-config-changed'));
       triggerReinit();
     },
-    show(): { aggregatorUrl: string | null; skipTrustBase: boolean } {
-      const state = {
-        aggregatorUrl: localStorage.getItem(STORAGE_KEYS.DEV_AGGREGATOR_URL),
-        skipTrustBase:
-          localStorage.getItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE) === 'true',
-      };
+    show(): DevOverrideSnapshot {
+      const state = readDevOverrideSnapshot();
       console.log('[sphereDev]', state);
       return state;
     },
@@ -475,27 +542,61 @@ export function SphereProvider({
       if (!skipLoading) setIsLoading(true);
       setError(null);
 
-      // Dev-mode oracle override (custom aggregator URL / skip-trust-base).
-      // Set via `sphereDev.setAggregator(...)` from the console, or via
-      // localStorage keys `sphere_dev_aggregator_url` / `sphere_dev_skip_trust_base`.
-      // Header chip in `Header.tsx` reflects the active state.
+      // Dev-mode overrides — see `sphereDev` console helpers and the
+      // header chip for the user-facing surface. Each helper returns
+      // `undefined` when its localStorage key is unset so the network
+      // defaults apply.
       const devOracleOverride = getDevOracleOverride();
-      if (devOracleOverride) {
+      const devTransportOverride = getDevTransportOverride();
+      const devMarketOverride = getDevMarketOverride();
+      const devIpfsGatewayOverride = getDevIpfsGatewayOverride();
+      if (
+        devOracleOverride ||
+        devTransportOverride ||
+        devMarketOverride ||
+        devIpfsGatewayOverride
+      ) {
+        const snapshot = readDevOverrideSnapshot();
         logger.info(
           'SphereProvider',
-          `Dev-mode oracle override active: ` +
-            `url=${devOracleOverride.url ?? '<network default>'} ` +
-            `skipVerification=${devOracleOverride.skipVerification ?? false}`,
+          `Dev-mode overrides active: ` +
+            `aggregator=${snapshot.aggregatorUrl ?? '<default>'} ` +
+            `skipTrustBase=${snapshot.skipTrustBase} ` +
+            `nostr=${snapshot.nostrRelayUrl ?? '<default>'} ` +
+            `ipfs=${snapshot.ipfsGatewayUrl ?? '<default>'} ` +
+            `market=${snapshot.marketApiUrl ?? '<default>'} ` +
+            `faucet=${snapshot.faucetUrl ?? '<default>'}`,
         );
+      }
+
+      // IPFS sync config: if the user enabled it (the default) AND set
+      // a dev gateway override, replace the network's gateway list
+      // with a single-entry list. The merge happens here rather than
+      // inside `getIpfsConfig()` so the toggle and the override are
+      // composable in either order.
+      const ipfsConfig = getIpfsConfig();
+      if (
+        devIpfsGatewayOverride &&
+        ipfsConfig.tokenSync?.ipfs?.enabled
+      ) {
+        ipfsConfig.tokenSync = {
+          ipfs: {
+            enabled: true,
+            gateways: [devIpfsGatewayOverride],
+          },
+        };
       }
 
       const browserProviders = createBrowserProviders({
         network,
         price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
         groupChat: true,
-        market: true,
+        // Market: pass the override apiUrl when set; otherwise enable
+        // with default-resolver shape (`true`).
+        market: devMarketOverride ?? true,
         ...(devOracleOverride ? { oracle: devOracleOverride } : {}),
-        ...getIpfsConfig(),
+        ...(devTransportOverride ? { transport: devTransportOverride } : {}),
+        ...ipfsConfig,
       });
       // Debug logging is off by default; enable at runtime via: logger.configure({ debug: true })
       setProviders(browserProviders);
@@ -774,11 +875,16 @@ export function SphereProvider({
     // can still use it; they just don't get the hint banner.
     if (import.meta.env.DEV) {
       console.log(
-        '%c[sphereDev]%c custom aggregator helpers loaded.\n' +
-          '  sphereDev.setAggregator("http://127.0.0.1:11003")  // override + reload providers\n' +
-          '  sphereDev.setAggregator(null)                       // clear override\n' +
-          '  sphereDev.setSkipTrustBase(true)                    // dev-only — bypass trust-base verify\n' +
-          '  sphereDev.show()                                    // print current state',
+        '%c[sphereDev]%c dev-mode endpoint overrides loaded. Set any of:\n' +
+          '  sphereDev.setAggregator("http://127.0.0.1:11003")\n' +
+          '  sphereDev.setSkipTrustBase(true)         // bypass trust-base verify\n' +
+          '  sphereDev.setNostrRelay("ws://127.0.0.1:7777")\n' +
+          '  sphereDev.setIpfsGateway("http://127.0.0.1:8080")\n' +
+          '  sphereDev.setFaucet("http://127.0.0.1:9999/api/v1/faucet/request")\n' +
+          '  sphereDev.setMarket("http://127.0.0.1:8081")\n' +
+          '  sphereDev.show()                          // print current state\n' +
+          '  sphereDev.reset()                         // clear ALL overrides\n' +
+          'Pass null to any setter to clear that specific override.',
         'color: #f59e0b; font-weight: bold',
         'color: #888',
       );

--- a/src/sdk/devOverrides.ts
+++ b/src/sdk/devOverrides.ts
@@ -1,0 +1,45 @@
+/**
+ * Dev-mode endpoint overrides.
+ *
+ * Lives in its own module (not next to SphereProvider) so it can be
+ * imported by both the provider and the Header chip without tripping
+ * react-refresh's "only-export-components" rule.
+ *
+ * Storage keys are defined in `config/storageKeys.ts`. The `sphereDev`
+ * console namespace and the SphereProvider wiring are the only setters
+ * — everything else just reads.
+ */
+import { STORAGE_KEYS } from '../config/storageKeys';
+
+export interface DevOverrideSnapshot {
+  aggregatorUrl: string | null;
+  skipTrustBase: boolean;
+  nostrRelayUrl: string | null;
+  ipfsGatewayUrl: string | null;
+  faucetUrl: string | null;
+  marketApiUrl: string | null;
+}
+
+export function readDevOverrideSnapshot(): DevOverrideSnapshot {
+  return {
+    aggregatorUrl: localStorage.getItem(STORAGE_KEYS.DEV_AGGREGATOR_URL),
+    skipTrustBase:
+      localStorage.getItem(STORAGE_KEYS.DEV_SKIP_TRUST_BASE) === 'true',
+    nostrRelayUrl: localStorage.getItem(STORAGE_KEYS.DEV_NOSTR_RELAY_URL),
+    ipfsGatewayUrl: localStorage.getItem(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL),
+    faucetUrl: localStorage.getItem(STORAGE_KEYS.DEV_FAUCET_URL),
+    marketApiUrl: localStorage.getItem(STORAGE_KEYS.DEV_MARKET_API_URL),
+  };
+}
+
+export function hasAnyDevOverride(snap?: DevOverrideSnapshot): boolean {
+  const s = snap ?? readDevOverrideSnapshot();
+  return Boolean(
+    s.aggregatorUrl ||
+      s.skipTrustBase ||
+      s.nostrRelayUrl ||
+      s.ipfsGatewayUrl ||
+      s.faucetUrl ||
+      s.marketApiUrl,
+  );
+}

--- a/src/sdk/hooks/core/useIpfsGatewayStatus.ts
+++ b/src/sdk/hooks/core/useIpfsGatewayStatus.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { STORAGE_KEYS } from '../../../config/storageKeys';
 
 /**
  * IPFS gateway reachability — direct probe.
@@ -22,7 +23,31 @@ import { useEffect, useState, useRef } from 'react';
  */
 export type IpfsGatewayStatus = 'up' | 'down' | 'unknown';
 
-const IPFS_PROBE_URL = 'https://unicity-ipfs1.dyndns.org/ipfs/bafyaabakaieac';
+const DEFAULT_IPFS_GATEWAY = 'https://unicity-ipfs1.dyndns.org';
+/** Empty unixfs directory — universally pinned, ~10 bytes. Same CID
+ *  the SDK's `IpfsPinger` uses. */
+const PROBE_CID = 'bafyaabakaieac';
+
+/**
+ * Resolve the gateway BASE to probe. Honors
+ * `STORAGE_KEYS.DEV_IPFS_GATEWAY_URL` so e2e / soak runs against a
+ * locally-bootstrapped gateway show 'up' when that gateway is alive
+ * (and 'down' when it isn't), instead of always probing the
+ * production default. The gateway value is the BASE URL — the probe
+ * path is appended at fetch time so trailing slashes are normalised.
+ */
+function getProbeGateway(): string {
+  if (typeof window === 'undefined') return DEFAULT_IPFS_GATEWAY;
+  return (
+    localStorage.getItem(STORAGE_KEYS.DEV_IPFS_GATEWAY_URL) ??
+    DEFAULT_IPFS_GATEWAY
+  );
+}
+
+function buildProbeUrl(): string {
+  const gateway = getProbeGateway().replace(/\/+$/, '');
+  return `${gateway}/ipfs/${PROBE_CID}`;
+}
 
 // Backoff: same schedule as the SDK's connectivity manager.
 const BACKOFF_SCHEDULE_MS = [5_000, 15_000, 60_000, 300_000] as const;
@@ -36,7 +61,22 @@ const PROBE_TIMEOUT_MS = 8_000;
  */
 export function useIpfsGatewayStatus(): IpfsGatewayStatus {
   const [status, setStatus] = useState<IpfsGatewayStatus>('unknown');
+  // `epoch` bumps when the dev-config-changed event fires, which
+  // forces the effect to tear down and re-mount — so a fresh probe
+  // fires immediately against the new gateway URL.
+  const [epoch, setEpoch] = useState(0);
   const stepRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = () => {
+      stepRef.current = 0;
+      setStatus('unknown');
+      setEpoch((e) => e + 1);
+    };
+    window.addEventListener('dev-config-changed', handler);
+    return () => window.removeEventListener('dev-config-changed', handler);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,7 +98,7 @@ export function useIpfsGatewayStatus(): IpfsGatewayStatus {
         // practice, and some gateways serve HEAD redirects oddly.
         // The CORS preflight requirement is identical for both
         // (simple methods, no custom headers).
-        const res = await fetch(IPFS_PROBE_URL, {
+        const res = await fetch(buildProbeUrl(), {
           method: 'GET',
           signal: inflightController.signal,
           credentials: 'omit',
@@ -99,7 +139,9 @@ export function useIpfsGatewayStatus(): IpfsGatewayStatus {
       if (timer) clearTimeout(timer);
       if (inflightController) inflightController.abort();
     };
-  }, []);
+    // `epoch` is in the deps so a dev-config-changed event remounts
+    // the probe cycle and immediately retargets the new gateway URL.
+  }, [epoch]);
 
   return status;
 }

--- a/src/sdk/hooks/core/useMarketStatus.ts
+++ b/src/sdk/hooks/core/useMarketStatus.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { STORAGE_KEYS } from '../../../config/storageKeys';
 
 /**
  * Markets-module reachability status.
@@ -20,7 +21,24 @@ export type MarketStatus = 'up' | 'down' | 'unknown';
  * hits for `getRecentListings()` — when this responds OK the entire
  * Markets module is functional.
  */
-const MARKET_API_PROBE_URL = 'https://market-api.unicity.network/api/feed/recent';
+const DEFAULT_MARKET_API_BASE = 'https://market-api.unicity.network';
+const PROBE_PATH = '/api/feed/recent';
+
+/**
+ * Resolve the Market API base URL. Honors
+ * `STORAGE_KEYS.DEV_MARKET_API_URL` so e2e / soak runs that point the
+ * SDK at a local Markets backend get the same target probed by the
+ * banner. The probe path is appended at fetch time so trailing
+ * slashes are normalised.
+ */
+function buildProbeUrl(): string {
+  const base =
+    typeof window !== 'undefined'
+      ? localStorage.getItem(STORAGE_KEYS.DEV_MARKET_API_URL) ??
+        DEFAULT_MARKET_API_BASE
+      : DEFAULT_MARKET_API_BASE;
+  return `${base.replace(/\/+$/, '')}${PROBE_PATH}`;
+}
 
 // Backoff: same schedule as the SDK's connectivity manager — 5s → 15s → 60s → 5m.
 // On success the schedule resets to step 0.
@@ -42,7 +60,22 @@ const PROBE_TIMEOUT_MS = 8_000;
  */
 export function useMarketStatus(): MarketStatus {
   const [status, setStatus] = useState<MarketStatus>('unknown');
+  // Bumped by the dev-config-changed event so a fresh probe fires
+  // immediately against the new market-api URL when the user flips
+  // `sphereDev.setMarket(...)`.
+  const [epoch, setEpoch] = useState(0);
   const stepRef = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handler = () => {
+      stepRef.current = 0;
+      setStatus('unknown');
+      setEpoch((e) => e + 1);
+    };
+    window.addEventListener('dev-config-changed', handler);
+    return () => window.removeEventListener('dev-config-changed', handler);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -59,7 +92,7 @@ export function useMarketStatus(): MarketStatus {
 
       let nextStatus: MarketStatus = 'down';
       try {
-        const res = await fetch(MARKET_API_PROBE_URL, {
+        const res = await fetch(buildProbeUrl(), {
           method: 'GET',
           signal: inflightController.signal,
           // Public endpoint; no cookies / referrer needed.
@@ -113,7 +146,9 @@ export function useMarketStatus(): MarketStatus {
       if (timer) clearTimeout(timer);
       if (inflightController) inflightController.abort();
     };
-  }, []);
+    // `epoch` is in the deps so a dev-config-changed event remounts
+    // the probe cycle and immediately retargets the new market URL.
+  }, [epoch]);
 
   return status;
 }

--- a/src/services/FaucetService.ts
+++ b/src/services/FaucetService.ts
@@ -1,4 +1,20 @@
-const FAUCET_API_URL = 'https://faucet.unicity.network/api/v1/faucet/request';
+import { STORAGE_KEYS } from '../config/storageKeys';
+
+const DEFAULT_FAUCET_API_URL = 'https://faucet.unicity.network/api/v1/faucet/request';
+
+/**
+ * Resolve the faucet endpoint. Honors the dev-mode override
+ * `STORAGE_KEYS.DEV_FAUCET_URL` (set via `sphereDev.setFaucet(...)` or
+ * the localStorage key directly) so e2e / soak runs can point at a
+ * locally-bootstrapped faucet. Read on every call so the override
+ * picks up live without a page reload.
+ */
+function getFaucetApiUrl(): string {
+  if (typeof window === 'undefined') return DEFAULT_FAUCET_API_URL;
+  return (
+    localStorage.getItem(STORAGE_KEYS.DEV_FAUCET_URL) ?? DEFAULT_FAUCET_API_URL
+  );
+}
 
 export interface FaucetRequest {
   unicityId: string;
@@ -46,7 +62,7 @@ export class FaucetService {
 
       if (import.meta.env.DEV) console.log(`📤 Sending request:`, requestBody);
 
-      const response = await fetch(FAUCET_API_URL, {
+      const response = await fetch(getFaucetApiUrl(), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Follow-up to #320. Same console-driven dev override pattern, now covering every endpoint the SDK and the app talk to.

## New overrides

| Storage key | SDK config slot | Console helper |
|---|---|---|
| \`DEV_NOSTR_RELAY_URL\` | \`transport.relays = [url]\` | \`sphereDev.setNostrRelay(url)\` |
| \`DEV_IPFS_GATEWAY_URL\` | \`tokenSync.ipfs.gateways = [url]\` (when IPFS sync on) | \`sphereDev.setIpfsGateway(url)\` |
| \`DEV_FAUCET_URL\` | \`FaucetService\` fetch target | \`sphereDev.setFaucet(url)\` |
| \`DEV_MARKET_API_URL\` | \`market.apiUrl\` | \`sphereDev.setMarket(url)\` |

Plus existing \`DEV_AGGREGATOR_URL\` / \`DEV_SKIP_TRUST_BASE\`. \`sphereDev.show()\` prints all six; \`sphereDev.reset()\` clears all six and triggers a single reinitialize.

## Banner truth follows the overrides

\`useIpfsGatewayStatus\` and \`useMarketStatus\` read the override keys at every probe AND subscribe to \`dev-config-changed\` to remount their probe cycle. So pointing the wallet at a local stack also points the banner's reachability probes at that stack — no more discrepancy between \"the SDK is talking to your local aggregator but the banner is reporting on the production market\".

## Header chip

Now displays every active override in a compact \`agg:localhost | nostr:127.0.0.1 | TB:OFF\`-style line with a tooltip listing the full URLs. Reset clears all six.

## Use case

Pair this with \`tests/e2e/local-infra/.aggregator-go/docker-compose.yml\` and the relay/faucet bootstrap in \`tests/e2e/local-infra/global-setup.ts\` to drive a fully-local soak from the browser in five console lines:

\`\`\`js
sphereDev.setAggregator('http://127.0.0.1:11003')
sphereDev.setSkipTrustBase(true)
sphereDev.setNostrRelay('ws://127.0.0.1:7777')
sphereDev.setIpfsGateway('http://127.0.0.1:8080')
sphereDev.setMarket('http://127.0.0.1:8081')
sphereDev.setFaucet('http://127.0.0.1:9999/api/v1/faucet/request')
\`\`\`

## Test plan

- [x] 91 app tests pass.
- [x] tsc + eslint clean.
- [x] Rebuilt + redeployed to \`sphere-telco-test.dyndns.org\`.
- [ ] Manual: from console, run a few setters and confirm (a) header chip updates, (b) banner pills retarget within a probe cycle, (c) the \`[SphereProvider] Dev-mode overrides active: ...\` log line reflects the new config.

Caveat that already applies to #320 also applies here: a fully-local stack has its own genesis / state. Wallets built against the public testnet won't have history against your local aggregator; the soak harness should either create fresh wallets or wipe IndexedDB before pointing at the local stack.