### PR TITLE
fix: pass network to Sphere.init so the registry loads testnet2 (icons regression)

### DIFF
--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -159,6 +159,7 @@ export function SphereProvider({
         setInitProgress({ step: 'initializing', message: 'Loading wallet...' });
         const { sphere: instance } = await Sphere.init({
           ...browserProviders,
+          network, // ensure the SDK configures TokenRegistry for THIS network (not the testnet default)
           l1: {},
           discoverAddresses: false, // Run separately below for UX
           onProgress: setInitProgress,
@@ -236,6 +237,7 @@ export function SphereProvider({
         setInitProgress({ step: 'initializing', message: 'Creating wallet...' });
         const { sphere: instance, generatedMnemonic } = await Sphere.init({
           ...providers,
+          network,
           autoGenerate: true,
           nametag: options?.nametag,
           l1: {},
@@ -259,7 +261,7 @@ export function SphereProvider({
         throw err;
       }
     },
-    [providers],
+    [providers, network],
   );
 
   const resolveNametag = useCallback(


### PR DESCRIPTION
## Problem

On v2/testnet2, token icons rendered as the generic Box on first load (symbols/amounts were correct). A **page reload made them appear**. v1 had no such issue.

## Root cause

`SphereProvider` configures the app-bundle `TokenRegistry` for **testnet2** (`TokenRegistry.configure({ remoteUrl: NETWORKS[network].tokenRegistryUrl })`), but it did **NOT pass `network` to `Sphere.init`**. The SDK's `Sphere.init` → `configureTokenRegistry(storage, options.network)` defaults to `NETWORKS.testnet` when `network` is `undefined` (sphere-sdk `core/Sphere.ts:782`), re-configuring the **same main-bundle singleton** with the **old testnet** registry.

So the registry used by `useAssets`/`AssetRow` ended up on testnet → `getDefinition(<testnet2 coinId>)` returned `null` → `getIconUrl` → `null` → `<Box>`. Symbols still showed because they were baked into the token at mint (when testnet2 was momentarily active). A reload masked it because the global registry cache served the eventually-correct data.

## Fix (sphere-only, no SDK publish)

Pass `network` to `Sphere.init` on the **load** and **create** paths, so the SDK configures `TokenRegistry` for testnet2 from the start. Added `network` to the `createWallet` `useCallback` deps.

## Follow-ups (SDK, separate PR + publish)
- `Sphere.import` / `Sphere.importFromLegacyFile` also need this, but `SphereImportOptions` has no `network` field (the SDK already reads `options.network` in `configureTokenRegistry`). Add `network?: NetworkType` to `SphereImportOptions` so the **re-import path** (the cutover flow) configures testnet2 too.
- `storeEngineToken` does not persist `iconUrl` to the stored Token (v1's `saveCommitmentOnlyToken` did) — sphere currently re-derives it via registry enrichment, but persisting it is more robust.

## Test Plan
- [x] `tsc -b` clean
- [x] `eslint` clean
- [ ] live: fresh load on testnet2 → token icons render WITHOUT a page reload