### PR TITLE
Fail closed on wallet-api-intended builds; surface session + storage degradation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 #VITE_WALLET_API_URL=https://wallet-api.staging.unicity.network
 VITE_WALLET_API_URL=/wallet-api
 
+# Composition assert (#351). Set on deployments that INTEND wallet-api
+# custody (the Pages workflow sets it next to VITE_WALLET_API_URL): when
+# truthy ('false'/'0' count as unset) and VITE_WALLET_API_URL is missing or
+# empty, provider composition throws instead of silently falling back to the
+# legacy local-custody bundle — a missing URL would change the custody model,
+# not just degrade a feature. Leave unset for intentionally legacy builds.
+#VITE_REQUIRE_WALLET_API=true
+
 # LOCAL dev-stack engine override (used by the two-profile smoke): point the
 # v2 token engine at the mock aggregator AND the trustbase that same gateway
 # serves. Set BOTH or neither — never mix a gateway with another network's

--- a/.github/workflows/deploy-pages-branch.yml
+++ b/.github/workflows/deploy-pages-branch.yml
@@ -85,6 +85,12 @@ jobs:
           # UNSET here on purpose: the testnet2 network preset supplies the
           # real gateway + the trustbase it serves — never mix trustbases.
           VITE_WALLET_API_URL: https://wallet-api.staging.unicity.network
+          # #351 composition assert: this deploy INTENDS wallet-api custody —
+          # if VITE_WALLET_API_URL ever goes missing from a bundle (stale CDN
+          # rebuild, env drift), the app fails fast at provider composition
+          # instead of silently swapping to the legacy local-custody model
+          # (the 2026-06-12 incident).
+          VITE_REQUIRE_WALLET_API: 'true'
           # Aggregator API key — inlined into the bundle at build time.
           # The testnet2 value is NOT a secret (see .env / .env.example), so it
           # is safe to hardcode here. Without it the deployed bundle gets

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.7",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.7.tgz",
-      "integrity": "sha512-Ht1+/cvS/sxK8+CG50cR8ksv4J/F8EA6PScO+o5FOqwz5gvL22gi+CxkJbpqcxPYMEZPamAOJw+Pi5ofg7TSOA==",
+      "version": "0.9.1-dev.8",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.8.tgz",
+      "integrity": "sha512-ktnIa0LR9XAKE6mobqBXy669ntXXTWfxseWfs0v2pxyRI8KVeS+eVk20QuHxfucHnt03tVfamygUnQpOhqdTuA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 // import { ThemeToggle } from '../theme';
 import { STORAGE_KEYS } from '../../config/storageKeys';
 import { IpfsSyncIndicator } from './IpfsSyncIndicator';
+import { WalletApiSessionIndicator } from './WalletApiSessionIndicator';
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { DiscordIcon, XIcon } from '../icons/SocialIcons';
 
@@ -152,9 +153,11 @@ export function Header() {
                 </div>
               )}
 
-              {/* Desktop: IPFS sync indicator */}
+              {/* Desktop: custody status — IPFS sync (legacy) / wallet-api
+                  session (S4); each renders only in its own composition. */}
               <div className="hidden lg:flex items-center gap-3">
                 <IpfsSyncIndicator />
+                <WalletApiSessionIndicator />
                 {/* <ThemeToggle /> */}
               </div>
             </div>
@@ -233,9 +236,10 @@ export function Header() {
               )
             ))}
 
-            {/* IPFS sync + Social links — mobile only */}
+            {/* Custody status + Social links — mobile only */}
             <div className="px-4 py-3 border-t border-neutral-200 dark:border-brand-orange-border mt-1 flex items-center">
               <IpfsSyncIndicator />
+              <WalletApiSessionIndicator />
               <div className="flex-1" />
               <div className="flex items-center gap-5">
                 {[

--- a/src/components/layout/WalletApiSessionIndicator.tsx
+++ b/src/components/layout/WalletApiSessionIndicator.tsx
@@ -1,0 +1,34 @@
+import { CloudOff } from 'lucide-react';
+import { useSphereContext, useWalletApiSession } from '../../sdk/hooks';
+import { HeaderTooltip } from './HeaderTooltip';
+
+/**
+ * Header badge for the wallet-api session state (#351 / sphere-sdk#515 F3).
+ *
+ * Renders ONLY when the wallet-api composition is active and the session is
+ * 'offline' — i.e. the SDK could not sign in to the backend, so server
+ * custody (inventory + mailbox) is not reachable even though the app booted.
+ * The 2026-06-12 incident class: this state must be visible, never log-only.
+ */
+export function WalletApiSessionIndicator() {
+  const { walletApiEnabled } = useSphereContext();
+  const { status, lastError } = useWalletApiSession();
+
+  if (!walletApiEnabled || status !== 'offline') return null;
+
+  return (
+    <HeaderTooltip
+      label={lastError ?? 'wallet-api sign-in failed — assets are unavailable'}
+    >
+      <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-red-500/10">
+        <span className="relative">
+          <CloudOff className="w-4 h-4 sm:w-5 sm:h-5 text-red-400 dark:text-red-500" />
+          <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+        </span>
+        <span className="text-xs font-medium text-red-400 dark:text-red-500">
+          Wallet API offline
+        </span>
+      </div>
+    </HeaderTooltip>
+  );
+}

--- a/src/components/wallet/WalletPanel.tsx
+++ b/src/components/wallet/WalletPanel.tsx
@@ -60,7 +60,11 @@ export function WalletPanel() {
           </div>
           <div className="space-y-1">
             <p className="text-sm font-medium text-neutral-900 dark:text-[#fefefe]">Initialization error</p>
-            <p className="text-xs text-neutral-500 dark:text-[rgba(255,255,255,0.45)]">Please reload the page</p>
+            {/* Show the actual message: composition asserts (#351) name the
+                misconfigured env vars — a generic "reload" hides the cause. */}
+            <p className="text-xs text-neutral-500 dark:text-[rgba(255,255,255,0.45)] break-words">
+              {walletError.message || 'Please reload the page'}
+            </p>
           </div>
           <motion.button
             whileHover={{ scale: 1.02 }}

--- a/src/config/walletApi.ts
+++ b/src/config/walletApi.ts
@@ -25,16 +25,49 @@ function resolveUrl(value: string): string {
   return new URL(value, window.location.origin).toString();
 }
 
-/** Backend base URL when wallet-api mode is enabled; null otherwise. */
+/**
+ * True when this bundle declares wallet-api intent (`VITE_REQUIRE_WALLET_API`).
+ * Set by deployments whose custody model is wallet-api (the Pages workflow):
+ * any value other than empty/`false`/`0` counts as set.
+ */
+export function isWalletApiRequired(): boolean {
+  const raw = import.meta.env.VITE_REQUIRE_WALLET_API as string | undefined;
+  return !!raw && raw !== 'false' && raw !== '0';
+}
+
+/**
+ * Backend base URL when wallet-api mode is enabled; null otherwise.
+ *
+ * #351 assert (2026-06-12 incident): a bundle built with
+ * `VITE_REQUIRE_WALLET_API` but without `VITE_WALLET_API_URL` must fail at
+ * provider composition instead of silently falling back to the legacy
+ * local-custody composition — a missing URL would otherwise CHANGE the
+ * custody model, not just degrade a feature.
+ */
 export function getWalletApiBaseUrl(): string | null {
   const raw = import.meta.env.VITE_WALLET_API_URL as string | undefined;
-  if (!raw) return null;
+  if (!raw) {
+    if (isWalletApiRequired()) {
+      throw new Error(
+        'VITE_REQUIRE_WALLET_API is set but VITE_WALLET_API_URL is missing or empty — ' +
+          'this build declares wallet-api custody, so composing the legacy local-custody ' +
+          'bundle instead would silently change the custody model. Bake VITE_WALLET_API_URL ' +
+          'into the build, or unset VITE_REQUIRE_WALLET_API for an intentionally legacy deployment.',
+      );
+    }
+    return null;
+  }
   return resolveUrl(raw);
 }
 
-/** True when the asset path rides wallet-api (drives IPFS-off, UI hints). */
+/**
+ * True when the asset path rides wallet-api (drives IPFS-off, UI hints).
+ * Reads the raw env (no #351 assert) so render paths never throw: the assert
+ * fires once, at provider composition (`buildProviders`), where
+ * SphereProvider catches it and surfaces a visible initialization error.
+ */
 export function isWalletApiEnabled(): boolean {
-  return getWalletApiBaseUrl() !== null;
+  return !!(import.meta.env.VITE_WALLET_API_URL as string | undefined);
 }
 
 /**

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -112,6 +112,11 @@ function setupIpfsSync(instance: Sphere, providers: BrowserProviders): void {
  * thin server-custody token storage + mailbox delivery + the S1 client.
  * Composing `delivery` moves ASSETS to wallet-api; messaging, group chat and
  * nametags stay on the Nostr transport in the base bundle.
+ *
+ * Fail-closed (#351): on builds with VITE_REQUIRE_WALLET_API set,
+ * getWalletApiBaseUrl() throws when VITE_WALLET_API_URL is missing — the
+ * error is caught by initialize() and surfaced as a visible init error
+ * instead of silently composing the legacy local-custody bundle.
  */
 function buildProviders(network: NetworkType): SphereAppProviders {
   const base = createBrowserProviders({

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useSphereContext } from './useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { formatAmount } from '../../index';
-import { showTransferToast } from '../../../components/ui/toast-utils';
+import { showToast, showTransferToast } from '../../../components/ui/toast-utils';
 import { CHAT_KEYS, GROUP_CHAT_KEYS, type DmReceivedDetail } from '../../../components/chat/data/chatTypes';
 import { sendWelcomeDM } from '../../welcomeDM';
 import type { IncomingTransfer } from '@unicitylabs/sphere-sdk';
@@ -167,6 +167,17 @@ export function useSphereEvents(): void {
       });
     };
 
+    // sphere-sdk#515 F2: a background custody save failed — the active
+    // custody provider rejected a write. Surface it (never log-only); the
+    // SEND pipeline already fails hard on its own writes.
+    const handleStorageDegraded = (data: { providerId: string; error: string }) => {
+      showToast(
+        `Token storage degraded (${data.providerId}): a background save failed — ${data.error}`,
+        'error',
+        10000,
+      );
+    };
+
     sphere.on('transfer:incoming', handleIncomingTransfer);
     sphere.on('transfer:confirmed', handleTransferConfirmed);
     sphere.on('history:updated', handleHistoryUpdated);
@@ -179,6 +190,7 @@ export function useSphereEvents(): void {
     sphere.on('message:read', handleMessageRead);
     sphere.on('composing:started', handleComposingStarted);
     sphere.on('payment_request:incoming', handlePaymentRequestIncoming);
+    sphere.on('storage:degraded', handleStorageDegraded);
 
     return () => {
       if (invalidateTimerRef.current) {
@@ -197,6 +209,7 @@ export function useSphereEvents(): void {
       sphere.off('message:read', handleMessageRead);
       sphere.off('composing:started', handleComposingStarted);
       sphere.off('payment_request:incoming', handlePaymentRequestIncoming);
+      sphere.off('storage:degraded', handleStorageDegraded);
     };
   }, [sphere, queryClient]);
 }

--- a/src/sdk/hooks/core/useWalletApiSession.ts
+++ b/src/sdk/hooks/core/useWalletApiSession.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useSphereContext } from './useSphere';
+
+export type WalletApiSessionStatus = 'online' | 'offline' | null;
+
+export interface UseWalletApiSessionReturn {
+  /** null until the first sign-in attempt resolves, then 'online'/'offline'. */
+  status: WalletApiSessionStatus;
+  /** Error string from the last 'offline' transition; null while online. */
+  lastError: string | null;
+}
+
+/**
+ * wallet-api session health (#351 / sphere-sdk#515 F3): the SDK records a
+ * failed wallet-api sign-in (`walletapi:session` event +
+ * `sphere.walletApiSessionStatus`) instead of silently degrading. This hook
+ * mirrors that state into React so the Header can show an offline badge.
+ */
+export function useWalletApiSession(): UseWalletApiSessionReturn {
+  const { sphere } = useSphereContext();
+  const [status, setStatus] = useState<WalletApiSessionStatus>(null);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sphere) {
+      setStatus(null);
+      setLastError(null);
+      return;
+    }
+
+    // Seed from the getter — the event may have fired during Sphere.init,
+    // before this hook mounted.
+    setStatus(sphere.walletApiSessionStatus);
+
+    const handleSession = (data: { status: 'online' | 'offline'; error?: string }) => {
+      setStatus(data.status);
+      setLastError(
+        data.status === 'offline' ? (data.error ?? 'wallet-api sign-in failed') : null,
+      );
+    };
+
+    sphere.on('walletapi:session', handleSession);
+    return () => {
+      sphere.off('walletapi:session', handleSession);
+    };
+  }, [sphere]);
+
+  return { status, lastError };
+}

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -9,6 +9,8 @@ export type { UseNametagReturn } from './core/useNametag';
 export { useSphereEvents } from './core/useSphereEvents';
 export { useIpfsSync } from './core/useIpfsSync';
 export type { IpfsSyncStatus, IpfsSyncState, UseIpfsSyncReturn } from './core/useIpfsSync';
+export { useWalletApiSession } from './core/useWalletApiSession';
+export type { WalletApiSessionStatus, UseWalletApiSessionReturn } from './core/useWalletApiSession';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/tests/unit/config/walletApi.test.ts
+++ b/tests/unit/config/walletApi.test.ts
@@ -3,6 +3,7 @@ import {
   getWalletApiBaseUrl,
   getEngineOverride,
   isWalletApiEnabled,
+  isWalletApiRequired,
 } from "../../../src/config/walletApi";
 
 afterEach(() => {
@@ -12,6 +13,7 @@ afterEach(() => {
 describe("getWalletApiBaseUrl / isWalletApiEnabled", () => {
   it("is disabled when VITE_WALLET_API_URL is unset", () => {
     vi.stubEnv("VITE_WALLET_API_URL", "");
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", ""); // isolate from local .env (#351 assert)
     expect(getWalletApiBaseUrl()).toBeNull();
     expect(isWalletApiEnabled()).toBe(false);
   });
@@ -25,6 +27,55 @@ describe("getWalletApiBaseUrl / isWalletApiEnabled", () => {
   it("resolves relative URLs (dev/preview proxy paths) against the app origin", () => {
     vi.stubEnv("VITE_WALLET_API_URL", "/wallet-api");
     expect(getWalletApiBaseUrl()).toBe(`${window.location.origin}/wallet-api`);
+  });
+});
+
+describe("VITE_REQUIRE_WALLET_API composition assert (#351)", () => {
+  it("flag unset + URL unset → legacy composition allowed (null, no throw)", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "");
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(isWalletApiRequired()).toBe(false);
+    expect(getWalletApiBaseUrl()).toBeNull();
+  });
+
+  it("flag set + URL unset → throws naming BOTH vars (never silently legacy)", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "true");
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(isWalletApiRequired()).toBe(true);
+    expect(() => getWalletApiBaseUrl()).toThrow(/VITE_REQUIRE_WALLET_API/);
+    expect(() => getWalletApiBaseUrl()).toThrow(/VITE_WALLET_API_URL/);
+    expect(() => getWalletApiBaseUrl()).toThrow(/custody/);
+  });
+
+  it("any non-false flag value arms the assert ('1', 'yes')", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    for (const value of ["1", "yes"]) {
+      vi.stubEnv("VITE_REQUIRE_WALLET_API", value);
+      expect(isWalletApiRequired()).toBe(true);
+      expect(() => getWalletApiBaseUrl()).toThrow(/VITE_WALLET_API_URL/);
+    }
+  });
+
+  it("explicit opt-outs 'false' and '0' disarm the assert", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    for (const value of ["false", "0"]) {
+      vi.stubEnv("VITE_REQUIRE_WALLET_API", value);
+      expect(isWalletApiRequired()).toBe(false);
+      expect(getWalletApiBaseUrl()).toBeNull();
+    }
+  });
+
+  it("flag set + URL set → normal wallet-api composition (no throw)", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "true");
+    vi.stubEnv("VITE_WALLET_API_URL", "https://wallet-api.staging.unicity.network");
+    expect(getWalletApiBaseUrl()).toBe("https://wallet-api.staging.unicity.network/");
+    expect(isWalletApiEnabled()).toBe(true);
+  });
+
+  it("isWalletApiEnabled never throws (render-path safety): misconfigured build reports false", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "true");
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(isWalletApiEnabled()).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #351

Finishes the 2026-06-12 incident-hardening chain on the frontend, coupled with the sphere-sdk 0.9.1-dev.8 bump (the #515/#516 fail-closed release, PR unicity-sphere/sphere-sdk#518).

## SDK bump
- `@unicitylabs/sphere-sdk` `0.9.1-dev.7` → exact `0.9.1-dev.8` (lockfile updated; tarball verified to carry `dist/impl/shared/wallet-api/index.d.ts`).

## #351 composition assert (F4)
- New `VITE_REQUIRE_WALLET_API` flag: when truthy (`'false'`/`'0'` opt out) and `VITE_WALLET_API_URL` is missing/empty, `getWalletApiBaseUrl()` throws at provider composition (`buildProviders`) with a message naming **both** vars — the app can no longer silently compose the legacy local-custody bundle when the deployment intended wallet-api custody (the stale-CDN incident path).
- `isWalletApiEnabled()` now reads the raw env so render paths never throw; the assert fires exactly once inside `initialize()`'s try, and `WalletPanel`'s init-error card now displays `walletError.message` so the misconfigured vars are visible in the UI, not just the console.
- The Pages workflow (`deploy-pages-branch.yml`) sets `VITE_REQUIRE_WALLET_API: 'true'` alongside `VITE_WALLET_API_URL`; both vars documented in `.env.example`.
- Unit tests: set/unset matrix (unset+unset → legacy null; set+unset → throws naming both vars; `'1'`/`'yes'` arm; `'false'`/`'0'` disarm; set+set → normal composition; `isWalletApiEnabled` render-path safety).

## sphere-sdk#515 F3/F2 signal surfacing (display-only)
- `walletapi:session` / `Sphere.walletApiSessionStatus` → new `useWalletApiSession` hook + `WalletApiSessionIndicator` header badge: a red "Wallet API offline" badge (error detail in tooltip) that renders only in wallet-api mode when the session is `offline` — the composition sibling of `IpfsSyncIndicator` (which renders only in legacy mode), mounted in both the desktop header and the mobile menu.
- `storage:degraded` → error toast (10s) through the existing `show-toast` bridge in `useSphereEvents`, naming the degraded provider and error.

## Gates
- `eslint .` — 0 errors (3 pre-existing warnings in `ExplorePage.tsx`, untouched)
- `vitest run` — 58/58 passing (6 files)
- `npm run build` (tsc -b + vite) — green

No existing unit test composed wallet-api custody without a client, so dev.8's fail-closed `INVALID_CONFIG` guard caught nothing in the suite — the full suite passes unmodified against the new SDK.