### PR TITLE
fix(uxf)(#331): replace shallow IDB name probe with content-aware Sphere context probes

### DIFF
--- a/src/components/uxf/UxfMigrationPrompt.tsx
+++ b/src/components/uxf/UxfMigrationPrompt.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  detectStorageState,
   UXF_MIGRATION_SKIP_KEY,
   UXF_MIGRATION_CHOICE_KEY,
   type UxfMigrationChoice,
 } from '../../config/uxf';
+import { useSphereContext } from '../../sdk/hooks/core/useSphere';
 
 type PromptVariant = 'legacy-only' | 'both';
 
@@ -136,18 +136,34 @@ function MigrationModal({ onChoice, onSkip, variant }: MigrationPromptProps) {
 }
 
 export function UxfMigrationPrompt() {
+  const { walletExists, hasLegacyData, hasProfileData } = useSphereContext();
   const [variant, setVariant] = useState<PromptVariant | null>(null);
 
   useEffect(() => {
-    const skipped = sessionStorage.getItem(UXF_MIGRATION_SKIP_KEY);
-    const persisted = localStorage.getItem(UXF_MIGRATION_CHOICE_KEY);
-    if (skipped || persisted) return;
+    // Persisted choice / one-shot session skip both suppress the modal
+    // for the rest of that lifetime — re-check on every dependency
+    // change because either could be written by another tab.
+    if (sessionStorage.getItem(UXF_MIGRATION_SKIP_KEY)) { setVariant(null); return; }
+    if (localStorage.getItem(UXF_MIGRATION_CHOICE_KEY)) { setVariant(null); return; }
 
-    detectStorageState().then(({ hasLegacy, hasUxf }) => {
-      if (hasLegacy && hasUxf) setVariant('both');
-      else if (hasLegacy) setVariant('legacy-only');
-    });
-  }, []);
+    // Pre-onboarding: no wallet → no migration question.
+    if (!walletExists) { setVariant(null); return; }
+
+    // Probes still pending — defer. Without this guard the (null, null)
+    // first render would fall through to "no legacy data", hiding the
+    // modal for users who DO have a legacy wallet until the next
+    // re-render. The banner uses the same guard for the same reason
+    // (see UxfBanner.tsx → `probesPending`).
+    if (hasLegacyData === null || hasProfileData === null) { setVariant(null); return; }
+
+    // Content-aware decision — mirrors the UxfBanner matrix:
+    // legacy data is the *only* thing that warrants a migration prompt.
+    // A Profile-only wallet (the fresh-install path) is the target
+    // state, not a state worth interrupting the user about.
+    if (hasLegacyData && hasProfileData) setVariant('both');
+    else if (hasLegacyData)               setVariant('legacy-only');
+    else                                  setVariant(null);
+  }, [walletExists, hasLegacyData, hasProfileData]);
 
   function handleChoice(choice: UxfMigrationChoice, eraseLegacy: boolean) {
     localStorage.setItem(UXF_MIGRATION_CHOICE_KEY, JSON.stringify({ choice, eraseLegacy }));

--- a/src/config/uxf.ts
+++ b/src/config/uxf.ts
@@ -5,26 +5,22 @@ export const UXF_MIGRATION_CHOICE_KEY = 'sphere_uxf_migration_choice';
 
 export type UxfMigrationChoice = 'merge' | 'legacy-only' | 'uxf-only';
 
-// Known legacy IndexedDB database names (pre-UXF schema)
-export const LEGACY_DB_NAMES = ['sphere-storage'] as const;
-// UXF OrbitDB uses a different storage key pattern
-export const UXF_DB_PATTERN = /^orbitdb/i;
-
-export async function detectStorageState(): Promise<{
-  hasLegacy: boolean;
-  hasUxf: boolean;
-}> {
-  if (!('databases' in indexedDB)) {
-    // Firefox <126 doesn't support indexedDB.databases()
-    return { hasLegacy: false, hasUxf: false };
-  }
-  try {
-    const dbs = await indexedDB.databases();
-    const names = dbs.map(d => d.name ?? '');
-    const hasLegacy = names.some(n => LEGACY_DB_NAMES.includes(n as typeof LEGACY_DB_NAMES[number]));
-    const hasUxf = names.some(n => UXF_DB_PATTERN.test(n));
-    return { hasLegacy, hasUxf };
-  } catch {
-    return { hasLegacy: false, hasUxf: false };
-  }
-}
+// ── Tombstone: detectStorageState() / LEGACY_DB_NAMES / UXF_DB_PATTERN ───
+//
+// REMOVED — issue #331.
+//
+// A shallow `indexedDB.databases()` name probe is the wrong shape for
+// "is there material legacy / UXF data?". Both stores share the
+// `sphere-storage` IndexedDB (the Profile local cache is also wired
+// through `createIndexedDBStorageProvider()`), so once *any* wallet —
+// legacy OR fresh Profile — has booted in the browser the legacy DB
+// name is present and a pure name probe always answers
+// `hasLegacy = true`. That made `UxfMigrationPrompt` fire on every
+// reload for fresh Profile-only wallets.
+//
+// The canonical predicate lives in
+// `src/sdk/utils/tokenStorageProbe.ts → hasMaterialContent`, surfaced
+// to consumers as `SphereContext.hasLegacyData` /
+// `SphereContext.hasProfileData`. Both `UxfBanner` and
+// `UxfMigrationPrompt` route through it — do NOT reintroduce a
+// name-based probe here.

--- a/tests/unit/components/uxf/UxfMigrationPrompt.test.tsx
+++ b/tests/unit/components/uxf/UxfMigrationPrompt.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * UxfMigrationPrompt visibility matrix — regression cover for issue #331.
+ *
+ * The modal must render only when there is REAL legacy data to migrate.
+ * The previous implementation used a shallow `indexedDB.databases()`
+ * name probe that fired on every reload for fresh Profile-only wallets
+ * because both stores share the `sphere-storage` IndexedDB.
+ *
+ * Decision table (mirrors the issue body):
+ *
+ *   | walletExists | hasLegacyData | hasProfileData | variant      |
+ *   |--------------|---------------|----------------|--------------|
+ *   | false        | any           | any            | none         |
+ *   | true         | null          | null           | none (defer) |
+ *   | true         | false         | false          | none         |
+ *   | true         | false         | true           | NONE (#331)  |
+ *   | true         | true          | false          | legacy-only  |
+ *   | true         | true          | true           | both         |
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { UxfMigrationPrompt } from '../../../../src/components/uxf/UxfMigrationPrompt';
+import {
+  SphereContext,
+  type SphereContextValue,
+} from '../../../../src/sdk/SphereContext';
+import {
+  UXF_MIGRATION_SKIP_KEY,
+  UXF_MIGRATION_CHOICE_KEY,
+} from '../../../../src/config/uxf';
+
+function makeCtx(
+  overrides: Partial<SphereContextValue>,
+): SphereContextValue {
+  return {
+    sphere: null,
+    providers: null,
+    isLoading: false,
+    isInitialized: false,
+    walletExists: true,
+    error: null,
+    isDiscoveringAddresses: false,
+    initProgress: null,
+    resolveNametag: vi.fn(),
+    createWallet: vi.fn(),
+    importWallet: vi.fn(),
+    importFromFile: vi.fn(),
+    finalizeWallet: vi.fn(),
+    deleteWallet: vi.fn(),
+    reinitialize: vi.fn(),
+    ipfsEnabled: true,
+    toggleIpfs: vi.fn(),
+    walletMode: 'profile',
+    hasLegacyData: null,
+    hasProfileData: null,
+    isSwitchingMode: false,
+    switchWalletMode: vi.fn(),
+    runLegacyToProfileMigration: vi.fn(),
+    refreshDataProbes: vi.fn(),
+    ...overrides,
+  } as unknown as SphereContextValue;
+}
+
+function renderPrompt(ctx: SphereContextValue) {
+  return render(
+    <SphereContext.Provider value={ctx}>
+      <UxfMigrationPrompt />
+    </SphereContext.Provider>,
+  );
+}
+
+const titleBoth = /Legacy & UXF profiles detected/;
+const titleLegacyOnly = /Legacy wallet detected/;
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+describe('UxfMigrationPrompt — visibility matrix', () => {
+  it('hides during onboarding (walletExists=false)', () => {
+    renderPrompt(
+      makeCtx({
+        walletExists: false,
+        hasLegacyData: true,
+        hasProfileData: true,
+      }),
+    );
+    expect(screen.queryByText(titleBoth)).toBeNull();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+
+  it('hides while probes are pending (defer rather than flash)', () => {
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: null,
+        hasProfileData: null,
+      }),
+    );
+    expect(screen.queryByText(titleBoth)).toBeNull();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+
+  it('hides when both stores are empty', () => {
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: false,
+        hasProfileData: false,
+      }),
+    );
+    expect(screen.queryByText(titleBoth)).toBeNull();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+
+  // ─── Issue #331 regression case ────────────────────────────────────
+  it('hides when ONLY the Profile store has data (fresh Profile-only wallet)', () => {
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: false,
+        hasProfileData: true,
+      }),
+    );
+    // The bug fired the "both" variant here on every reload — there is
+    // no legacy data to migrate, so the modal must stay hidden.
+    expect(screen.queryByText(titleBoth)).toBeNull();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+
+  it('shows the legacy-only variant when only the legacy store has data', () => {
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: true,
+        hasProfileData: false,
+      }),
+    );
+    expect(screen.getByText(titleLegacyOnly)).toBeDefined();
+    expect(screen.queryByText(titleBoth)).toBeNull();
+  });
+
+  it('shows the both variant when both stores carry data', () => {
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: true,
+        hasProfileData: true,
+      }),
+    );
+    expect(screen.getByText(titleBoth)).toBeDefined();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+});
+
+describe('UxfMigrationPrompt — skip/persisted gates', () => {
+  it('stays hidden when the session skip key is set', () => {
+    sessionStorage.setItem(UXF_MIGRATION_SKIP_KEY, '1');
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: true,
+        hasProfileData: true,
+      }),
+    );
+    expect(screen.queryByText(titleBoth)).toBeNull();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+
+  it('stays hidden when a persisted choice is recorded', () => {
+    localStorage.setItem(
+      UXF_MIGRATION_CHOICE_KEY,
+      JSON.stringify({ choice: 'merge', eraseLegacy: false }),
+    );
+    renderPrompt(
+      makeCtx({
+        walletExists: true,
+        hasLegacyData: true,
+        hasProfileData: false,
+      }),
+    );
+    expect(screen.queryByText(titleBoth)).toBeNull();
+    expect(screen.queryByText(titleLegacyOnly)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #331 — UXF migration modal re-fires on every reload for fresh Profile-only wallets.

\`UxfMigrationPrompt\` used \`detectStorageState()\` — a shallow \`indexedDB.databases()\` name probe — to decide whether to show the modal. Both the legacy IDB store and the new Profile OrbitDB local cache share the \`sphere-storage\` IndexedDB name, so once *any* wallet has booted in the browser the legacy DB name is present and the name-probe always answers \`hasLegacy = true\`.

Replaced with \`SphereContext.{walletExists, hasLegacyData, hasProfileData}\` — content-aware probes (\`tokenStorageProbe.hasMaterialContent\`) that correctly answer "is there material legacy / UXF data."

## Decision table (locked by tests)

| walletExists | hasLegacyData | hasProfileData | variant      |
|--------------|---------------|----------------|--------------|
| false        | any           | any            | none         |
| true         | null          | null           | none (defer) |
| true         | false         | false          | none         |
| true         | false         | true           | NONE (#331 regression case) |
| true         | true          | false          | legacy-only  |
| true         | true          | true           | both         |

## Also

Deletes \`detectStorageState\`, \`LEGACY_DB_NAMES\`, \`UXF_DB_PATTERN\` from \`src/config/uxf.ts\` — \`UxfMigrationPrompt\` was their only caller. A tombstone comment points future readers at \`tokenStorageProbe.ts → hasMaterialContent\` so the name-probe pattern doesn't get re-introduced.

## Test plan

- [x] 8 new tests in \`tests/unit/components/uxf/UxfMigrationPrompt.test.tsx\` covering all 6 cells of the visibility matrix + skip/persisted-choice gates
- [x] Verified live on sphere-telco-test.dyndns.org

Closes #331