### PR TITLE
fix(marketplace): proactively gate marketplace on maintenance status

### DIFF
--- a/src/hooks/useMaintenanceStatus.ts
+++ b/src/hooks/useMaintenanceStatus.ts
@@ -1,0 +1,65 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+const API_BASE = import.meta.env.VITE_SPHERE_API_URL ?? 'http://localhost:3001';
+
+export interface MaintenanceStatus {
+  enabled: boolean;
+  message: string | null;
+  updatedAt: string | null;
+}
+
+const NOT_UNDER_MAINTENANCE: MaintenanceStatus = { enabled: false, message: null, updatedAt: null };
+
+/**
+ * Polls the allowlisted `/api/maintenance/status` endpoint. That route is exempt
+ * from the maintenance gate, so it always answers 200 — unlike the marketplace
+ * routes, which answer 503 while `sphere` is under maintenance. Knowing the state
+ * up-front lets us skip the marketplace requests entirely instead of firing them
+ * and letting the browser log the (expected) 503s as red console errors.
+ */
+async function fetchStatus(): Promise<MaintenanceStatus> {
+  try {
+    const res = await fetch(`${API_BASE}/api/maintenance/status`, {
+      headers: { 'x-client': 'sphere' },
+    });
+    if (!res.ok) return NOT_UNDER_MAINTENANCE;
+    return (await res.json()) as MaintenanceStatus;
+  } catch {
+    // Fail-open: a hiccup on the status endpoint must never hide the marketplace.
+    return NOT_UNDER_MAINTENANCE;
+  }
+}
+
+export function useMaintenanceStatus() {
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    // If any API call slips through and gets a 503 maintenance response, it
+    // dispatches `maintenance:forced` — invalidate immediately instead of
+    // waiting up to 30s for the next poll.
+    const handler = (): void => { void qc.invalidateQueries({ queryKey: ['maintenance-status'] }); };
+    window.addEventListener('maintenance:forced', handler);
+    return () => window.removeEventListener('maintenance:forced', handler);
+  }, [qc]);
+
+  return useQuery({
+    queryKey: ['maintenance-status'],
+    queryFn: fetchStatus,
+    refetchInterval: 30_000,
+    staleTime: 0,
+    retry: 1,
+  });
+}
+
+/**
+ * Gate for marketplace queries. True only once we KNOW the API is not under
+ * maintenance for the `sphere` client. While the status is still loading the
+ * gate stays closed so marketplace requests wait for the (fast, allowlisted)
+ * status call rather than racing ahead and triggering 503s. `fetchStatus`
+ * fails open, so a status outage never permanently blocks the marketplace.
+ */
+export function useMarketplaceEnabled(): boolean {
+  const { data, isSuccess } = useMaintenanceStatus();
+  return isSuccess && !data.enabled;
+}

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -11,88 +11,108 @@ import {
   fetchRatingReplies,
   fetchCategories,
 } from '../services/marketplaceApi';
+import { useMarketplaceEnabled } from './useMaintenanceStatus';
+
+// Every query below talks to the sphere-api marketplace/metrics routes, which the
+// maintenance gate answers with 503 while `sphere` is under maintenance. Gating on
+// `useMarketplaceEnabled()` means the requests simply don't fire in that window, so
+// the browser never logs the (expected) 503s as red console errors. The wallet core
+// is unaffected — it talks to the chain/SDK, not sphere-api.
 
 export function useProjects(params?: { type?: 'app' | 'skill'; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'projects', params],
     queryFn: () => fetchProjects(params),
+    enabled: marketplaceEnabled,
     staleTime: 5 * 60_000,
   });
 }
 
 export function useFeaturedProjects(type?: 'app' | 'skill') {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'featured', type],
     queryFn: () => fetchFeaturedProjects(type),
+    enabled: marketplaceEnabled,
     staleTime: 5 * 60_000,
     retry: 1,
   });
 }
 
 export function useProject(slug: string, preview?: boolean) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project', slug, { preview }],
     queryFn: () => fetchProject(slug, preview),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
   });
 }
 
 export function useProjectQuests(slug: string) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project-quests', slug],
     queryFn: () => fetchProjectQuests(slug),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
   });
 }
 
 export function useProjectAchievements(slug: string) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project-achievements', slug],
     queryFn: () => fetchProjectAchievements(slug),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
   });
 }
 
 export function useCategories() {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'categories'],
     queryFn: fetchCategories,
+    enabled: marketplaceEnabled,
     staleTime: 10 * 60_000,
   });
 }
 
 export function useProjectMetrics(projectId: string | undefined) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['metrics', 'project', projectId],
     queryFn: () => fetchProjectMetrics(projectId!),
-    enabled: !!projectId,
+    enabled: marketplaceEnabled && !!projectId,
     staleTime: 60_000,
   });
 }
 
 export function useProjectMetricsBatch(projectIds: string[]) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['metrics', 'projects', projectIds.slice().sort().join(',')],
     queryFn: () => fetchProjectMetricsBatch(projectIds),
-    enabled: projectIds.length > 0,
+    enabled: marketplaceEnabled && projectIds.length > 0,
     staleTime: 60_000,
   });
 }
 
 export function useProjectRatings(slug: string | undefined, page = 1, sort: 'helpful' | 'recent' = 'helpful') {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'ratings', slug, page, sort],
     queryFn: () => fetchProjectRatings(slug!, page, 20, sort),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
     staleTime: 30_000,
   });
 }
 
 export function useRatingReplies(ratingId: string | undefined, enabled = true) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'replies', ratingId],
     queryFn: () => fetchRatingReplies(ratingId!),
-    enabled: enabled && !!ratingId,
+    enabled: marketplaceEnabled && enabled && !!ratingId,
     staleTime: 15_000,
   });
 }

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -7,6 +7,7 @@ import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCa
 import { ProjectCard } from '../components/marketplace/ProjectCard';
 import { CategoryFilter } from '../components/marketplace/CategoryFilter';
 import { MaintenanceScreen } from '../components/MaintenanceScreen';
+import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -101,16 +102,10 @@ function HeroDivider() {
 export function ExplorePage() {
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState<string | null>(null);
-  const [maintenance, setMaintenance] = useState<string | null | undefined>(undefined);
-
-  useEffect(() => {
-    function onForced(e: Event) {
-      const detail = (e as CustomEvent<{ message?: string }>).detail;
-      setMaintenance(detail?.message ?? null);
-    }
-    window.addEventListener('maintenance:forced', onForced);
-    return () => window.removeEventListener('maintenance:forced', onForced);
-  }, []);
+  // Proactive maintenance status — the hook polls the allowlisted status endpoint
+  // and also listens for `maintenance:forced`, so the marketplace queries (gated on
+  // the same status) never fire requests that would 503 during maintenance.
+  const { data: maintenance } = useMaintenanceStatus();
 
   // Data — always filtered for apps only
   const { data: projectsData, isLoading } = useProjects({ type: 'app' });
@@ -155,8 +150,8 @@ export function ExplorePage() {
   const itemLabel = 'projects';
   const searchPlaceholder = 'Search projects...';
 
-  if (maintenance !== undefined) {
-    return <MaintenanceScreen message={maintenance} />;
+  if (maintenance?.enabled) {
+    return <MaintenanceScreen message={maintenance.message} />;
   }
 
   return (


### PR DESCRIPTION
## Problem
While `sphere-api` is in **maintenance mode**, its maintenance gate answers the marketplace/metrics routes with **503** for client `sphere` (by design). The browser logs each 503 as a red console error:

```
GET .../api/marketplace/featured 503 (Service Unavailable)
GET .../api/marketplace 503 (Service Unavailable)
```

This is expected behaviour — the user already sees the `MaintenanceScreen` — but the console noise looks like a failure and alarms the team. These same endpoints also feed the **desktop home shortcuts**, so they fire on load.

## Fix
Add `useMaintenanceStatus` — polls the **allowlisted** `/api/maintenance/status` endpoint (always **200**, exempt from the gate) and exposes `useMarketplaceEnabled()`. Every marketplace/metrics query in `useMarketplace.ts` now gates on it, so **under maintenance the requests never fire → zero 503s in the console**. `ExplorePage` reads the same status to show the `MaintenanceScreen` proactively, and the hook still listens for `maintenance:forced` to flip instantly if a 503 ever slips through.

## Scoped on purpose
Unlike `sphere-quest-frontend`, sphere is a **wallet** — its core (balance, chat, agents, send/receive) talks to the chain/SDK, not `sphere-api`. So this is **not** a whole-app gate: only the marketplace surfaces are gated; the wallet stays fully usable during maintenance and the desktop home just hides its marketplace sections.

## Verification
- `tsc -b && vite build` — passes.
- `eslint` on changed files — 0 errors (only pre-existing `allItems` exhaustive-deps warnings).