### PR TITLE
Pages branch deploys: bake the staging wallet-api URL into the bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 # and are served by the dev/preview proxy, which forwards them to
 # WALLET_API_PROXY_TARGET (default http://127.0.0.1:3000 — the wallet-api
 # repo's `docker compose -f docker-compose.dev.yml up --build --wait` stack).
+# Absolute https URLs pass through unchanged — the staging backend serves
+# wildcard CORS, so it works cross-origin without the proxy. This is the
+# value the GitHub Pages branch deploys bake in at build time (see
+# .github/workflows/deploy-pages-branch.yml):
+#VITE_WALLET_API_URL=https://wallet-api.staging.unicity.network
 VITE_WALLET_API_URL=/wallet-api
 
 # LOCAL dev-stack engine override (used by the two-profile smoke): point the

--- a/.github/workflows/deploy-pages-branch.yml
+++ b/.github/workflows/deploy-pages-branch.yml
@@ -77,6 +77,14 @@ jobs:
           # Public URL — baked into the bundle at build time. Hardcoded
           # because the same value applies to every branch preview deploy.
           VITE_SPHERE_API_URL: https://quest-api.staging.unicity.network
+          # wallet-api backend (S4 asset path) — absolute https URL, baked in
+          # at build time. The staging backend serves wildcard CORS, so the
+          # github.io origin reaches it directly (no dev proxy involved; the
+          # SDK derives the wss:// wake socket from this same base). Engine
+          # override vars (VITE_AGGREGATOR_URL / VITE_TRUSTBASE_URL) stay
+          # UNSET here on purpose: the testnet2 network preset supplies the
+          # real gateway + the trustbase it serves — never mix trustbases.
+          VITE_WALLET_API_URL: https://wallet-api.staging.unicity.network
           # Aggregator API key — inlined into the bundle at build time.
           # The testnet2 value is NOT a secret (see .env / .env.example), so it
           # is safe to hardcode here. Without it the deployed bundle gets


### PR DESCRIPTION
Closes #349

## What

Adds `VITE_WALLET_API_URL: https://wallet-api.staging.unicity.network` to the Build step `env` block of `.github/workflows/deploy-pages-branch.yml`, and documents the staging value as a commented alternative in `.env.example`. That is the whole change — no app code is touched.

## Wiring mechanism (and why)

The Pages pipeline builds every branch with `npm run build` and injects build-time public values directly in the Build step's `env` block — that is how `VITE_SPHERE_API_URL` (already the staging quest-api URL) and the non-secret testnet2 `VITE_AGGREGATOR_API_KEY` are wired today. No committed `.env.production` exists and CI has no `.env` (gitignored), so the workflow env block is the only mechanism the pipeline supports — and the smallest committed change consistent with the existing vars. It only affects the Pages build path: local dev still uses the gitignored `.env` (`VITE_WALLET_API_URL=/wallet-api` riding the Vite proxy), which this PR does not touch.

Engine override vars (`VITE_AGGREGATOR_URL` / `VITE_TRUSTBASE_URL`) remain **unset** in the workflow on purpose: the testnet2 network preset (SphereProvider default) supplies the real gateway + the trustbase it serves.

## Verification done

- `getWalletApiBaseUrl()` (`src/config/walletApi.ts`) resolves via `new URL(value, window.location.origin)` — absolute https values pass through unchanged; the SDK client then strips the trailing slash.
- Wake socket scheme: sphere-sdk `wallet-api/client.ts` builds the WS URL with `this.baseUrl.replace(/^http/, 'ws')` after `assertSecureBaseUrl` enforces https (http only on loopback) — so the staging base yields `wss://wallet-api.staging.unicity.network/v1/ws?...`. No hardcoded `ws://`, no SDK change needed.
- Local gates: lint + unit tests + `npm run build` with the staging env values; `grep` of `dist/` confirms the bundle contains the absolute staging URL and does not use the `/wallet-api` dev-proxy path as the base.
- Live check: the push already deployed this branch via the modified workflow — the bundle served at `https://unicity-sphere.github.io/sphere/feat-pages-staging-wallet-api/` inlines `resolveUrl("https://wallet-api.staging.unicity.network")` with zero `"/wallet-api"` proxy-path hits.
- `BASE_PATH=/sphere/<branch>/` handling is untouched (no change to the BASE_PATH line, the redirect job, or the SPA 404 fallback).

## Staging bucket CORS — resolved

The browser fetches blob presigned URLs directly from the staging S3 bucket. **Owner confirmed the bucket CORS is set to wildcard**, so this is wired end-to-end. For the record (per wallet-api `docs/DEPLOYMENT.md` bucket-CORS checklist item): the SDK's presigned PUT sends `content-type`, `x-amz-checksum-sha256` and `if-none-match`, which trigger a preflight — the bucket config must keep `AllowedMethods` ⊇ GET/PUT/HEAD and `AllowedHeaders` covering those three (`["*"]` does). No `ExposeHeaders` needed: the SDK reads only status + body on blob GET/PUT (the 412 dedupe path is a status check).