### PR TITLE
fix(registry): resolve fresh-wallet token symbols without relogin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.8.0-dev.2",
+        "@unicitylabs/sphere-sdk": "0.8.0-dev.3",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2809,9 +2809,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.8.0-dev.2",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.2.tgz",
-      "integrity": "sha512-Pmxf7f3sDWcduSl72uI2lQf/QW8GkkrPc6sH9JSFnYuBFxJETMbEwZ89LOSHy1su7Rdb+2KceP0zHKPf8qFe7w==",
+      "version": "0.8.0-dev.3",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.3.tgz",
+      "integrity": "sha512-JeRSaZuxZFOa+xoBB4J+2+Lj0FOkjNOqAjzhMa5xMfGr1/OVgt/VFvUfS7SP4Vd9iyTl8s6RYoXymU5YB+H8jQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.8.0-dev.2",
+    "@unicitylabs/sphere-sdk": "0.8.0-dev.3",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/hooks/payments/useAssets.ts
+++ b/src/sdk/hooks/payments/useAssets.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSphereContext } from '../core/useSphere';
+import { useRegistryReady } from './useRegistryReady';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { TokenRegistry, toHumanReadable } from '@unicitylabs/sphere-sdk';
 import type { Asset } from '../..';
@@ -23,20 +24,7 @@ export interface UseAssetsReturn {
 
 export function useAssets(): UseAssetsReturn {
   const { sphere } = useSphereContext();
-  const [registryReady, setRegistryReady] = useState(
-    () => TokenRegistry.getInstance().getAllDefinitions().length > 0,
-  );
-
-  // Wait for TokenRegistry to load from remote, then trigger re-render
-  // so asset symbols get resolved from the registry.
-  useEffect(() => {
-    if (registryReady) return;
-    let cancelled = false;
-    TokenRegistry.waitForReady(15_000).then((loaded) => {
-      if (!cancelled && loaded) setRegistryReady(true);
-    });
-    return () => { cancelled = true; };
-  }, [registryReady]);
+  const registryReady = useRegistryReady();
 
   const query = useQuery({
     queryKey: SPHERE_KEYS.payments.assets.list,

--- a/src/sdk/hooks/payments/useRegistryReady.ts
+++ b/src/sdk/hooks/payments/useRegistryReady.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+
+/**
+ * Tracks whether the TokenRegistry has loaded its definitions, so symbol/decimals
+ * enrichment can run.
+ *
+ * Re-arms reliably: a slow or failed FIRST remote fetch (fresh wallet, no cache)
+ * must not leave the UI stuck on the coin-id fallback (e.g. "746A4E") until the
+ * user logs out and back in. The previous `waitForReady(15_000)` could resolve
+ * `false` on a slow first fetch and — with a `[registryReady]` dependency — never
+ * retry, even though the registry's background auto-refresh populates the data a
+ * few seconds later.
+ */
+export function useRegistryReady(): boolean {
+  const [registryReady, setRegistryReady] = useState(
+    () => TokenRegistry.getInstance().getAllDefinitions().length > 0,
+  );
+
+  useEffect(() => {
+    if (registryReady) return;
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | undefined;
+
+    const markIfLoaded = (): boolean => {
+      if (cancelled) return false;
+      if (TokenRegistry.getInstance().getAllDefinitions().length > 0) {
+        setRegistryReady(true);
+        return true;
+      }
+      return false;
+    };
+
+    // No timeout — wait for the real initial load (cache → remote). A slow first
+    // fetch must not make us give up.
+    TokenRegistry.waitForReady(0).then(() => {
+      if (markIfLoaded()) return;
+      // Initial load brought no data; the registry's background auto-refresh may
+      // still populate it — poll until it does.
+      interval = setInterval(() => {
+        if (markIfLoaded() && interval) clearInterval(interval);
+      }, 1000);
+    });
+
+    return () => {
+      cancelled = true;
+      if (interval) clearInterval(interval);
+    };
+  }, [registryReady]);
+
+  return registryReady;
+}

--- a/src/sdk/hooks/payments/useTokens.ts
+++ b/src/sdk/hooks/payments/useTokens.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSphereContext } from '../core/useSphere';
+import { useRegistryReady } from './useRegistryReady';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { TokenRegistry } from '@unicitylabs/sphere-sdk';
 import type { Token } from '@unicitylabs/sphere-sdk';
@@ -18,20 +19,7 @@ export interface UseTokensReturn {
 
 export function useTokens(): UseTokensReturn {
   const { sphere } = useSphereContext();
-  const [registryReady, setRegistryReady] = useState(
-    () => TokenRegistry.getInstance().getAllDefinitions().length > 0,
-  );
-
-  // Wait for TokenRegistry to load from remote, then trigger re-render
-  // so token symbols get resolved from the registry.
-  useEffect(() => {
-    if (registryReady) return;
-    let cancelled = false;
-    TokenRegistry.waitForReady(15_000).then((loaded) => {
-      if (!cancelled && loaded) setRegistryReady(true);
-    });
-    return () => { cancelled = true; };
-  }, [registryReady]);
+  const registryReady = useRegistryReady();
 
   const query = useQuery({
     queryKey: SPHERE_KEYS.payments.tokens.list,


### PR DESCRIPTION
## Problem

On a **fresh wallet** (no registry cache), a token that arrives immediately (mint/receive) shows the **raw coin-id fallback** (e.g. \`746A4E\`, raw \`1e18\` amount) instead of the registry symbol/decimals (ETH, 18). It only corrects after **logout → login**.

## Root cause (verified)

Two layers:
- **SDK** freezes the symbol into the stored token at creation when the registry is empty (`storeEngineToken` / `parseTokenInfo` → `getSymbol` fallback = `coinId.slice(0,6).toUpperCase()`), and `getAssets()` returns it verbatim — it never re-resolves. *(root-cause SDK fix is a separate follow-up; see below)*
- **App** compensates at display time via `registry.getDefinition()` in `useAssets`/`useTokens`, but only when `registryReady` is true. `registryReady` flipped via `TokenRegistry.waitForReady(15_000)`, which **resolves `false` on a slow first remote fetch** and — with a `[registryReady]` dependency — **never retries**, even though the registry's background auto-refresh populates the data seconds later. So the override never runs that session → fallback persists until relogin (relogin re-mounts with the registry already loaded).

## Fix (sphere-only, no SDK publish)

Extract a shared `useRegistryReady` hook used by both `useAssets` and `useTokens`:
- `waitForReady(0)` — wait for the **real** initial load (no premature timeout).
- If that brings no data, **poll** `getAllDefinitions().length > 0` until the background auto-refresh populates it, then flip `registryReady`.

The existing enrichment `useMemo` (dep `[query.data, registryReady]`) then re-runs and resolves symbol/decimals **in the same session** — no relogin.

## Follow-ups (separate, need SDK publish)
- SDK root cause: `aggregateTokens`/`getAssets` should re-resolve symbol from the registry at read time (or `storeEngineToken` should `await waitForReady(0)` before baking) so the frozen value is never wrong.
- SDK hardening: network-aware registry cache key (the global `TOKEN_REGISTRY_CACHE` can serve a stale cross-network registry).

## Test Plan
- [x] `tsc -b` clean
- [x] `eslint` clean on changed files
- [ ] live: fresh testnet2 wallet, mint/receive a token → symbol resolves to UCT/ETH without relogin