### PR TITLE
Pin sphere-sdk 0.9.1-dev.9 (reload fix #521) + F5 smoke assertions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.8",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.8.tgz",
-      "integrity": "sha512-ktnIa0LR9XAKE6mobqBXy669ntXXTWfxseWfs0v2pxyRI8KVeS+eVk20QuHxfucHnt03tVfamygUnQpOhqdTuA==",
+      "version": "0.9.1-dev.9",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.9.tgz",
+      "integrity": "sha512-LHKBDpFOP+ZxkprNyWmmOyaqAZuX6tx0oyBfOLIZVythLISYsyWtvdziuc+jzybygzBTE4yucigNX2wjbzbS7A==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/tests/e2e/two-profile-smoke.spec.ts
+++ b/tests/e2e/two-profile-smoke.spec.ts
@@ -11,6 +11,11 @@
  *   A creates + funds a wallet → sends UCT to B → B sees the balance →
  *   B sends A a payment request → A pays it → both UIs converge.
  *
+ * Each profile is hard-reloaded (F5) right after its first balance
+ * assertion: reload drops all in-memory engine state, so re-asserting the
+ * SAME balance proves it survives a full pull from wallet-api (the
+ * sphere-sdk#521 regression — fixed in 0.9.1-dev.9 — lost it here).
+ *
  * Nametags ride Nostr (unchanged by this integration) and are REQUIRED for
  * recipient resolution: the engine send path needs the recipient's published
  * chain pubkey, so both profiles register one during onboarding.
@@ -72,6 +77,16 @@ async function createWallet(page: Page, tag: string): Promise<void> {
   });
 }
 
+/**
+ * F5 and re-assert the same balance. Reload discards all in-memory state,
+ * so the balance can only come back via the full pull from wallet-api —
+ * exactly the path sphere-sdk#521 broke (fixed in 0.9.1-dev.9).
+ */
+async function reloadAndExpectBalance(page: Page, balance: string): Promise<void> {
+  await page.reload();
+  await expect(visible(page, balance)).toBeVisible({ timeout: 240_000 });
+}
+
 /** Open mint via Top Up (UCT/BTC/SOL/ETH basket) and wait for the deposit. */
 async function topUp(page: Page): Promise<void> {
   await visibleButton(page, 'Top Up').click();
@@ -91,6 +106,9 @@ test('two profiles converge over wallet-api: fund, send, request, pay', async ({
   await createWallet(a, TAG_A);
   await createWallet(b, TAG_B);
   await topUp(a);
+
+  // ── A reloads (F5): minted balance must survive the full pull ───────────
+  await reloadAndExpectBalance(a, '100.0000 UCT');
 
   // ── A sends 10 UCT to @B (mailbox delivery + B's claim/handoff) ─────────
   await visibleButton(a, 'Send').click();
@@ -112,6 +130,9 @@ test('two profiles converge over wallet-api: fund, send, request, pay', async ({
 
   // ── B receives: wake → mailbox claim → inventory custody → balance ──────
   await expect(visible(b, '10.0000 UCT')).toBeVisible({ timeout: 240_000 });
+
+  // ── B reloads (F5): received balance must survive the full pull ─────────
+  await reloadAndExpectBalance(b, '10.0000 UCT');
 
   // ── B requests 5 UCT from @A (§16 payment request) ──────────────────────
   await visibleButton(b, 'Top Up').click();


### PR DESCRIPTION
Closes #357

## What

- Pin `@unicitylabs/sphere-sdk` `0.9.1-dev.8` → `0.9.1-dev.9` (npm; lockfile resolves dev.9).
- Extend `tests/e2e/two-profile-smoke.spec.ts` with hard-reload (F5) assertions:
  - after profile A's mint assertion: `page.reload()` + re-assert `100.0000 UCT`;
  - after profile B's receive assertion: `page.reload()` + re-assert `10.0000 UCT`.

## Why

dev.9 ships the sphere-sdk#521 fix (PR #522): a reload discards all in-memory engine state, so a re-asserted balance can only come back via the full pull from wallet-api — exactly the path #521 broke. The new assertions fail on dev.8 and pass on dev.9, locking the fix in.

## Verification

- Local: `tsc -b` and ESLint clean; the two-profile Playwright smoke run against the live dev compose stack (real wallet-api + Postgres + Redis + MinIO + mock aggregator), reload assertions included.
- CI on this PR is the authoritative gate.