### PR TITLE
chore(sphere): bump sphere-sdk to 0.8.0-dev.5 (fail-loud network)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.8.0-dev.4",
+        "@unicitylabs/sphere-sdk": "^0.8.0-dev.5",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2854,9 +2854,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.8.0-dev.4",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.4.tgz",
-      "integrity": "sha512-qNNXHpYLuCZXacG/Dn7WvMX0+5sqjeVzdVA6vz8sUJ07+KpVJ5+zR8S6r/twuraK6qx21mB2WjTFVr03K/oZLg==",
+      "version": "0.8.0-dev.5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.5.tgz",
+      "integrity": "sha512-2sN/Ys6GEh/chRVDiN8lAYpb6X4qtpx1HiXh76AivNcBv9pck5G0BxMrMImxV8i6GitlR+c1hj7tdWZn1WonRw==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.8.0-dev.4",
+    "@unicitylabs/sphere-sdk": "^0.8.0-dev.5",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Bumps `@unicitylabs/sphere-sdk` 0.8.0-dev.4 → **0.8.0-dev.5**.

dev.5 = dev.4 + fail-loud network requirement (sphere-sdk#469) + integration test fixes / shared `TEST_NETWORK` constant (#470) + Phase 1 regression tests (#467).

sphere already passes `network` at every Sphere entry point (init/create/load via earlier work, import/importFromLegacyFile via #341), so it is fully compatible with the fail-loud SDK — no `INVALID_CONFIG` at runtime.

## Verification (against the published dev.5)
- [x] dev.5 installed; confirmed it contains the fail-loud throw + `SphereImportOptions.network`
- [x] `tsc -b` → exit 0
- [x] `npm run build` → green (✓ built in 14s, 3328 modules)