### PR TITLE
fix(sphere): pass network to Sphere.import/importFromLegacyFile + bump SDK to dev.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.8.0-dev.3",
+        "@unicitylabs/sphere-sdk": "^0.8.0-dev.4",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -1343,62 +1343,90 @@
       "optional": true
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.13.tgz",
-      "integrity": "sha512-8NN9cQP3jDn+p9+QE9ByiEoZ2lemDFf/unTgiKmS3JF93ph240EUVdbCyyEgOMfykzb0okTM4gzvwfx9osJebQ==",
+      "version": "5.1.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.19.tgz",
+      "integrity": "sha512-hYNeHQpUSwLPopWCgDf6OklOvVwJPS/vYZOiBG3VXPIzx5AkONBOfdkgVwB4YsIBH2V6z+TMgMH0yXUZsMurPA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.1.0",
+        "@libp2p/interface": "^3.2.3",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
-        "multiformats": "^13.4.0",
-        "protons-runtime": "^5.6.0",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^6.0.1",
         "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
+        "uint8arrays": "^6.1.1"
       }
     },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/@libp2p/interface": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.1.0.tgz",
-      "integrity": "sha512-RE7/XyvC47fQBe1cHxhMvepYKa5bFCUyFrrpj8PuM0E7JtzxU7F+Du5j4VXbg2yLDcToe0+j8mB7jvwE2AThYw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.3.tgz",
+      "integrity": "sha512-OKZFrY+x8IYl4Fr/YWjh4s6+uks5zQBIAdg2cl+zaRUpPORfk1ELI4r+eB+fUlXR9mHDsQylSSzmAqi0drDfiA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
         "@multiformats/dns": "^1.0.6",
-        "@multiformats/multiaddr": "^13.0.1",
+        "@multiformats/multiaddr": "^13.0.3",
         "main-event": "^1.0.1",
-        "multiformats": "^13.4.0",
-        "progress-events": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
         "uint8arraylist": "^2.4.8"
       }
     },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/@libp2p/logger": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.2.tgz",
-      "integrity": "sha512-XtanXDT+TuMuZoCK760HGV1AmJsZbwAw5AiRUxWDbsZPwAroYq64nb41AHRu9Gyc0TK9YD+p72+5+FIxbw0hzw==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.8.tgz",
+      "integrity": "sha512-oPTkWJhYvhk8fjInH1ySyUDC/LLuqHsVqpNprtImd/64lnRHInV0EbwpRYwjdPNXAxYXDU/eQJzyqMWUNnN4+A==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.1.0",
-        "@multiformats/multiaddr": "^13.0.1",
+        "@libp2p/interface": "^3.2.3",
+        "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^9.0.1",
-        "multiformats": "^13.4.0",
+        "multiformats": "^14.0.0",
         "weald": "^1.1.0"
       }
     },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/@libp2p/peer-id": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.4.tgz",
-      "integrity": "sha512-Z3xK0lwwKn4bPg3ozEpPr1HxsRi2CxZdghOL+MXoFah/8uhJJHxHFA8A/jxtKn4BB8xkk6F8R5vKNIS05yaCYw==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.10.tgz",
+      "integrity": "sha512-FgXeraxl932zim/K+vipCkscjLNMsyNVBh1NpGcJ+y8DQi/jgFXV4YZ0M2JuWM20GTcVCqDT5P10A0DJHRjecg==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/interface": "^3.1.0",
-        "multiformats": "^13.4.0",
-        "uint8arrays": "^5.1.0"
+        "@libp2p/crypto": "^5.1.19",
+        "@libp2p/interface": "^3.2.3",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
       }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/@mixpanel/rrdom": {
       "version": "2.0.0-alpha.18.4",
@@ -1471,18 +1499,35 @@
         "uint8arrays": "^5.0.2"
       }
     },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/@multiformats/multiaddr": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.1.tgz",
-      "integrity": "sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
-        "multiformats": "^13.0.0",
-        "uint8-varint": "^2.0.1",
-        "uint8arrays": "^5.0.0"
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
       }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -1497,12 +1542,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
-      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1"
+        "@noble/hashes": "2.2.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -1512,9 +1557,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -2809,9 +2854,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.8.0-dev.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.3.tgz",
-      "integrity": "sha512-JeRSaZuxZFOa+xoBB4J+2+Lj0FOkjNOqAjzhMa5xMfGr1/OVgt/VFvUfS7SP4Vd9iyTl8s6RYoXymU5YB+H8jQ==",
+      "version": "0.8.0-dev.4",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.4.tgz",
+      "integrity": "sha512-qNNXHpYLuCZXacG/Dn7WvMX0+5sqjeVzdVA6vz8sUJ07+KpVJ5+zR8S6r/twuraK6qx21mB2WjTFVr03K/oZLg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",
@@ -2934,6 +2979,33 @@
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "uuid": "13.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3666,9 +3738,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
-      "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
+      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -4972,9 +5044,9 @@
       "license": "ISC"
     },
     "node_modules/interface-datastore": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.2.tgz",
-      "integrity": "sha512-jebn+GV/5LTDDoyicNIB4D9O0QszpPqT09Z/MpEWvf3RekjVKpXJCDguM5Au2fwIFxFDAQMZe5bSla0jMamCNg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
@@ -4982,30 +5054,50 @@
         "uint8arrays": "^5.1.0"
       }
     },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/interface-store": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.1.tgz",
-      "integrity": "sha512-OPRRUO3Cs6Jr/t98BrJLQp1jUTPgrRH0PqFfuNoPAqd+J7ABN1tjFVjQdaOBiybYJTS/AyBSZnZVWLPvp3dW3w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
     "node_modules/ipns": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.3.tgz",
-      "integrity": "sha512-b2Zeh8+7qOV11NjnTsYLpG8K6T13uBMndpzk9N9E2Qjz/u80qsxvKpspSP32sErOLr/GWjdFVVc02E9PMojQNA==",
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
         "@libp2p/crypto": "^5.0.0",
         "@libp2p/interface": "^3.0.2",
         "@libp2p/logger": "^6.0.4",
-        "cborg": "^4.2.3",
+        "cborg": "^5.1.0",
         "interface-datastore": "^9.0.2",
         "multiformats": "^13.2.2",
-        "protons-runtime": "^5.5.0",
+        "protons-runtime": "^6.0.1",
         "timestamp-nano": "^1.0.1",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -5342,9 +5434,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.5.tgz",
-      "integrity": "sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -5670,9 +5762,9 @@
       }
     },
     "node_modules/main-event": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.1.tgz",
-      "integrity": "sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
@@ -6035,13 +6127,13 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
-      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "eventemitter3": "^5.0.1",
+        "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
       },
       "engines": {
@@ -6299,9 +6391,9 @@
       "license": "MIT"
     },
     "node_modules/progress-events": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
-      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
@@ -6323,15 +6415,36 @@
       "license": "MIT"
     },
     "node_modules/protons-runtime": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.6.0.tgz",
-      "integrity": "sha512-/Kde+sB9DsMFrddJT/UZWe6XqvL7SL5dbag/DBCElFKhkwDj7XKt53S+mzLyaDP5OqS0wXjV5SA572uWDaT0Hg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "uint8-varint": "^2.0.2",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.1"
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/protons-runtime/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/public-encrypt": {
@@ -6948,33 +7061,6 @@
         "uuid": "14.0.0"
       }
     },
-    "node_modules/state-transition-sdk-v2/node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "2.2.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/state-transition-sdk-v2/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/state-transition-sdk-v2/node_modules/uuid": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
@@ -7315,35 +7401,62 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
-      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.0"
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/uint8arraylist": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
-      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
         "uint8arrays": "^5.0.1"
       }
     },
-    "node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
         "multiformats": "^13.0.0"
       }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -7650,24 +7763,24 @@
       }
     },
     "node_modules/weald": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.1.tgz",
-      "integrity": "sha512-PaEQShzMCz8J/AD2N3dJMc1hTZWkJeLKS2NMeiVkV5KDHwgZe7qXLEzyodsT/SODxWDdXJJqocuwf3kHzcXhSQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "ms": "^3.0.0-canary.1",
+        "ms": "^4.0.0-nightly.202508271359",
         "supports-color": "^10.0.0"
       }
     },
     "node_modules/weald/node_modules/ms": {
-      "version": "3.0.0-canary.202508261828",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.202508261828.tgz",
-      "integrity": "sha512-NotsCoUCIUkojWCzQff4ttdCfIPoA1UGZsyQbi7KmqkNRfKCrvga8JJi2PknHymHOuor0cJSn/ylj52Cbt2IrQ==",
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/weald/node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.8.0-dev.3",
+    "@unicitylabs/sphere-sdk": "^0.8.0-dev.4",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -302,6 +302,7 @@ export function SphereProvider({
       setInitProgress({ step: 'initializing', message: 'Importing wallet...' });
       const instance = await Sphere.import({
         ...providers,
+        network,
         mnemonic,
         nametag: options?.nametag,
         l1: {},
@@ -313,7 +314,7 @@ export function SphereProvider({
       // finalizeWallet(sphere) after address selection / nametag are done.
       return instance;
     },
-    [providers],
+    [providers, network],
   );
 
   const importFromFile = useCallback(
@@ -325,6 +326,7 @@ export function SphereProvider({
         setInitProgress({ step: 'initializing', message: 'Importing file...' });
         const result = await Sphere.importFromLegacyFile({
           ...providers,
+          network,
           fileContent: options.fileContent,
           fileName: options.fileName,
           password: options.password,
@@ -355,7 +357,7 @@ export function SphereProvider({
         };
       }
     },
-    [providers],
+    [providers, network],
   );
 
   const deleteWallet = useCallback(async () => {


### PR DESCRIPTION
Follow-up to #340 (which was merged with only the `Sphere.init` network forwarding). This adds the missing piece: `network` passed to `Sphere.import` and `Sphere.importFromLegacyFile`, plus the SDK bump to `0.8.0-dev.4`.

## Why
On the integration branch, `Sphere.import`/`importFromLegacyFile` do NOT pass `network`, so wallet import loads the **testnet** registry instead of **testnet2** (the same wrong-network/missing-icons class the init fix addressed). `SphereImportOptions.network` exists since SDK dev.4, so this compiles + works against dev.4.

It also makes sphere compatible with the SDK fail-loud change (sphere-sdk#469): every Sphere entry point now passes `network`, so once sphere is on a #469-containing SDK build, import won't throw `INVALID_CONFIG`.

## Coverage (all 5 entry points pass network)
`createBrowserProviders` (134), `Sphere.init` load (162) + create (240), `Sphere.import` (305), `Sphere.importFromLegacyFile` (329).

## Verification
- [x] `tsc -b` clean, `eslint` clean
- [x] `npm run build` green (exit 0) against `@unicitylabs/sphere-sdk@0.8.0-dev.4`

Note: when SDK #469 is published as dev.5, bump this pin to dev.5 for the fail-loud safety net (one-line follow-up).