### PR TITLE
fix(layout): BaseModal z-index above MobileBottomNav

### DIFF
--- a/src/components/wallet/ui/BaseModal.tsx
+++ b/src/components/wallet/ui/BaseModal.tsx
@@ -36,11 +36,11 @@ export function BaseModal({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
-            className="fixed inset-0 z-100 bg-black/60 dark:bg-black/80 backdrop-blur-sm"
+            className="fixed inset-0 z-[200] bg-black/60 dark:bg-black/80 backdrop-blur-sm"
           />
 
           {/* Modal Container — full-screen on mobile, centered dialog on desktop */}
-          <div className="fixed inset-0 z-100 flex items-end sm:items-center justify-center sm:p-6 pointer-events-none">
+          <div className="fixed inset-0 z-[200] flex items-end sm:items-center justify-center sm:p-6 pointer-events-none">
             <motion.div
               initial={{ scale: 0.9, opacity: 0, y: 20 }}
               animate={{ scale: 1, opacity: 1, y: 0 }}


### PR DESCRIPTION
User-reported issue with #322: in the SettingsModal, the bottom \"Save & reload\" action was hidden behind the mobile bottom navigation bar.

## Root cause

Shared infrastructure: \`BaseModal\` rendered both the backdrop and the dialog container at \`z-100\`, while \`MobileBottomNav\` sits at \`z-[150]\` (mobile/MobileBottomNav.tsx:75). The nav literally covered any action button that lived in a modal's footer.

## Fix

Bump \`BaseModal\` backdrop + container from \`z-100\` to \`z-[200]\` so they layer above the nav (\`z-[150]\`) and below the rare extremely-high-z components like \`NewConversationModal\`'s \`z-100001\`. Modals should cover any persistent navigation surface — that's the whole point of being modal.

## Blast radius

Affects every modal in the app that uses \`BaseModal\` (TopUp, Send, Lookup, CreateAddress, RegisterNametag, group/DM modals, etc.). Their footers were all behind the bottom nav on mobile to varying degrees of visibility depending on how tall the body was. This fix makes the modal-on-top contract correct for all of them.

## Test plan

- [x] 91 tests pass.
- [x] tsc + eslint clean.
- [x] Rebuilt + redeployed.
- [ ] Manual: open the gear → SettingsModal — Save & Reload now visible without scrolling past the bottom nav.