### PR TITLE
chore(sphere): bump sphere-sdk to 0.8.0-dev.6 (per-network storage isolation)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.8.0-dev.5",
+        "@unicitylabs/sphere-sdk": "^0.8.0-dev.6",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2854,9 +2854,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.8.0-dev.5",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.5.tgz",
-      "integrity": "sha512-2sN/Ys6GEh/chRVDiN8lAYpb6X4qtpx1HiXh76AivNcBv9pck5G0BxMrMImxV8i6GitlR+c1hj7tdWZn1WonRw==",
+      "version": "0.8.0-dev.6",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.8.0-dev.6.tgz",
+      "integrity": "sha512-yj0bj2SWXeHyllCnNNH4l9kmVahVUGt3FVhjmRSwy/E3qWgIlp8bMikAoTiRL8faoNxGjxPV4DRfm/HaGOMF4A==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.8.0-dev.5",
+    "@unicitylabs/sphere-sdk": "^0.8.0-dev.6",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -386,8 +386,22 @@ export function SphereProvider({
           tokenStorage: providers.tokenStorage,
         });
       } catch (err) {
-        logger.warn('SphereProvider', 'Sphere.clear() failed, deleting IndexedDB directly', err);
-        // Fallback: nuke the IndexedDB databases directly
+        logger.warn('SphereProvider', 'Sphere.clear() failed, sweeping IndexedDB directly', err);
+      }
+      // Sweep ALL Sphere IndexedDB databases by prefix. The token DB is now per-network
+      // (sphere-token-storage-{network}-{chainPubkey}), so a fixed-name delete would miss
+      // both the active per-network DB and any orphaned-network DBs. Run this always (not
+      // just on clear() failure): Sphere.clear() closes its own handles, so deletion is not
+      // blocked. Falls back to the known base names where indexedDB.databases() is missing.
+      try {
+        const dbs = (await indexedDB.databases?.()) ?? [];
+        const toDelete = dbs
+          .map((d) => d.name)
+          .filter((n): n is string => !!n && (n === 'sphere-storage' || n.startsWith('sphere-token-storage')));
+        for (const name of toDelete) {
+          try { indexedDB.deleteDatabase(name); } catch { /* best effort */ }
+        }
+      } catch {
         for (const dbName of ['sphere-storage', 'sphere-token-storage']) {
           try { indexedDB.deleteDatabase(dbName); } catch { /* best effort */ }
         }


### PR DESCRIPTION
## Summary
Bumps `@unicitylabs/sphere-sdk` `0.8.0-dev.5` → `0.8.0-dev.6` and adapts wallet deletion to the SDK's new per-network token storage. dev.6 makes wallet storage fully **per-network**, so testnet2 (v2) state can never share a token DB / KV / IPNS with testnet (v1).

## SDK dev.6 (what changed under the hood)
- Token DB: `sphere-token-storage-{network}-{chainPubkey}` (was `sphere-token-storage-{addressId}`).
- KV: token/payment per-address keys network-scoped; chat + seed keys stay shared.
- IPNS: per-network HKDF (`ipfs-storage-ed25519-v1:{network}`).
- Storage identifier: full `chainPubkey` (not the truncated `getAddressId`).

## Changes here
1. **Bump** sphere-sdk → 0.8.0-dev.6 (package.json + lock). `network="testnet2"` is already threaded through every Sphere entry point (main.tsx + SphereProvider), so per-network storage engages automatically.
2. **fix(wallet): delete-wallet sweep.** The token DB is now per-network, so the old hardcoded fallback `['sphere-storage','sphere-token-storage']` missed the active DB and orphaned-network DBs. Now enumerates `indexedDB.databases()` and deletes `sphere-storage` + every `sphere-token-storage*` by prefix (always-run; `Sphere.clear()` closes its own handles so deletion isn't blocked), with a base-name fallback where `databases()` is unavailable.

## Audited (multi-agent) — sphere otherwise CLEAN for this SDK update
- Provider wiring: `network='testnet2'` threaded through `createBrowserProviders` + all 4 Sphere entry points. No gap.
- No hand-rolled SDK DB names / storage keys anywhere else in `src/` (chat `buildAddressId` is a local React-Query/localStorage key, not SDK storage; unaffected).
- IPNS/IPFS fully delegated to the SDK (only a boolean `sphere_ipfs_enabled` flag persisted); onboarding `ipnsName`/`ipnsLoading` fields are vestigial dead UI.

## ⚠️ Fresh-start cutover (expected, no code change)
The KV DB `sphere-storage` (mnemonic) is network-agnostic, so `Sphere.exists()` stays true for returning testers — but the active token DB moved to the new per-network name, so a returning **testnet2** tester (dev.5→dev.6, same network) lands on an **empty** inventory; old tokens sit in the orphaned non-network `sphere-token-storage`. **Identity + XP are preserved** (`deriveDirectAddress` takes only chainPubkey → byte-identical DIRECT:// address). Per the fresh-start policy (no real testnet2 users yet) the resolution is **re-top-up on testnet2**. A one-time "migrated — re-top-up" notice can be added later if desired.

## Out of scope (separate, pre-existing)
Cross-device IPFS sync reliability (IPNS-over-gateway propagation/caching can be slow or "work intermittently" on first cross-device pull) is inherent to IPNS and unchanged by the per-network rename (publish/resolve/subscribe all use the same derived per-network name). Tracked as a future IPFS-sync hardening effort (push-sync reliability, cache-busting resolve, sequence-aware retry).