### PR TITLE
fix(wallet): disable group chat (NIP-29) at SDK init

### DIFF
--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -136,7 +136,9 @@ export function SphereProvider({
         // testnet2 network preset; only the apiKey is injected (non-secret on testnet2).
         oracle: { apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY },
         price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
-        groupChat: true,
+        // Group chat (NIP-29) is disabled: the UI is already hidden (PR #339), and
+        // skipping the module here stops the SDK from connecting to NIP-29 relays.
+        groupChat: false,
         market: true,
         ...getIpfsConfig(),
       });


### PR DESCRIPTION
## What

Disable the Group Chat (NIP-29) module at SDK initialization by passing
`groupChat: false` to `createBrowserProviders` in `SphereProvider`.

## Why

Group Chat UI access was already hidden in #339 (desktop icon removed,
activity blocked). However, the SDK still **loaded the GroupChat module and
connected to NIP-29 relays** on every wallet init — wasted relay connections
and background traffic for a feature users can't reach.

## How

`createBrowserProviders({ groupChat: false })` → `resolveGroupChatConfig`
returns `undefined` → `Sphere.init` never creates the module
(`_groupChat = null`). `sphere.groupChat` then resolves to `null`, and every
consumer already guards against that case:

- `ServicesProvider` — `const groupChat = sphere?.groupChat ?? null;` (effect returns early)
- `useGroupChat` / `useGroupUnreadCount` — all paths guard with `if (!groupChat)`

So no relay connection is opened and nothing else changes at runtime.

## Verification

- `tsc -b` — passes
- `eslint src/sdk/SphereProvider.tsx` — clean

## Base

Targets the migration integration branch `feat/sdk-migration-v2` (where the
related Group Chat / SDK-dev work lives), consistent with #339–#342.
