### PR TITLE
wallet-api integration (S4): provider swap, auth lifecycle, module-routed payment requests, two-profile smoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,23 @@ VITE_SPHERE_API_URL=http://localhost:3001
 # For mainnet this MUST be a real secret: set it only in the deploy env, never commit it.
 VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 
+# wallet-api backend (S4 provider swap). When set, the ASSET path rides the
+# wallet-api backend (server inventory custody + mailbox delivery + §16
+# payment requests); messaging/DMs/nametags stay on Nostr. Unset → the legacy
+# local-custody composition. Relative values resolve against the app origin
+# and are served by the dev/preview proxy, which forwards them to
+# WALLET_API_PROXY_TARGET (default http://127.0.0.1:3000 — the wallet-api
+# repo's `docker compose -f docker-compose.dev.yml up --build --wait` stack).
+VITE_WALLET_API_URL=/wallet-api
+
+# LOCAL dev-stack engine override (used by the two-profile smoke): point the
+# v2 token engine at the mock aggregator AND the trustbase that same gateway
+# serves. Set BOTH or neither — never mix a gateway with another network's
+# trustbase. Relative values ride the dev/preview proxy
+# (AGGREGATOR_PROXY_TARGET, default http://127.0.0.1:3001).
+#VITE_AGGREGATOR_URL=/local-agg
+#VITE_TRUSTBASE_URL=/local-agg/trustbase.json
+
 # Welcome DM
 VITE_WELCOME_AGENT_NAMETAG=kbbot
 VITE_WELCOME_DELAY_MS=4000

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist-ssr
 *.local
 agentic-chatbot-main
 
+# Playwright artifacts (two-profile smoke)
+test-results
+playwright-report
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.9.0-dev.0",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@types/crypto-js": "^4.2.2",
@@ -1485,6 +1486,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2739,14 +2756,16 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.0-dev.0.tgz",
-      "integrity": "sha512-yjRmXEpjS7B2vBnPixqJSXv0zPX2x5IEy4c7LBy+ujvxTUKB6U4Y/DQuEVC9LDT5EhVeAgYoL9rwT3xCxac7Mw==",
+      "version": "0.9.1-dev.7",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.7.tgz",
+      "integrity": "sha512-Ht1+/cvS/sxK8+CG50cR8ksv4J/F8EA6PScO+o5FOqwz5gvL22gi+CxkJbpqcxPYMEZPamAOJw+Pi5ofg7TSOA==",
+      "license": "MIT",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@unicitylabs/nostr-js-sdk": "^0.5.0",
-        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
@@ -2785,6 +2804,18 @@
         "ws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@unicitylabs/sphere-sdk/node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
@@ -2854,9 +2885,10 @@
       "license": "MIT"
     },
     "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.0-rc.6027e82",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.6027e82.tgz",
-      "integrity": "sha512-PV6lHwJOCjpICG0Vd7Ty+5mZa7migGtopa1QVBjp9xRRtfNXDAvf8YPzXE6PQOtKCVP5ymmKuWKRKkNoNOw2zA==",
+      "version": "2.0.0-rc.68bc1e5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
+      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
+      "license": "ISC",
       "dependencies": {
         "@noble/curves": "2.2.0",
         "@noble/hashes": "2.2.0",
@@ -2874,6 +2906,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
@@ -6120,6 +6153,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -19,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.9.0-dev.0",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@types/crypto-js": "^4.2.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+/**
+ * Playwright config for the two-profile wallet-api smoke (LOCAL-ONLY).
+ *
+ * Requires the wallet-api dev stack (postgres + redis + minio + mock
+ * aggregator + wallet-api) running on the default loopback ports:
+ *
+ *   cd ../wallet-api && docker compose -f docker-compose.dev.yml up --build --wait
+ *   npm run test:e2e
+ *
+ * NOT part of CI (`.github/workflows/ci.yml` runs lint/unit/build only) —
+ * it needs docker and reaches public Nostr relays for nametag bindings.
+ *
+ * The app is built with the smoke env (wallet-api + LOCAL mock aggregator +
+ * the trustbase that same aggregator serves — never mix trustbases) and
+ * served by `vite preview`, whose proxy provides the same-origin route to
+ * the stack. Set SMOKE_BASE_URL to reuse an already-running dev server
+ * (e.g. `VITE_WALLET_API_URL=/wallet-api ... npm run dev`) while iterating.
+ */
+import { defineConfig } from '@playwright/test';
+
+const PORT = 4317;
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 600_000,
+  expect: { timeout: 30_000 },
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.SMOKE_BASE_URL || `http://localhost:${PORT}`,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: process.env.SMOKE_BASE_URL
+    ? undefined
+    : {
+        command: `npm run build && npx vite preview --port ${PORT} --strictPort`,
+        url: `http://localhost:${PORT}`,
+        reuseExistingServer: false,
+        timeout: 240_000,
+        env: {
+          VITE_WALLET_API_URL: '/wallet-api',
+          VITE_AGGREGATOR_URL: '/local-agg',
+          VITE_TRUSTBASE_URL: '/local-agg/trustbase.json',
+          // Keep the sphere-quest marketplace off the mock aggregator's port
+          // (its default base URL collides with :3001 on the dev stack).
+          VITE_SPHERE_API_URL: 'http://127.0.0.1:1',
+        },
+      },
+});

--- a/src/components/layout/IpfsSyncIndicator.tsx
+++ b/src/components/layout/IpfsSyncIndicator.tsx
@@ -16,13 +16,17 @@ function getStatusText(
 }
 
 export function IpfsSyncIndicator() {
-  const { ipfsEnabled, toggleIpfs } = useSphereContext();
+  const { ipfsEnabled, toggleIpfs, walletApiEnabled } = useSphereContext();
   const { status, lastSynced } = useIpfsSync();
   const isSyncing = ipfsEnabled && status === 'syncing';
   const isError = ipfsEnabled && status === 'error';
   const statusText = getStatusText(ipfsEnabled, status, lastSynced);
 
   const iconClass = 'w-4 h-4 sm:w-5 sm:h-5';
+
+  // wallet-api custody (S4): IPFS token sync is forced off in SphereProvider —
+  // hide the toggle so it cannot suggest a second token mirror exists.
+  if (walletApiEnabled) return null;
 
   return (
     <HeaderTooltip label={ipfsEnabled ? 'Disable IPFS sync' : 'Enable IPFS sync'}>

--- a/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
+++ b/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
@@ -6,10 +6,21 @@ export const PaymentRequestStatus = {
     PENDING: 'PENDING',
     ACCEPTED: 'ACCEPTED',
     REJECTED: 'REJECTED',
-    PAID: 'PAID'
+    PAID: 'PAID',
+    // Backend model is open → paid | declined | expired (§16): a stale request
+    // can expire server-side; a pay/reject attempt on it surfaces a 409.
+    EXPIRED: 'EXPIRED'
 } as const;
 
 export type PaymentRequestStatus = typeof PaymentRequestStatus[keyof typeof PaymentRequestStatus];
+
+const STATUS_MAP: Record<SDKPaymentRequest['status'], PaymentRequestStatus> = {
+    pending: PaymentRequestStatus.PENDING,
+    accepted: PaymentRequestStatus.ACCEPTED,
+    rejected: PaymentRequestStatus.REJECTED,
+    paid: PaymentRequestStatus.PAID,
+    expired: PaymentRequestStatus.EXPIRED,
+};
 
 export interface IncomingPaymentRequest {
     id: string;
@@ -37,70 +48,89 @@ function bridgeRequest(sdk: SDKPaymentRequest): IncomingPaymentRequest {
         recipientNametag: sdk.senderNametag ?? '',
         requestId: sdk.requestId,
         timestamp: sdk.timestamp,
-        status: PaymentRequestStatus.PENDING,
+        status: STATUS_MAP[sdk.status] ?? PaymentRequestStatus.PENDING,
     };
 }
 
+/**
+ * Incoming payment requests, driven by the PaymentsModule (the SDK list is
+ * the source of truth — statuses are read back after every action, never
+ * flipped optimistically):
+ *
+ * - `accept` — local status only; the wallet-api backend has no 'accepted'
+ *   state (§16 models open → paid | declined | expired), so the requester is
+ *   NOT notified until the request is actually paid.
+ * - `reject` — server-confirmed on the wallet-api path: the §16 'declined'
+ *   respond happens BEFORE the local flip, and a server rejection (403
+ *   non-addressee / 409 non-open, e.g. expired) propagates to the caller —
+ *   surface it, the local status stays pending.
+ * - `pay` — `payments.payPaymentRequest`: sends the transfer, then links the
+ *   transferId in the 'paid' respond. A failed respond after a successful
+ *   send is logged by the SDK, never reported as a payment failure.
+ */
 export const useIncomingPaymentRequests = () => {
     const { sphere } = useSphereContext();
     const [requests, setRequests] = useState<IncomingPaymentRequest[]>([]);
 
-    useEffect(() => {
+    const refresh = useCallback(() => {
         if (!sphere) return;
+        setRequests(sphere.payments.getPaymentRequests().map(bridgeRequest));
+    }, [sphere]);
 
-        const handler = (sdkReq: SDKPaymentRequest) => {
-            setRequests(prev => [...prev, bridgeRequest(sdkReq)]);
-        };
+    useEffect(() => {
+        if (!sphere) {
+            setRequests([]);
+            return;
+        }
 
+        // Seed from the module: requests that arrived before this hook
+        // mounted (e.g. the wallet-api sign-in backfill) are not re-emitted.
+        refresh();
+
+        const handler = () => refresh();
         sphere.on('payment_request:incoming', handler);
-
         return () => {
             sphere.off('payment_request:incoming', handler);
         };
-    }, [sphere]);
-
-    const updateStatus = useCallback(async (
-        request: IncomingPaymentRequest,
-        status: typeof PaymentRequestStatus[keyof typeof PaymentRequestStatus],
-        responseType: 'accepted' | 'rejected' | 'paid',
-    ) => {
-        if (!sphere) return;
-        const transport = sphere.getTransport();
-        if (transport.sendPaymentRequestResponse) {
-            await transport.sendPaymentRequestResponse(request.senderPubkey, {
-                requestId: request.requestId,
-                responseType,
-            });
-        }
-        setRequests(prev =>
-            prev.map(r => r.id === request.id ? { ...r, status } : r)
-        );
-    }, [sphere]);
+    }, [sphere, refresh]);
 
     const pendingCount = useMemo(
         () => requests.filter(r => r.status === PaymentRequestStatus.PENDING).length,
         [requests],
     );
 
-    const accept = useCallback(
-        (request: IncomingPaymentRequest) => updateStatus(request, PaymentRequestStatus.ACCEPTED, 'accepted'),
-        [updateStatus],
-    );
+    const accept = useCallback(async (request: IncomingPaymentRequest) => {
+        if (!sphere) return;
+        try {
+            await sphere.payments.acceptPaymentRequest(request.id);
+        } finally {
+            refresh();
+        }
+    }, [sphere, refresh]);
 
-    const reject = useCallback(
-        (request: IncomingPaymentRequest) => updateStatus(request, PaymentRequestStatus.REJECTED, 'rejected'),
-        [updateStatus],
-    );
+    const reject = useCallback(async (request: IncomingPaymentRequest) => {
+        if (!sphere) return;
+        try {
+            await sphere.payments.rejectPaymentRequest(request.id);
+        } finally {
+            refresh();
+        }
+    }, [sphere, refresh]);
 
-    const paid = useCallback(
-        (request: IncomingPaymentRequest) => updateStatus(request, PaymentRequestStatus.PAID, 'paid'),
-        [updateStatus],
-    );
+    const pay = useCallback(async (request: IncomingPaymentRequest) => {
+        if (!sphere) return;
+        try {
+            await sphere.payments.payPaymentRequest(request.id);
+        } finally {
+            refresh();
+        }
+    }, [sphere, refresh]);
 
-    const clearProcessed = useCallback(
-        () => setRequests(prev => prev.filter(r => r.status === PaymentRequestStatus.PENDING)),
-        [],
-    );
+    const clearProcessed = useCallback(() => {
+        if (!sphere) return;
+        sphere.payments.clearProcessedPaymentRequests();
+        refresh();
+    }, [sphere, refresh]);
 
-    return { requests, pendingCount, accept, reject, paid, clearProcessed };
+    return { requests, pendingCount, accept, reject, pay, clearProcessed };
 };

--- a/src/components/wallet/L3/modals/PaymentRequestModal.tsx
+++ b/src/components/wallet/L3/modals/PaymentRequestModal.tsx
@@ -1,6 +1,5 @@
 import { Check, Sparkles, Trash2, Loader2, XIcon, ArrowRight, Clock, Receipt, AlertCircle } from 'lucide-react';
 import { type IncomingPaymentRequest, PaymentRequestStatus } from '../hooks/useIncomingPaymentRequests';
-import { useTransfer } from '../../../../sdk';
 import { getErrorMessage } from '../../../../sdk/errors';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
@@ -13,13 +12,14 @@ interface PaymentRequestsModalProps {
   onClose: () => void;
   requests: IncomingPaymentRequest[];
   pendingCount: number;
+  /** Server-confirmed on wallet-api — 403/409 rejections throw and are surfaced here. */
   reject: (request: IncomingPaymentRequest) => Promise<void>;
-  paid: (request: IncomingPaymentRequest) => Promise<void>;
+  /** Pays via payments.payPaymentRequest (send + linked 'paid' respond). */
+  pay: (request: IncomingPaymentRequest) => Promise<void>;
   clearProcessed: () => void;
 }
 
-export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, reject, clearProcessed, paid }: PaymentRequestsModalProps) {
-  const { transfer } = useTransfer();
+export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, reject, clearProcessed, pay }: PaymentRequestsModalProps) {
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -33,18 +33,14 @@ export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, 
     }
   };
 
-  const handlePay = async (req: IncomingPaymentRequest) => {
+  /** Run a request action; failures (e.g. 403/409 on reject, send failures
+   *  on pay) land in the per-request error slot — never silent, never an
+   *  optimistic status flip. */
+  const handleAction = async (req: IncomingPaymentRequest, action: (r: IncomingPaymentRequest) => Promise<void>) => {
     setProcessingId(req.id);
     setErrors(prev => ({ ...prev, [req.id]: '' }));
     try {
-      const recipient = req.recipientNametag ? `@${req.recipientNametag}` : req.senderPubkey;
-      if (import.meta.env.DEV) console.log(`Initiating payment for request ${req.requestId} to ${recipient}`);
-      await transfer({
-        recipient,
-        amount: req.amount.toString(),
-        coinId: req.coinId,
-      });
-      paid(req);
+      await action(req);
     } catch (error: unknown) {
       setErrors(prev => ({ ...prev, [req.id]: getErrorMessage(error) }));
     } finally {
@@ -90,8 +86,8 @@ export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, 
                 key={req.id}
                 req={req}
                 error={errors[req.id]}
-                onPay={() => handlePay(req)}
-                onReject={() => reject(req)}
+                onPay={() => handleAction(req, pay)}
+                onReject={() => handleAction(req, reject)}
                 isProcessing={processingId === req.id}
                 isGlobalDisabled={isGlobalProcessing}
               />
@@ -133,11 +129,12 @@ function RequestCard({ req, error, onPay, onReject, isProcessing, isGlobalDisabl
   const amountDisplay = AmountFormatUtils.formatDisplayAmount(req.amount.toString(), req.coinId);
   const timeAgo = getTimeAgo(req.timestamp);
 
-  // Стиль статуса
+  // Status styling
   const statusConfig = {
     [PaymentRequestStatus.ACCEPTED]: { color: 'text-emerald-500', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20', icon: Check, label: 'Payment Sent' },
     [PaymentRequestStatus.PAID]: { color: 'text-emerald-500', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20', icon: Check, label: 'Paid Successfully' },
     [PaymentRequestStatus.REJECTED]: { color: 'text-red-500', bg: 'bg-red-500/10', border: 'border-red-500/20', icon: XIcon, label: 'Request Declined' },
+    [PaymentRequestStatus.EXPIRED]: { color: 'text-neutral-500', bg: 'bg-neutral-500/10', border: 'border-neutral-500/20', icon: Clock, label: 'Request Expired' },
     [PaymentRequestStatus.PENDING]: { color: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/20', icon: Clock, label: 'Awaiting Payment' },
   };
 

--- a/src/components/wallet/L3/views/L3WalletView.tsx
+++ b/src/components/wallet/L3/views/L3WalletView.tsx
@@ -127,7 +127,7 @@ interface L3WalletViewProps {
   paymentRequests: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest[];
   paymentRequestsPendingCount: number;
   paymentRequestsReject: (request: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest) => Promise<void>;
-  paymentRequestsPaid: (request: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest) => Promise<void>;
+  paymentRequestsPay: (request: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest) => Promise<void>;
   paymentRequestsClearProcessed: () => void;
 }
 
@@ -144,7 +144,7 @@ export function L3WalletView({
   paymentRequests,
   paymentRequestsPendingCount,
   paymentRequestsReject,
-  paymentRequestsPaid,
+  paymentRequestsPay,
   paymentRequestsClearProcessed,
 }: L3WalletViewProps) {
   const navigate = useNavigate();
@@ -510,7 +510,7 @@ export function L3WalletView({
         requests={paymentRequests}
         pendingCount={paymentRequestsPendingCount}
         reject={paymentRequestsReject}
-        paid={paymentRequestsPaid}
+        pay={paymentRequestsPay}
         clearProcessed={paymentRequestsClearProcessed}
       />
       <SeedPhraseModal

--- a/src/components/wallet/WalletPanel.tsx
+++ b/src/components/wallet/WalletPanel.tsx
@@ -22,7 +22,7 @@ export function WalletPanel() {
   const { isLoading: isWalletLoading, walletExists, error: walletError } = useWalletStatus();
   const { identity, nametag, isLoading: isLoadingIdentity } = useIdentity();
   const { initProgress } = useSphereContext();
-  const { pendingCount, requests, reject, paid, clearProcessed } = useIncomingPaymentRequests();
+  const { pendingCount, requests, reject, pay, clearProcessed } = useIncomingPaymentRequests();
   const { setFullscreen } = useUIState();
 
   // Track previous pending count to detect new requests
@@ -252,7 +252,7 @@ export function WalletPanel() {
           paymentRequests={requests}
           paymentRequestsPendingCount={pendingCount}
           paymentRequestsReject={reject}
-          paymentRequestsPaid={paid}
+          paymentRequestsPay={pay}
           paymentRequestsClearProcessed={clearProcessed}
         />
       </div>

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -34,6 +34,10 @@ export const STORAGE_KEYS = {
   // Dev Settings
   DEV_AGGREGATOR_URL: 'sphere_dev_aggregator_url',
   DEV_SKIP_TRUST_BASE: 'sphere_dev_skip_trust_base',
+
+  // wallet-api device label — one session row per (owner, device) on the
+  // backend; the SDK stores the refresh token under it (ARCHITECTURE §4).
+  WALLET_API_DEVICE_ID: 'sphere_wallet_api_device_id',
 } as const;
 
 const STORAGE_PREFIX = 'sphere_';
@@ -55,3 +59,20 @@ export function clearAllSphereData(): void {
 }
 
 export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];
+
+/**
+ * Stable per-device label for the wallet-api session (ARCHITECTURE §4: one
+ * session row per (owner, device); the refresh token is stored under it).
+ * Persisted so reloads reuse the session instead of forcing a fresh
+ * challenge sign-in and a new server session row per page load.
+ *
+ * The key carries the `sphere_` prefix, so `clearAllSphereData()` (wallet
+ * deletion) resets the device identity together with everything else.
+ */
+export function getOrCreateWalletApiDeviceId(): string {
+  const existing = localStorage.getItem(STORAGE_KEYS.WALLET_API_DEVICE_ID);
+  if (existing) return existing;
+  const deviceId = `sphere-web-${crypto.randomUUID()}`;
+  localStorage.setItem(STORAGE_KEYS.WALLET_API_DEVICE_ID, deviceId);
+  return deviceId;
+}

--- a/src/config/walletApi.ts
+++ b/src/config/walletApi.ts
@@ -1,0 +1,60 @@
+/**
+ * wallet-api composition config (S4 provider swap).
+ *
+ * The ASSET path moves to the wallet-api backend when `VITE_WALLET_API_URL`
+ * is set; messaging, DMs and nametags stay on Nostr. When unset, the app
+ * keeps the legacy local-custody composition (IndexedDB + Nostr asset
+ * delivery) unchanged.
+ *
+ * URLs may be relative (e.g. `/wallet-api`): they resolve against the app
+ * origin, which is how the dev/preview proxy in vite.config.ts is reached —
+ * the backend serves no CORS headers, so cross-origin browser calls need the
+ * local proxy (production deployments must solve this at the edge).
+ */
+
+/** Engine override for the LOCAL compose stack (smoke tests / local dev). */
+export interface EngineOverrideConfig {
+  /** Aggregator gateway URL (the mock aggregator of the dev stack). */
+  aggregatorUrl: string;
+  /** Trust base JSON URL — MUST be the trustbase the same gateway serves. */
+  trustBaseUrl: string;
+}
+
+/** Resolve an env URL; relative values resolve against the app origin. */
+function resolveUrl(value: string): string {
+  return new URL(value, window.location.origin).toString();
+}
+
+/** Backend base URL when wallet-api mode is enabled; null otherwise. */
+export function getWalletApiBaseUrl(): string | null {
+  const raw = import.meta.env.VITE_WALLET_API_URL as string | undefined;
+  if (!raw) return null;
+  return resolveUrl(raw);
+}
+
+/** True when the asset path rides wallet-api (drives IPFS-off, UI hints). */
+export function isWalletApiEnabled(): boolean {
+  return getWalletApiBaseUrl() !== null;
+}
+
+/**
+ * Aggregator + trustbase override for the LOCAL dev stack. Both URLs must be
+ * set together: the trustbase is the engine's source of truth for the
+ * network id, and mixing a gateway with another network's trustbase would
+ * make the engine reject every proof (or worse, accept the wrong network).
+ */
+export function getEngineOverride(): EngineOverrideConfig | null {
+  const aggregatorUrl = import.meta.env.VITE_AGGREGATOR_URL as string | undefined;
+  const trustBaseUrl = import.meta.env.VITE_TRUSTBASE_URL as string | undefined;
+  if (!aggregatorUrl && !trustBaseUrl) return null;
+  if (!aggregatorUrl || !trustBaseUrl) {
+    throw new Error(
+      'VITE_AGGREGATOR_URL and VITE_TRUSTBASE_URL must be set together — ' +
+        'a gateway must be paired with the trustbase it serves (never mix trustbases).',
+    );
+  }
+  return {
+    aggregatorUrl: resolveUrl(aggregatorUrl),
+    trustBaseUrl: resolveUrl(trustBaseUrl),
+  };
+}

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -1,10 +1,19 @@
 import { createContext } from 'react';
 import type { Sphere, PeerInfo, InitProgress } from '@unicitylabs/sphere-sdk';
 import type { BrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
+import type { WalletApiProviderExtras } from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+
+/**
+ * The app's provider bundle: the browser base, plus — when the asset path
+ * rides wallet-api (VITE_WALLET_API_URL set) — the S4 extras (`delivery`,
+ * `walletApi`). The extras are additive: helpers taking `BrowserProviders`
+ * keep working unchanged.
+ */
+export type SphereAppProviders = BrowserProviders & Partial<WalletApiProviderExtras>;
 
 export interface SphereContextValue {
   sphere: Sphere | null;
-  providers: BrowserProviders | null;
+  providers: SphereAppProviders | null;
 
   isLoading: boolean;
   isInitialized: boolean;
@@ -36,6 +45,13 @@ export interface SphereContextValue {
   ipfsEnabled: boolean;
   /** Toggle IPFS sync on/off (persists to localStorage, triggers reinitialize) */
   toggleIpfs: () => void;
+
+  /**
+   * True when the asset path rides the wallet-api backend (S4 composition).
+   * IPFS token sync is unavailable in this mode — server inventory custody
+   * and a second token-storage mirror have undefined handoff semantics.
+   */
+  walletApiEnabled: boolean;
 }
 
 export interface CreateWalletOptions {

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -12,9 +12,19 @@ import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
 import {
   createBrowserProviders,
+  createUnicityAggregatorProvider,
   type BrowserProviders,
 } from '@unicitylabs/sphere-sdk/impl/browser';
-import { SphereContext } from './SphereContext';
+import {
+  createSphereProviders,
+  createWalletApiProviders,
+} from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+import { SphereContext, type SphereAppProviders } from './SphereContext';
+import {
+  getEngineOverride,
+  getWalletApiBaseUrl,
+  isWalletApiEnabled,
+} from '../config/walletApi';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
   ? '/coingecko'
@@ -26,7 +36,11 @@ import type {
   ImportFromFileOptions,
   ImportFromFileResult,
 } from './SphereContext';
-import { clearAllSphereData, STORAGE_KEYS } from '../config/storageKeys';
+import {
+  clearAllSphereData,
+  getOrCreateWalletApiDeviceId,
+  STORAGE_KEYS,
+} from '../config/storageKeys';
 import { migrateApprovedSessions } from '../utils/connected-sites';
 
 // One-time migration from old approved sessions format (idempotent)
@@ -56,6 +70,10 @@ function isIpfsEnabled(): boolean {
 }
 
 function getIpfsConfig() {
+  // wallet-api mode: server inventory custody — a second token-storage
+  // mirror (IPFS) has undefined ownership-handoff/tombstone semantics, so
+  // token sync is forced off (the toggle is hidden too).
+  if (isWalletApiEnabled()) return {};
   if (!isIpfsEnabled()) return {};
   return {
     tokenSync: {
@@ -79,11 +97,54 @@ async function disconnectTransport(providers: BrowserProviders): Promise<void> {
 
 /** Add IPFS storage provider and trigger initial sync (fire-and-forget) */
 function setupIpfsSync(instance: Sphere, providers: BrowserProviders): void {
+  if (isWalletApiEnabled()) return; // see getIpfsConfig()
   if (providers.ipfsTokenStorage) {
     instance.addTokenStorageProvider(providers.ipfsTokenStorage)
       .then(() => instance.sync())
       .catch(err => logger.warn('SphereProvider', 'IPFS sync failed', err));
   }
+}
+
+/**
+ * Compose the app's provider bundle (S4): the browser base, an optional
+ * engine-port override (LOCAL dev stack: mock aggregator + the trustbase it
+ * serves), and — when VITE_WALLET_API_URL is set — the wallet-api preset:
+ * thin server-custody token storage + mailbox delivery + the S1 client.
+ * Composing `delivery` moves ASSETS to wallet-api; messaging, group chat and
+ * nametags stay on the Nostr transport in the base bundle.
+ */
+function buildProviders(network: NetworkType): SphereAppProviders {
+  const base = createBrowserProviders({
+    network,
+    // v2 token engine: aggregator URL + trust base come from the network
+    // preset; only the apiKey is injected (non-secret on testnet2).
+    oracle: { apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY },
+    price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
+    // Group chat (NIP-29) is disabled: the UI is already hidden (PR #339), and
+    // skipping the module here stops the SDK from connecting to NIP-29 relays.
+    groupChat: false,
+    market: true,
+    ...getIpfsConfig(),
+  });
+
+  const engineOverride = getEngineOverride();
+  const withEngine = engineOverride
+    ? createSphereProviders(base, {
+        engine: createUnicityAggregatorProvider({
+          url: engineOverride.aggregatorUrl,
+          trustBaseUrl: engineOverride.trustBaseUrl,
+          network,
+        }),
+      })
+    : base;
+
+  const walletApiBaseUrl = getWalletApiBaseUrl();
+  if (!walletApiBaseUrl) return withEngine;
+  return createWalletApiProviders(withEngine, {
+    baseUrl: walletApiBaseUrl,
+    network,
+    deviceId: getOrCreateWalletApiDeviceId(),
+  });
 }
 
 /** Clean up persisted wallet data on creation/import failure */
@@ -110,7 +171,7 @@ export function SphereProvider({
 }: SphereProviderProps) {
   const queryClient = useQueryClient();
   const [sphere, setSphere] = useState<Sphere | null>(null);
-  const [providers, setProviders] = useState<BrowserProviders | null>(null);
+  const [providers, setProviders] = useState<SphereAppProviders | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [walletExists, setWalletExists] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -130,18 +191,7 @@ export function SphereProvider({
       if (!skipLoading) setIsLoading(true);
       setError(null);
 
-      const browserProviders = createBrowserProviders({
-        network,
-        // v2 token engine: aggregator URL + trust base (networkId 4) come from the
-        // testnet2 network preset; only the apiKey is injected (non-secret on testnet2).
-        oracle: { apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY },
-        price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
-        // Group chat (NIP-29) is disabled: the UI is already hidden (PR #339), and
-        // skipping the module here stops the SDK from connecting to NIP-29 relays.
-        groupChat: false,
-        market: true,
-        ...getIpfsConfig(),
-      });
+      const browserProviders = buildProviders(network);
       // Debug logging is off by default; enable at runtime via: logger.configure({ debug: true })
       setProviders(browserProviders);
 
@@ -366,6 +416,15 @@ export function SphereProvider({
     // Notify connected dApps before destroying — ConnectPage/IframeAgent listen for this
     window.dispatchEvent(new CustomEvent('sphere:wallet-logout'));
 
+    // Best-effort wallet-api session revoke (S4 auth lifecycle): the SDK only
+    // calls walletApi.logout() on address switch, not on destroy — without
+    // this the server session row would outlive wallet deletion.
+    if (providers?.walletApi) {
+      await providers.walletApi.logout().catch((err) => {
+        logger.warn('SphereProvider', 'wallet-api logout failed (best effort)', err);
+      });
+    }
+
     // Destroy sphere to close SDK connections (Nostr, IndexedDB handles, etc.)
     if (sphereRef.current) {
       await sphereRef.current.destroy();
@@ -459,6 +518,7 @@ export function SphereProvider({
     reinitialize: initialize,
     ipfsEnabled,
     toggleIpfs,
+    walletApiEnabled: isWalletApiEnabled(),
   };
 
   return (

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -98,6 +98,10 @@ export function useSphereEvents(): void {
     };
 
     const handleIdentityChange = () => {
+      // New identity = new transfer stream (wallet-api sessions are
+      // per-identity): clear the toast dedup set so the new address's
+      // transfers are never swallowed by ids seen under the old one.
+      seenTransferIdsRef.current.clear();
       refreshIdentityCache();
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.identity.all });
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.payments.all });

--- a/src/sphere-sdk-browser.d.ts
+++ b/src/sphere-sdk-browser.d.ts
@@ -46,4 +46,31 @@ declare module '@unicitylabs/sphere-sdk/impl/browser' {
   export function createBrowserProviders(
     config?: BrowserProvidersConfig,
   ): BrowserProviders;
+
+  /**
+   * Browser oracle (network-config) provider factory. Used to select the
+   * engine port at composition time (createSphereProviders) when the app
+   * must point at a non-preset gateway + the trustbase it serves — e.g. the
+   * LOCAL dev-stack mock aggregator in the two-profile smoke.
+   */
+  export interface BrowserAggregatorProviderConfig {
+    /** Aggregator (gateway) URL */
+    url: string;
+    /** API key for authentication */
+    apiKey?: string;
+    /** Request timeout (ms) */
+    timeout?: number;
+    /** Skip trust base loading (dev only) */
+    skipVerification?: boolean;
+    /** Enable debug logging */
+    debug?: boolean;
+    /** Trust base JSON URL (fetched by the browser loader) */
+    trustBaseUrl?: string;
+    /** Embedded-fallback network (required when trustBaseUrl is set) */
+    network?: NetworkType;
+  }
+
+  export function createUnicityAggregatorProvider(
+    config: BrowserAggregatorProviderConfig,
+  ): OracleProvider;
 }

--- a/tests/e2e/two-profile-smoke.spec.ts
+++ b/tests/e2e/two-profile-smoke.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Two-profile wallet-api smoke (LOCAL-ONLY — see playwright.config.ts for
+ * the required dev stack and the run command).
+ *
+ * Two isolated browser contexts = two wallets (separate IndexedDB,
+ * localStorage, deviceIds). One pass exercises the whole S4 surface against
+ * the REAL backend: challenge sign-in, open minting via the mock aggregator,
+ * blob upload (presigned PUT), inventory deposit, mailbox delivery + claim
+ * with the §6 inventory handoff, and §16 payment requests end-to-end:
+ *
+ *   A creates + funds a wallet → sends UCT to B → B sees the balance →
+ *   B sends A a payment request → A pays it → both UIs converge.
+ *
+ * Nametags ride Nostr (unchanged by this integration) and are REQUIRED for
+ * recipient resolution: the engine send path needs the recipient's published
+ * chain pubkey, so both profiles register one during onboarding.
+ *
+ * Triage rule (wallet-api ARCHITECTURE §18): infra failures (stack down,
+ * 5xx, relay timeouts) are retried/blocked on — they never license test
+ * weakening. Only deterministic failures are code defects.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+/** The app renders mobile+desktop duplicates; assert/click the visible one. */
+function visible(page: Page, text: string): Locator {
+  return page.getByText(text).filter({ visible: true }).first();
+}
+
+function visibleButton(page: Page, name: string): Locator {
+  return page.getByRole('button', { name, exact: true }).filter({ visible: true }).first();
+}
+
+/** The visible WalletScreen overlay (send/request modals) containing `text`. */
+function modalScreen(page: Page, text: string): Locator {
+  return page
+    .locator('div.absolute.inset-0.z-10')
+    .filter({ hasText: text })
+    .filter({ visible: true })
+    .last();
+}
+
+// One run-unique suffix; nametags are first-seen-wins on the public relays,
+// so they must never repeat across runs.
+const runId = Math.random().toString(36).slice(2, 8);
+const TAG_A = `smka${runId}`;
+const TAG_B = `smkb${runId}`;
+
+/** Walk onboarding: create wallet + register a nametag + ack the mnemonic. */
+async function createWallet(page: Page, tag: string): Promise<void> {
+  await page.goto('/home');
+  // Tutorial overlay shows on first visit only.
+  await page
+    .getByText('Skip tutorial')
+    .first()
+    .click({ timeout: 15_000 })
+    .catch(() => {});
+  await page.getByRole('button', { name: 'Create New Wallet' }).first().click();
+
+  // "Choose Unicity ID" — register the nametag (publishes the Nostr binding
+  // the other profile resolves; mints the nametag token via the engine).
+  await page.locator('input').first().fill(tag);
+  const cont = page.getByRole('button', { name: 'Continue' });
+  await expect(cont).toBeEnabled({ timeout: 30_000 });
+  await cont.click();
+
+  // Mnemonic backup → wallet view (creation + nametag mint happen here).
+  await page
+    .getByRole('button', { name: "I've Saved My Recovery Phrase" })
+    .click({ timeout: 180_000 });
+  await expect(page.getByText(`@${tag}`).filter({ visible: true }).first()).toBeVisible({
+    timeout: 180_000,
+  });
+}
+
+/** Open mint via Top Up (UCT/BTC/SOL/ETH basket) and wait for the deposit. */
+async function topUp(page: Page): Promise<void> {
+  await visibleButton(page, 'Top Up').click();
+  await visible(page, 'Get test tokens').click();
+  // Mint (mock aggregator) + §6 deposit (upload-urls → PUT → apply) for the
+  // whole basket; the assets list then shows the UCT balance.
+  await expect(visible(page, '100.0000 UCT')).toBeVisible({ timeout: 240_000 });
+}
+
+test('two profiles converge over wallet-api: fund, send, request, pay', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await ctxA.newPage();
+  const b = await ctxB.newPage();
+
+  // ── Onboard both profiles (A funds itself via open minting) ─────────────
+  await createWallet(a, TAG_A);
+  await createWallet(b, TAG_B);
+  await topUp(a);
+
+  // ── A sends 10 UCT to @B (mailbox delivery + B's claim/handoff) ─────────
+  await visibleButton(a, 'Send').click();
+  await a.getByRole('button', { name: /^UCT / }).filter({ visible: true }).first().click();
+  await a.getByPlaceholder("Recipient's Unicity ID").fill(TAG_B);
+  await a.locator('input[inputmode="decimal"]').fill('10');
+  // Nametag resolution hits public relays — retry while the binding settles.
+  await expect(async () => {
+    await a.getByRole('button', { name: 'Review' }).click();
+    await expect(a.getByText('You are sending')).toBeVisible({ timeout: 15_000 });
+  }).toPass({ timeout: 120_000, intervals: [5_000] });
+  // Scope to the confirm screen — the wallet panel has its own 'Send' button.
+  await modalScreen(a, 'You are sending')
+    .getByRole('button', { name: 'Send', exact: true })
+    .click();
+  await expect(visible(a, 'Success!')).toBeVisible({ timeout: 180_000 });
+  await visibleButton(a, 'Close').click();
+  await expect(visible(a, '90.0000 UCT')).toBeVisible({ timeout: 60_000 });
+
+  // ── B receives: wake → mailbox claim → inventory custody → balance ──────
+  await expect(visible(b, '10.0000 UCT')).toBeVisible({ timeout: 240_000 });
+
+  // ── B requests 5 UCT from @A (§16 payment request) ──────────────────────
+  await visibleButton(b, 'Top Up').click();
+  await visible(b, 'Payment Request').click();
+  await b.getByRole('button', { name: /^UCT/ }).filter({ visible: true }).first().click();
+  await b.getByPlaceholder('Who should pay you?').fill(TAG_A);
+  await b.locator('input[inputmode="decimal"]').fill('5');
+  await b.getByPlaceholder('Message (optional)').fill('smoke: lunch money');
+  await expect(async () => {
+    await b.getByRole('button', { name: 'Review' }).click();
+    await expect(b.getByRole('button', { name: 'Send Request' })).toBeVisible({ timeout: 15_000 });
+  }).toPass({ timeout: 120_000, intervals: [5_000] });
+  await visibleButton(b, 'Send Request').click();
+  await expect(visible(b, 'Request Sent!')).toBeVisible({ timeout: 120_000 });
+  await visibleButton(b, 'Close').click();
+
+  // ── A pays it (payPaymentRequest: send + linked 'paid' respond) ─────────
+  // The requests modal auto-opens on the incoming request (wake push).
+  await expect(visible(a, 'smoke: lunch money')).toBeVisible({ timeout: 240_000 });
+  await visibleButton(a, 'Pay Now').click();
+  await expect(visible(a, 'Paid Successfully')).toBeVisible({ timeout: 240_000 });
+
+  // ── Convergence: B holds 15 UCT, A holds 85 ─────────────────────────────
+  await expect(visible(b, '15.0000 UCT')).toBeVisible({ timeout: 240_000 });
+  await expect(visible(a, '85.0000 UCT')).toBeVisible({ timeout: 60_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/tests/unit/config/storageKeys.test.ts
+++ b/tests/unit/config/storageKeys.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   STORAGE_KEYS,
   clearAllSphereData,
+  getOrCreateWalletApiDeviceId,
 } from "../../../src/config/storageKeys";
 
 // ==========================================
@@ -120,5 +121,55 @@ describe("clearAllSphereData", () => {
     );
 
     consoleSpy.mockRestore();
+  });
+});
+
+// ==========================================
+// Test: getOrCreateWalletApiDeviceId
+// ==========================================
+
+describe("getOrCreateWalletApiDeviceId", () => {
+  let localStorageMock: { [key: string]: string };
+
+  beforeEach(() => {
+    localStorageMock = {};
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => localStorageMock[key] || null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageMock[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageMock[key];
+      }),
+      key: vi.fn((index: number) => Object.keys(localStorageMock)[index] || null),
+      get length() {
+        return Object.keys(localStorageMock).length;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("generates a device id once and persists it under the sphere_ key", () => {
+    const first = getOrCreateWalletApiDeviceId();
+
+    expect(first).toMatch(/^sphere-web-/);
+    expect(localStorageMock[STORAGE_KEYS.WALLET_API_DEVICE_ID]).toBe(first);
+
+    // Stable across calls — one (owner, device) session row, not one per load
+    expect(getOrCreateWalletApiDeviceId()).toBe(first);
+  });
+
+  it("resets the device identity when sphere data is cleared (wallet deletion)", () => {
+    const first = getOrCreateWalletApiDeviceId();
+
+    clearAllSphereData();
+    expect(localStorageMock[STORAGE_KEYS.WALLET_API_DEVICE_ID]).toBeUndefined();
+
+    const second = getOrCreateWalletApiDeviceId();
+    expect(second).toMatch(/^sphere-web-/);
+    expect(second).not.toBe(first);
   });
 });

--- a/tests/unit/config/walletApi.test.ts
+++ b/tests/unit/config/walletApi.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  getWalletApiBaseUrl,
+  getEngineOverride,
+  isWalletApiEnabled,
+} from "../../../src/config/walletApi";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getWalletApiBaseUrl / isWalletApiEnabled", () => {
+  it("is disabled when VITE_WALLET_API_URL is unset", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(getWalletApiBaseUrl()).toBeNull();
+    expect(isWalletApiEnabled()).toBe(false);
+  });
+
+  it("passes absolute URLs through", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "http://127.0.0.1:3000");
+    expect(getWalletApiBaseUrl()).toBe("http://127.0.0.1:3000/");
+    expect(isWalletApiEnabled()).toBe(true);
+  });
+
+  it("resolves relative URLs (dev/preview proxy paths) against the app origin", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "/wallet-api");
+    expect(getWalletApiBaseUrl()).toBe(`${window.location.origin}/wallet-api`);
+  });
+});
+
+describe("getEngineOverride", () => {
+  it("is null when neither override is set", () => {
+    vi.stubEnv("VITE_AGGREGATOR_URL", "");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "");
+    expect(getEngineOverride()).toBeNull();
+  });
+
+  it("resolves both URLs when both are set", () => {
+    vi.stubEnv("VITE_AGGREGATOR_URL", "/local-agg");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "/local-agg/trustbase.json");
+    expect(getEngineOverride()).toEqual({
+      aggregatorUrl: `${window.location.origin}/local-agg`,
+      trustBaseUrl: `${window.location.origin}/local-agg/trustbase.json`,
+    });
+  });
+
+  it("fails loud when only one of the pair is set (trustbase mixing guard)", () => {
+    vi.stubEnv("VITE_AGGREGATOR_URL", "/local-agg");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "");
+    expect(() => getEngineOverride()).toThrow(/must be set together/);
+
+    vi.stubEnv("VITE_AGGREGATOR_URL", "");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "/local-agg/trustbase.json");
+    expect(() => getEngineOverride()).toThrow(/must be set together/);
+  });
+});

--- a/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
+++ b/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  useIncomingPaymentRequests,
+  PaymentRequestStatus,
+} from "../../../src/components/wallet/L3/hooks/useIncomingPaymentRequests";
+
+// ============================================================================
+// Fake sphere: implements exactly the PaymentsModule surface the hook is
+// allowed to use. There is deliberately NO getTransport() — the legacy
+// implementation bypassed the module via the transport, which silently
+// no-ops on the wallet-api path; any regression to it throws here.
+// ============================================================================
+
+type SdkStatus = "pending" | "accepted" | "rejected" | "paid" | "expired";
+
+interface FakeSdkRequest {
+  id: string;
+  senderPubkey: string;
+  senderNametag?: string;
+  amount: string;
+  coinId: string;
+  symbol: string;
+  message?: string;
+  requestId: string;
+  timestamp: number;
+  status: SdkStatus;
+}
+
+function makeRequest(id: string, status: SdkStatus = "pending"): FakeSdkRequest {
+  return {
+    id,
+    senderPubkey: "02".padEnd(66, "a"),
+    senderNametag: "alice",
+    amount: "1000",
+    coinId: "coin-1",
+    symbol: "UCT",
+    requestId: `req-${id}`,
+    timestamp: Date.now(),
+    status,
+  };
+}
+
+function makeFakeSphere(initial: FakeSdkRequest[] = []) {
+  const requests = [...initial];
+  const listeners = new Map<string, Set<(data: unknown) => void>>();
+
+  const find = (id: string) => requests.find((r) => r.id === id);
+
+  const sphere = {
+    on: (evt: string, fn: (data: unknown) => void) => {
+      if (!listeners.has(evt)) listeners.set(evt, new Set());
+      listeners.get(evt)!.add(fn);
+    },
+    off: (evt: string, fn: (data: unknown) => void) => {
+      listeners.get(evt)?.delete(fn);
+    },
+    payments: {
+      getPaymentRequests: vi.fn(() => requests.map((r) => ({ ...r }))),
+      acceptPaymentRequest: vi.fn(async (id: string) => {
+        const r = find(id);
+        if (r) r.status = "accepted";
+      }),
+      rejectPaymentRequest: vi.fn(async (id: string) => {
+        const r = find(id);
+        if (r) r.status = "rejected";
+      }),
+      payPaymentRequest: vi.fn(async (id: string) => {
+        const r = find(id);
+        if (r) r.status = "paid";
+        return { success: true, id: "transfer-1" };
+      }),
+      clearProcessedPaymentRequests: vi.fn(() => {
+        for (let i = requests.length - 1; i >= 0; i--) {
+          if (requests[i].status !== "pending") requests.splice(i, 1);
+        }
+      }),
+    },
+    // Test-side helpers
+    _receive: (r: FakeSdkRequest) => {
+      requests.unshift(r);
+      listeners.get("payment_request:incoming")?.forEach((fn) => fn({ ...r }));
+    },
+  };
+  return sphere;
+}
+
+let fakeSphere: ReturnType<typeof makeFakeSphere> | null = null;
+
+vi.mock("../../../src/sdk/hooks/core/useSphere", () => ({
+  useSphereContext: () => ({ sphere: fakeSphere }),
+}));
+
+beforeEach(() => {
+  fakeSphere = null;
+});
+
+describe("useIncomingPaymentRequests", () => {
+  it("seeds from payments.getPaymentRequests() on mount (sign-in backfill)", () => {
+    fakeSphere = makeFakeSphere([makeRequest("a"), makeRequest("b", "expired")]);
+
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    expect(result.current.requests).toHaveLength(2);
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+    expect(result.current.requests[1].status).toBe(PaymentRequestStatus.EXPIRED);
+    expect(result.current.pendingCount).toBe(1);
+    // Legacy bridge fields preserved
+    expect(result.current.requests[0].amount).toBe(1000n);
+    expect(result.current.requests[0].recipientNametag).toBe("alice");
+  });
+
+  it("adds requests on payment_request:incoming", async () => {
+    fakeSphere = makeFakeSphere();
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+    expect(result.current.requests).toHaveLength(0);
+
+    act(() => {
+      fakeSphere!._receive(makeRequest("live-1"));
+    });
+
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+    expect(result.current.pendingCount).toBe(1);
+  });
+
+  it("pays through payments.payPaymentRequest (no raw transfer + paid flip)", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await act(() => result.current.pay(result.current.requests[0]));
+
+    expect(fakeSphere.payments.payPaymentRequest).toHaveBeenCalledWith("a");
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PAID);
+  });
+
+  it("rejects through payments.rejectPaymentRequest (server-confirmed)", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await act(() => result.current.reject(result.current.requests[0]));
+
+    expect(fakeSphere.payments.rejectPaymentRequest).toHaveBeenCalledWith("a");
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.REJECTED);
+  });
+
+  it("propagates a server reject failure and does NOT flip the status", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    // 403 non-addressee / 409 non-open propagate from the module — the
+    // request must stay pending locally (the respond IS the state change).
+    fakeSphere.payments.rejectPaymentRequest.mockRejectedValueOnce(
+      new Error("HTTP 409: request is not open"),
+    );
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await expect(
+      act(() => result.current.reject(result.current.requests[0])),
+    ).rejects.toThrow(/409/);
+
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+  });
+
+  it("propagates a pay failure and leaves the request pending", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    fakeSphere.payments.payPaymentRequest.mockRejectedValueOnce(
+      new Error("INSUFFICIENT_FUNDS"),
+    );
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await expect(
+      act(() => result.current.pay(result.current.requests[0])),
+    ).rejects.toThrow(/INSUFFICIENT_FUNDS/);
+
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+  });
+
+  it("clearProcessed delegates to the module and keeps pending requests", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a"), makeRequest("b", "paid")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+    expect(result.current.requests).toHaveLength(2);
+
+    act(() => result.current.clearProcessed());
+
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+    expect(result.current.requests[0].id).toBe("a");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,26 @@ export default defineConfig(({ mode }) => {
   // the SPA HTML fallback — a proxied URL without a "." (e.g.
   // /coingecko/simple/price?ids=bitcoin) would otherwise be rewritten to
   // index.html and never reach the proxy (the SDK then gets HTML, not JSON).
-  const proxyPaths = ['/rpc', '/dev-rpc', '/coingecko'];
+  const proxyPaths = ['/rpc', '/dev-rpc', '/coingecko', '/wallet-api', '/local-agg'];
+
+  // wallet-api backend + LOCAL dev-stack aggregator (docker-compose.dev.yml
+  // in the wallet-api repo). Neither serves CORS headers, so the browser app
+  // reaches them through this same-origin proxy in dev/preview (set
+  // VITE_WALLET_API_URL=/wallet-api etc.); production deployments must solve
+  // CORS/edge routing on the backend side.
+  const localStackProxy = {
+    '/wallet-api': {
+      target: env.WALLET_API_PROXY_TARGET || 'http://127.0.0.1:3000',
+      changeOrigin: true,
+      ws: true, // the SDK's wake socket (/v1/ws) rides the same base URL
+      rewrite: (p: string) => p.replace(/^\/wallet-api/, ''),
+    },
+    '/local-agg': {
+      target: env.AGGREGATOR_PROXY_TARGET || 'http://127.0.0.1:3001',
+      changeOrigin: true,
+      rewrite: (p: string) => p.replace(/^\/local-agg/, ''),
+    },
+  };
 
   return {
     plugins: [
@@ -101,8 +120,14 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: true,
           rewrite: (path) => path.replace(/^\/coingecko/, ''),
-        }
+        },
+        ...localStackProxy,
       }
+    },
+    // `vite preview` (used by the Playwright smoke) needs the same
+    // same-origin route to the local stack as the dev server.
+    preview: {
+      proxy: { ...localStackProxy },
     },
     // Ensure polyfill shims resolve correctly for symlinked file: dependencies
     resolve: {


### PR DESCRIPTION
Closes #347

Phase 3 of the wallet-api program (development-workflow.md): the **ASSET path moves onto the wallet-api backend** through the sphere-sdk S4 presets. Messaging, DMs and nametags stay on Nostr — chat is untouched.

## What changed

- **SDK pin:** `@unicitylabs/sphere-sdk` → exact `0.9.1-dev.7` — the first release exporting `./impl/shared/wallet-api` **with dts** (no new d.ts shim needed; the existing `impl/browser` shim stays and gains only the `createUnicityAggregatorProvider` declaration).
- **Provider swap (`SphereProvider`):** `createBrowserProviders(...)` is wrapped with `createWalletApiProviders(base, { baseUrl, network, deviceId })` when `VITE_WALLET_API_URL` is set; unset keeps the legacy local-custody composition byte-for-byte (controlled rollout via env). Composing `delivery` moves assets to wallet-api by SDK design — no Nostr-asset code paths remain in use in wallet-api mode.
- **Device identity:** `getOrCreateWalletApiDeviceId()` persists one device label in localStorage (one server session row per (owner, device); reloads reuse the session instead of a challenge sign-in per page load). Wallet deletion resets it via `clearAllSphereData()`.
- **Auth lifecycle:** sign-in on init/unlock and logout-then-re-sign-in on address switch are SDK-automatic (verified live). Added the one missing piece: best-effort `walletApi.logout()` in `deleteWallet` — `Sphere.destroy()` does not revoke the server session.
- **Engine port override (smoke/local dev):** `VITE_AGGREGATOR_URL` + `VITE_TRUSTBASE_URL` (both-or-neither, fail-loud guard against trustbase mixing) select the engine port through the SDK composition root (`createSphereProviders` + browser oracle factory with `trustBaseUrl`). This is how the smoke runs against the dev stack's mock aggregator + the LOCAL trustbase it serves, with zero hand-rolled trustbase plumbing.
- **Product-visible: IPFS token sync is OFF in wallet-api mode.** Server inventory custody plus a second token-storage mirror has undefined ownership-handoff/tombstone semantics (§6), so `getIpfsConfig()`/`setupIpfsSync` are gated and the header toggle is hidden (`walletApiEnabled` on the context). If product wants both, that is an SDK composition question to raise — not app glue.
- **Payment requests ride the module API** (the one real behavioral bug fixed): `useIncomingPaymentRequests` previously bypassed PaymentsModule via `sphere.getTransport().sendPaymentRequestResponse()`, which on wallet-api would leave the server request `open` forever while the UI lied. Now:
  - the SDK list is the source of truth — seeded from `payments.getPaymentRequests()` (sign-in backfill), statuses read back after every action, never flipped optimistically;
  - `reject` → `payments.rejectPaymentRequest()` — server-confirmed on wallet-api; 403/409 propagate and are surfaced in the modal's error slot;
  - **Pay Now** → `payments.payPaymentRequest()` — send + linked `transferId` in the §16 'paid' respond; the bare `paid` callback is gone (a 'paid' respond without a fulfilling transfer is a VALIDATION_ERROR on wallet-api);
  - `accept` stays local-only by design (§16 models open → paid|declined|expired; there is no requester-visible "accepted");
  - `EXPIRED` added to the UI status model.
- **`useSphereEvents`:** transfer-toast dedup set cleared on `identity:changed` (sessions are per-identity now).
- **Local routing (CORS):** the backend serves **no CORS headers**, so the dev/preview server proxies `/wallet-api` (ws-enabled — the wake socket rides the same base URL) and `/local-agg`; relative env URLs resolve against the app origin. `.env.example` documents the defaults for the `docker-compose.dev.yml` stack. Production deployments must solve CORS at the backend/edge (reported as a backend finding).

## Two-profile smoke (Playwright, LOCAL-ONLY)

`tests/e2e/two-profile-smoke.spec.ts` — two isolated browser contexts (= two wallets, two deviceIds) against the **real** wallet-api compose stack. One pass covers: challenge sign-in, open minting via the mock aggregator (LOCAL trustbase), presigned blob upload, §6 inventory deposit, mailbox delivery + claim with inventory handoff, and §16 payment requests:

A onboards (+nametag) and mints → sends 10 UCT to @B → B's balance shows 10 UCT → B sends A a §16 payment request (5 UCT) → A's requests modal auto-opens on the wake push → A pays via Pay Now → A shows "Paid Successfully", B converges at 15 UCT / A at 85.

```sh
cd ../wallet-api && docker compose -f docker-compose.dev.yml up --build --wait
cd ../sphere && npm run test:e2e        # builds with the smoke env, serves via vite preview
```

**Deliberately not in CI** (needs docker + public Nostr relays for nametag bindings); the existing CI workflow (lint → unit → build) is untouched. Latest local runs: **passed** (1.1m against a dev server; re-run self-contained via `npm run test:e2e`).

## Gates

- `npm run lint` — 0 errors (3 pre-existing warnings in `ExplorePage.tsx`)
- `npm run test:run` — 52/52 (new: deviceId helper, env config incl. trustbase-mixing guard, payment-request hook: module routing, 403/409 propagation, no-transport-bypass regression guard)
- `npm run build` — green (tsc -b + vite)
- smoke — 1 passed against the real stack

## Findings surfaced while verifying (no app workarounds applied)

- **wallet-api:** concurrent `POST /v1/inventory/apply` deltas adding the same `(owner_id, token_id)` (Top Up runs four mints in parallel) surface as an unhandled Postgres 23505 → `500 INTERNAL` (`inventory/service.js executeAdds`). Clients converge after SDK retries, but per §13 this should be a mapped, deterministic outcome (no-op success or 409) — needs a wallet-api issue + spec decision.
- **wallet-api deployment:** no CORS headers anywhere — any browser app not behind a same-origin proxy cannot talk to it (§4 deployment posture gap).
- The presigned-PUT `412 PreconditionFailed` storms during parallel mints are the documented §5.2 "identical blob already exists" path — by design, but noisy; the SDK could treat them more quietly.
