### PR TITLE
Disable Group Chat: hide desktop icon and block access

### DIFF
--- a/src/config/activities.ts
+++ b/src/config/activities.ts
@@ -27,6 +27,9 @@ export interface AgentConfig {
   requiresWallet?: boolean;
   iframeUrl?: string;
   iframeUrls?: { label: string; url: string }[];
+  // When false, the agent is disabled: it is excluded from the public `agents`
+  // list, so its desktop icon is not rendered and it cannot be opened/routed.
+  enabled?: boolean;
 }
 
 // All agents configuration
@@ -50,6 +53,8 @@ const allAgents: AgentConfig[] = [
     color: 'from-indigo-500 to-purple-500',
     type: 'chat',
     requiresWallet: true,
+    // Group Chat is currently disabled — hidden from the desktop and not openable.
+    enabled: false,
   },
   {
     id: 'custom',
@@ -62,7 +67,9 @@ const allAgents: AgentConfig[] = [
   },
 ];
 
-export const agents: AgentConfig[] = allAgents;
+// Only enabled agents are exposed: disabled ones (enabled === false) are
+// excluded everywhere — no desktop icon, and getAgentConfig() won't resolve them.
+export const agents: AgentConfig[] = allAgents.filter((a) => a.enabled !== false);
 
 // Get agent by ID
 export function getAgentConfig(agentId: string): AgentConfig | undefined {


### PR DESCRIPTION
## What

Disables the Group Chat agent in the wallet UI via a new `enabled` flag on `AgentConfig`.

- Add `enabled?: boolean` to `AgentConfig` (defaults to enabled when omitted).
- Set `enabled: false` on the `group-chat` agent.
- The exported `agents` list now filters out disabled agents: `allAgents.filter(a => a.enabled !== false)`.

## Effect

- The Group Chat desktop icon is no longer rendered — `useDesktopOrder` maps over the `agents` list.
- The agent can no longer be opened or routed — `getAgentConfig('group-chat')` returns `undefined`.
- Any previously-open group-chat tab is auto-removed on the next desktop load, since `useDesktopState` validates persisted tabs against `getAgentConfig`. As a result the `GroupChatSection` view (and its `useGroupChat` relay fetches) no longer mounts.

## Scope / note

This is a **UI-level disable only**. The SDK GroupChat module is still initialized (`groupChat: true` in `SphereProvider`) and `ServicesProvider` still connects it to NIP-29 relays in the background. To fully disable group chat at the SDK level (no relay connection at all), set `groupChat: false` in `SphereProvider` — intentionally left out of this PR.

## Verification

- `npx tsc --noEmit` — pass
- `npx eslint src/config/activities.ts` — pass
- Verified live via HMR: the Group Chat icon is removed from the desktop.