### PR TITLE
chore: bump @unicitylabs/sphere-sdk to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.7.1-dev.3",
+        "@unicitylabs/sphere-sdk": "0.7.2",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2766,9 +2766,9 @@
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.5.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0-dev.3.tgz",
-      "integrity": "sha512-j1YuLsJs2PDZIEn+98Us/+kbn8kwu6HRMbPuI1lZZXv04cbZdViKcGkEZ/Pi/11QitdOGMkKaXnDncgPc7ccNg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
+      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",
@@ -2809,14 +2809,14 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.7.1-dev.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.7.1-dev.3.tgz",
-      "integrity": "sha512-LPmgS2g2bPDAwsXbK5GiVioLcwOf2Dj/K2k/ASQdXOQkhGk4IH8TVNnL4EKIP65e98n6WbzENNC5tV0uFwXybw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.7.2.tgz",
+      "integrity": "sha512-ecVTstgl/zILGcBELq8GrWPmd+0MECNjFzgPZb4T8IKCSQFu6asjc0KE0OWtsQvF8NJGYkz04LPTs9I7hdXNKA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "0.5.0-dev.3",
+        "@unicitylabs/nostr-js-sdk": "^0.5.0",
         "@unicitylabs/state-transition-sdk": "1.6.1-rc.f37cb85",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
@@ -5341,9 +5341,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.43",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.43.tgz",
-      "integrity": "sha512-5n+HnmkNpgZCfaNVxrTGZHr6Lhv3gd0UtbD5lrzun3T2YNyVvCuJz9vkap2E0YWZWU1XF+0XljYAkrAJBbwbrg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.5.tgz",
+      "integrity": "sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.7.1-dev.3",
+    "@unicitylabs/sphere-sdk": "0.7.2",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Updates `@unicitylabs/sphere-sdk` from `0.7.1-dev.3` to the released `0.7.2`.

## Changes
- `package.json` + `package-lock.json` bumped to `@unicitylabs/sphere-sdk@0.7.2`

## Verification
- `npm install` — clean
- `npx tsc --noEmit` — passes