### PR TITLE
Wallet api integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,23 @@ VITE_SPHERE_API_URL=http://localhost:3001
 # For mainnet this MUST be a real secret: set it only in the deploy env, never commit it.
 VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 
+# wallet-api backend (S4 provider swap). When set, the ASSET path rides the
+# wallet-api backend (server inventory custody + mailbox delivery + §16
+# payment requests); messaging/DMs/nametags stay on Nostr. Unset → the legacy
+# local-custody composition. Relative values resolve against the app origin
+# and are served by the dev/preview proxy, which forwards them to
+# WALLET_API_PROXY_TARGET (default http://127.0.0.1:3000 — the wallet-api
+# repo's `docker compose -f docker-compose.dev.yml up --build --wait` stack).
+VITE_WALLET_API_URL=/wallet-api
+
+# LOCAL dev-stack engine override (used by the two-profile smoke): point the
+# v2 token engine at the mock aggregator AND the trustbase that same gateway
+# serves. Set BOTH or neither — never mix a gateway with another network's
+# trustbase. Relative values ride the dev/preview proxy
+# (AGGREGATOR_PROXY_TARGET, default http://127.0.0.1:3001).
+#VITE_AGGREGATOR_URL=/local-agg
+#VITE_TRUSTBASE_URL=/local-agg/trustbase.json
+
 # Welcome DM
 VITE_WELCOME_AGENT_NAMETAG=kbbot
 VITE_WELCOME_DELAY_MS=4000

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 #VITE_WALLET_API_URL=https://wallet-api.staging.unicity.network
 VITE_WALLET_API_URL=/wallet-api
 
+# Composition assert (#351). Set on deployments that INTEND wallet-api
+# custody (the Pages workflow sets it next to VITE_WALLET_API_URL): when
+# truthy ('false'/'0' count as unset) and VITE_WALLET_API_URL is missing or
+# empty, provider composition throws instead of silently falling back to the
+# legacy local-custody bundle — a missing URL would change the custody model,
+# not just degrade a feature. Leave unset for intentionally legacy builds.
+#VITE_REQUIRE_WALLET_API=true
+
 # LOCAL dev-stack engine override (used by the two-profile smoke): point the
 # v2 token engine at the mock aggregator AND the trustbase that same gateway
 # serves. Set BOTH or neither — never mix a gateway with another network's

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 # and are served by the dev/preview proxy, which forwards them to
 # WALLET_API_PROXY_TARGET (default http://127.0.0.1:3000 — the wallet-api
 # repo's `docker compose -f docker-compose.dev.yml up --build --wait` stack).
+# Absolute https URLs pass through unchanged — the staging backend serves
+# wildcard CORS, so it works cross-origin without the proxy. This is the
+# value the GitHub Pages branch deploys bake in at build time (see
+# .github/workflows/deploy-pages-branch.yml):
+#VITE_WALLET_API_URL=https://wallet-api.staging.unicity.network
 VITE_WALLET_API_URL=/wallet-api
 
 # LOCAL dev-stack engine override (used by the two-profile smoke): point the

--- a/.github/workflows/deploy-pages-branch.yml
+++ b/.github/workflows/deploy-pages-branch.yml
@@ -9,9 +9,36 @@ on:
 permissions:
   contents: write  # Needed to push to gh-pages branch
 
+# Per-operation concurrency (sphere#369). Deploys are keyed per-branch
+# (`deploy-<branch>`) and delete-cleanups per-deleted-ref (`cleanup-<type>-<ref>`)
+# in DISJOINT namespaces, so a branch-deletion cleanup can never share a group
+# with — and therefore can never cancel — any branch's deploy.
+#
+# The old global `gh-pages-deploy` group (with cancel-in-progress: false) put
+# the push-deploy and the delete-cleanup in the SAME group. On a squash-merge
+# that also deletes the PR branch, both runs become pending together; GitHub
+# keeps only the newest pending run per group and cancels the older one, so the
+# just-merged deploy was silently cancelled and staging kept the old bundle.
+# Note `github.ref` is NOT a fix on its own: on a `delete` event it resolves to
+# the default branch (`main`), so it would still collide a deploy of `main` with
+# any cleanup. The event-aware prefixed key below is collision-free regardless
+# of which branch is the default. (ref_type is folded into the cleanup key so a
+# branch and a same-named tag deleted together don't share a cleanup group.)
+#
+# Trade-off vs. the old design: the global group serialized ALL gh-pages pushes,
+# so they never raced. These per-op groups let pushes of DIFFERENT refs overlap,
+# and peaceiris pushes non-force with no retry (verified against the action
+# source). So two near-simultaneous deploys (two branches whose ~2-min builds
+# finish together) — or the run's two sequential pushes, build-and-deploy then
+# deploy-redirect, when a foreign push interleaves — can fail with a re-runnable
+# non-fast-forward error (re-run the workflow). That is never a folder-restore
+# and never a silent no-ship: a loud, recoverable failure replacing #369's
+# invisible one. (A deploy-vs-cleanup overlap is rarer still: a deploy pushes
+# only after its build, by which point a seconds-fast cleanup has already landed
+# and the deploy fast-forwards cleanly.)
 concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
+  group: pages-${{ github.event_name == 'delete' && format('cleanup-{0}-{1}', github.event.ref_type, github.event.ref) || format('deploy-{0}', github.ref_name) }}
+  cancel-in-progress: true
 
 jobs:
   # Cleanup job - runs when a branch is deleted

--- a/.github/workflows/deploy-pages-branch.yml
+++ b/.github/workflows/deploy-pages-branch.yml
@@ -77,6 +77,14 @@ jobs:
           # Public URL — baked into the bundle at build time. Hardcoded
           # because the same value applies to every branch preview deploy.
           VITE_SPHERE_API_URL: https://quest-api.staging.unicity.network
+          # wallet-api backend (S4 asset path) — absolute https URL, baked in
+          # at build time. The staging backend serves wildcard CORS, so the
+          # github.io origin reaches it directly (no dev proxy involved; the
+          # SDK derives the wss:// wake socket from this same base). Engine
+          # override vars (VITE_AGGREGATOR_URL / VITE_TRUSTBASE_URL) stay
+          # UNSET here on purpose: the testnet2 network preset supplies the
+          # real gateway + the trustbase it serves — never mix trustbases.
+          VITE_WALLET_API_URL: https://wallet-api.staging.unicity.network
           # Aggregator API key — inlined into the bundle at build time.
           # The testnet2 value is NOT a secret (see .env / .env.example), so it
           # is safe to hardcode here. Without it the deployed bundle gets

--- a/.github/workflows/deploy-pages-branch.yml
+++ b/.github/workflows/deploy-pages-branch.yml
@@ -85,6 +85,12 @@ jobs:
           # UNSET here on purpose: the testnet2 network preset supplies the
           # real gateway + the trustbase it serves — never mix trustbases.
           VITE_WALLET_API_URL: https://wallet-api.staging.unicity.network
+          # #351 composition assert: this deploy INTENDS wallet-api custody —
+          # if VITE_WALLET_API_URL ever goes missing from a bundle (stale CDN
+          # rebuild, env drift), the app fails fast at provider composition
+          # instead of silently swapping to the legacy local-custody model
+          # (the 2026-06-12 incident).
+          VITE_REQUIRE_WALLET_API: 'true'
           # Aggregator API key — inlined into the bundle at build time.
           # The testnet2 value is NOT a secret (see .env / .env.example), so it
           # is safe to hardcode here. Without it the deployed bundle gets

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist-ssr
 *.local
 agentic-chatbot-main
 
+# Playwright artifacts (two-profile smoke)
+test-results
+playwright-report
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.16",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.15",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.15.tgz",
-      "integrity": "sha512-eWRefN7z6q6MHEoXdX+mRmmjyCaqLZ6Vj/QEst8wP+t80i7LEn3C69d+Yt9pkZXg0E/r6vgOHBmuxyL7t+jWtA==",
+      "version": "0.9.1-dev.16",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.16.tgz",
+      "integrity": "sha512-8AzwaQTZes2vdfP+P2W16X0qofCeZvt+LhsChB4qPi42CEp68UlkLpshzzEQXmuVbE6BP826NVa/IEeIoV52Yw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.17",
+        "@unicitylabs/sphere-sdk": "0.10.0",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.17",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.17.tgz",
-      "integrity": "sha512-VXFI/dfl5Fv9ubthbXWU8uzbQsoZKv6Hr4JIC56Tn6F92y1Pzk/kOr1jCZPYvK5vyEx3/2jncR8wxO/IjhmU8g==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.0.tgz",
+      "integrity": "sha512-MOo4Rd72udmitb7xtfmhXEx/IhqDre8BrjIFfFde2oi4XeFF2kmTF+CBI/bRJI9zkuqlLZ8w6mL3l7GkwMB2kg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.7",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.7.tgz",
-      "integrity": "sha512-Ht1+/cvS/sxK8+CG50cR8ksv4J/F8EA6PScO+o5FOqwz5gvL22gi+CxkJbpqcxPYMEZPamAOJw+Pi5ofg7TSOA==",
+      "version": "0.9.1-dev.8",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.8.tgz",
+      "integrity": "sha512-ktnIa0LR9XAKE6mobqBXy669ntXXTWfxseWfs0v2pxyRI8KVeS+eVk20QuHxfucHnt03tVfamygUnQpOhqdTuA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.12",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.12",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.12.tgz",
-      "integrity": "sha512-tSRpJHQUsNhIl4lGTY/DdMkblTxSXmWln7xjuvy0CzddlhwfxB/GlkqXNFz4c17GYeDtbgZtfN4OaU+tzGTSOA==",
+      "version": "0.9.1-dev.13",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.13.tgz",
+      "integrity": "sha512-ijFOa6LS8pLU76SpObNP1inwmJiKezCyBpUtGSj/gg42hgoL3vNvN4rbcUg5S2qXnDFa27LUG4vJCA+6gxrrLw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.10",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.10.tgz",
-      "integrity": "sha512-vL1TjXcA4PavY/eDNNhqaWQrlq8wJve7yCjxwRwKXIp5Qp8CqhzZT4C/0eQBDcXnIv3cc3UGUaXcJW+xpSaUQw==",
+      "version": "0.9.1-dev.11",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.11.tgz",
+      "integrity": "sha512-z0Y1Ld69RmhJfsH0nDHOS5AUg8rzQuMBytK67eBTALxOOe4FQXqdO5GOwVn0DuI1eLLENauDvtPS+qx0LCCm8w==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.8",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.8.tgz",
-      "integrity": "sha512-ktnIa0LR9XAKE6mobqBXy669ntXXTWfxseWfs0v2pxyRI8KVeS+eVk20QuHxfucHnt03tVfamygUnQpOhqdTuA==",
+      "version": "0.9.1-dev.9",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.9.tgz",
+      "integrity": "sha512-LHKBDpFOP+ZxkprNyWmmOyaqAZuX6tx0oyBfOLIZVythLISYsyWtvdziuc+jzybygzBTE4yucigNX2wjbzbS7A==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.13",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.13.tgz",
-      "integrity": "sha512-ijFOa6LS8pLU76SpObNP1inwmJiKezCyBpUtGSj/gg42hgoL3vNvN4rbcUg5S2qXnDFa27LUG4vJCA+6gxrrLw==",
+      "version": "0.9.1-dev.15",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.15.tgz",
+      "integrity": "sha512-eWRefN7z6q6MHEoXdX+mRmmjyCaqLZ6Vj/QEst8wP+t80i7LEn3C69d+Yt9pkZXg0E/r6vgOHBmuxyL7t+jWtA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.12",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.11",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.11.tgz",
-      "integrity": "sha512-z0Y1Ld69RmhJfsH0nDHOS5AUg8rzQuMBytK67eBTALxOOe4FQXqdO5GOwVn0DuI1eLLENauDvtPS+qx0LCCm8w==",
+      "version": "0.9.1-dev.12",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.12.tgz",
+      "integrity": "sha512-tSRpJHQUsNhIl4lGTY/DdMkblTxSXmWln7xjuvy0CzddlhwfxB/GlkqXNFz4c17GYeDtbgZtfN4OaU+tzGTSOA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.9",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.9.tgz",
-      "integrity": "sha512-LHKBDpFOP+ZxkprNyWmmOyaqAZuX6tx0oyBfOLIZVythLISYsyWtvdziuc+jzybygzBTE4yucigNX2wjbzbS7A==",
+      "version": "0.9.1-dev.10",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.10.tgz",
+      "integrity": "sha512-vL1TjXcA4PavY/eDNNhqaWQrlq8wJve7yCjxwRwKXIp5Qp8CqhzZT4C/0eQBDcXnIv3cc3UGUaXcJW+xpSaUQw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.16",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.17",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.16",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.16.tgz",
-      "integrity": "sha512-8AzwaQTZes2vdfP+P2W16X0qofCeZvt+LhsChB4qPi42CEp68UlkLpshzzEQXmuVbE6BP826NVa/IEeIoV52Yw==",
+      "version": "0.9.1-dev.17",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.17.tgz",
+      "integrity": "sha512-VXFI/dfl5Fv9ubthbXWU8uzbQsoZKv6Hr4JIC56Tn6F92y1Pzk/kOr1jCZPYvK5vyEx3/2jncR8wxO/IjhmU8g==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.9.0-dev.0",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@types/crypto-js": "^4.2.2",
@@ -1485,6 +1486,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2739,14 +2756,16 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.0-dev.0.tgz",
-      "integrity": "sha512-yjRmXEpjS7B2vBnPixqJSXv0zPX2x5IEy4c7LBy+ujvxTUKB6U4Y/DQuEVC9LDT5EhVeAgYoL9rwT3xCxac7Mw==",
+      "version": "0.9.1-dev.7",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.7.tgz",
+      "integrity": "sha512-Ht1+/cvS/sxK8+CG50cR8ksv4J/F8EA6PScO+o5FOqwz5gvL22gi+CxkJbpqcxPYMEZPamAOJw+Pi5ofg7TSOA==",
+      "license": "MIT",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@unicitylabs/nostr-js-sdk": "^0.5.0",
-        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
@@ -2785,6 +2804,18 @@
         "ws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@unicitylabs/sphere-sdk/node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
@@ -2854,9 +2885,10 @@
       "license": "MIT"
     },
     "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.0-rc.6027e82",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.6027e82.tgz",
-      "integrity": "sha512-PV6lHwJOCjpICG0Vd7Ty+5mZa7migGtopa1QVBjp9xRRtfNXDAvf8YPzXE6PQOtKCVP5ymmKuWKRKkNoNOw2zA==",
+      "version": "2.0.0-rc.68bc1e5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
+      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
+      "license": "ISC",
       "dependencies": {
         "@noble/curves": "2.2.0",
         "@noble/hashes": "2.2.0",
@@ -2874,6 +2906,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }
@@ -6120,6 +6153,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.17",
+    "@unicitylabs/sphere-sdk": "0.10.0",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.16",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.12",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.16",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.17",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.12",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.8",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -19,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.9.0-dev.0",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.7",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@types/crypto-js": "^4.2.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+/**
+ * Playwright config for the two-profile wallet-api smoke (LOCAL-ONLY).
+ *
+ * Requires the wallet-api dev stack (postgres + redis + minio + mock
+ * aggregator + wallet-api) running on the default loopback ports:
+ *
+ *   cd ../wallet-api && docker compose -f docker-compose.dev.yml up --build --wait
+ *   npm run test:e2e
+ *
+ * NOT part of CI (`.github/workflows/ci.yml` runs lint/unit/build only) —
+ * it needs docker and reaches public Nostr relays for nametag bindings.
+ *
+ * The app is built with the smoke env (wallet-api + LOCAL mock aggregator +
+ * the trustbase that same aggregator serves — never mix trustbases) and
+ * served by `vite preview`, whose proxy provides the same-origin route to
+ * the stack. Set SMOKE_BASE_URL to reuse an already-running dev server
+ * (e.g. `VITE_WALLET_API_URL=/wallet-api ... npm run dev`) while iterating.
+ */
+import { defineConfig } from '@playwright/test';
+
+const PORT = 4317;
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 600_000,
+  expect: { timeout: 30_000 },
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.SMOKE_BASE_URL || `http://localhost:${PORT}`,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: process.env.SMOKE_BASE_URL
+    ? undefined
+    : {
+        command: `npm run build && npx vite preview --port ${PORT} --strictPort`,
+        url: `http://localhost:${PORT}`,
+        reuseExistingServer: false,
+        timeout: 240_000,
+        env: {
+          VITE_WALLET_API_URL: '/wallet-api',
+          VITE_AGGREGATOR_URL: '/local-agg',
+          VITE_TRUSTBASE_URL: '/local-agg/trustbase.json',
+          // Keep the sphere-quest marketplace off the mock aggregator's port
+          // (its default base URL collides with :3001 on the dev stack).
+          VITE_SPHERE_API_URL: 'http://127.0.0.1:1',
+        },
+      },
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 // import { ThemeToggle } from '../theme';
 import { STORAGE_KEYS } from '../../config/storageKeys';
 import { IpfsSyncIndicator } from './IpfsSyncIndicator';
+import { WalletApiSessionIndicator } from './WalletApiSessionIndicator';
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { DiscordIcon, XIcon } from '../icons/SocialIcons';
 
@@ -152,9 +153,11 @@ export function Header() {
                 </div>
               )}
 
-              {/* Desktop: IPFS sync indicator */}
+              {/* Desktop: custody status — IPFS sync (legacy) / wallet-api
+                  session (S4); each renders only in its own composition. */}
               <div className="hidden lg:flex items-center gap-3">
                 <IpfsSyncIndicator />
+                <WalletApiSessionIndicator />
                 {/* <ThemeToggle /> */}
               </div>
             </div>
@@ -233,9 +236,10 @@ export function Header() {
               )
             ))}
 
-            {/* IPFS sync + Social links — mobile only */}
+            {/* Custody status + Social links — mobile only */}
             <div className="px-4 py-3 border-t border-neutral-200 dark:border-brand-orange-border mt-1 flex items-center">
               <IpfsSyncIndicator />
+              <WalletApiSessionIndicator />
               <div className="flex-1" />
               <div className="flex items-center gap-5">
                 {[

--- a/src/components/layout/IpfsSyncIndicator.tsx
+++ b/src/components/layout/IpfsSyncIndicator.tsx
@@ -16,13 +16,17 @@ function getStatusText(
 }
 
 export function IpfsSyncIndicator() {
-  const { ipfsEnabled, toggleIpfs } = useSphereContext();
+  const { ipfsEnabled, toggleIpfs, walletApiEnabled } = useSphereContext();
   const { status, lastSynced } = useIpfsSync();
   const isSyncing = ipfsEnabled && status === 'syncing';
   const isError = ipfsEnabled && status === 'error';
   const statusText = getStatusText(ipfsEnabled, status, lastSynced);
 
   const iconClass = 'w-4 h-4 sm:w-5 sm:h-5';
+
+  // wallet-api custody (S4): IPFS token sync is forced off in SphereProvider —
+  // hide the toggle so it cannot suggest a second token mirror exists.
+  if (walletApiEnabled) return null;
 
   return (
     <HeaderTooltip label={ipfsEnabled ? 'Disable IPFS sync' : 'Enable IPFS sync'}>

--- a/src/components/layout/WalletApiSessionIndicator.tsx
+++ b/src/components/layout/WalletApiSessionIndicator.tsx
@@ -1,34 +1,64 @@
-import { CloudOff } from 'lucide-react';
-import { useSphereContext, useWalletApiSession } from '../../sdk/hooks';
+import { CloudOff, RadioTower } from 'lucide-react';
+import { useSphereContext, useWalletApiSession, useRealtimeStatus } from '../../sdk/hooks';
 import { HeaderTooltip } from './HeaderTooltip';
 
 /**
- * Header badge for the wallet-api session state (#351 / sphere-sdk#515 F3).
+ * Header badge for the wallet-api session state (#351 / sphere-sdk#515 F3) and
+ * the realtime wake-socket liveness (`realtime:status`).
  *
- * Renders ONLY when the wallet-api composition is active and the session is
- * 'offline' — i.e. the SDK could not sign in to the backend, so server
- * custody (inventory + mailbox) is not reachable even though the app booted.
- * The 2026-06-12 incident class: this state must be visible, never log-only.
+ * Two distinct, ordered states (sign-in is the hard failure, takes priority):
+ *  - session 'offline' — the SDK could not sign in, so server custody
+ *    (inventory + mailbox) is unreachable even though the app booted. The
+ *    2026-06-12 incident class: must be visible, never log-only.
+ *  - signed-in but the wake socket is 'reconnecting'/'closed' — cross-session
+ *    updates won't arrive in realtime (they fall back to the slower poll
+ *    backstop). A window can be signed-in while its wake socket is dead, so
+ *    this liveness is surfaced separately from sign-in.
  */
 export function WalletApiSessionIndicator() {
   const { walletApiEnabled } = useSphereContext();
   const { status, lastError } = useWalletApiSession();
+  const { status: realtimeStatus } = useRealtimeStatus();
 
-  if (!walletApiEnabled || status !== 'offline') return null;
+  if (!walletApiEnabled) return null;
 
-  return (
-    <HeaderTooltip
-      label={lastError ?? 'wallet-api sign-in failed — assets are unavailable'}
-    >
-      <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-red-500/10">
-        <span className="relative">
-          <CloudOff className="w-4 h-4 sm:w-5 sm:h-5 text-red-400 dark:text-red-500" />
-          <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
-        </span>
-        <span className="text-xs font-medium text-red-400 dark:text-red-500">
-          Wallet API offline
-        </span>
-      </div>
-    </HeaderTooltip>
-  );
+  if (status === 'offline') {
+    return (
+      <HeaderTooltip
+        label={lastError ?? 'wallet-api sign-in failed — assets are unavailable'}
+      >
+        <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-red-500/10">
+          <span className="relative">
+            <CloudOff className="w-4 h-4 sm:w-5 sm:h-5 text-red-400 dark:text-red-500" />
+            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+          </span>
+          <span className="text-xs font-medium text-red-400 dark:text-red-500">
+            Wallet API offline
+          </span>
+        </div>
+      </HeaderTooltip>
+    );
+  }
+
+  // Wake-socket degraded while signed-in: realtime updates are delayed (the
+  // poll backstop still keeps state correct), so this is a milder warning.
+  if (realtimeStatus === 'reconnecting' || realtimeStatus === 'closed') {
+    return (
+      <HeaderTooltip
+        label="Realtime updates paused — reconnecting. Changes from other windows may be delayed."
+      >
+        <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-amber-500/10">
+          <span className="relative">
+            <RadioTower className="w-4 h-4 sm:w-5 sm:h-5 text-amber-500 dark:text-amber-400" />
+            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-amber-500" />
+          </span>
+          <span className="text-xs font-medium text-amber-500 dark:text-amber-400">
+            Reconnecting
+          </span>
+        </div>
+      </HeaderTooltip>
+    );
+  }
+
+  return null;
 }

--- a/src/components/layout/WalletApiSessionIndicator.tsx
+++ b/src/components/layout/WalletApiSessionIndicator.tsx
@@ -1,0 +1,34 @@
+import { CloudOff } from 'lucide-react';
+import { useSphereContext, useWalletApiSession } from '../../sdk/hooks';
+import { HeaderTooltip } from './HeaderTooltip';
+
+/**
+ * Header badge for the wallet-api session state (#351 / sphere-sdk#515 F3).
+ *
+ * Renders ONLY when the wallet-api composition is active and the session is
+ * 'offline' — i.e. the SDK could not sign in to the backend, so server
+ * custody (inventory + mailbox) is not reachable even though the app booted.
+ * The 2026-06-12 incident class: this state must be visible, never log-only.
+ */
+export function WalletApiSessionIndicator() {
+  const { walletApiEnabled } = useSphereContext();
+  const { status, lastError } = useWalletApiSession();
+
+  if (!walletApiEnabled || status !== 'offline') return null;
+
+  return (
+    <HeaderTooltip
+      label={lastError ?? 'wallet-api sign-in failed — assets are unavailable'}
+    >
+      <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-red-500/10">
+        <span className="relative">
+          <CloudOff className="w-4 h-4 sm:w-5 sm:h-5 text-red-400 dark:text-red-500" />
+          <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+        </span>
+        <span className="text-xs font-medium text-red-400 dark:text-red-500">
+          Wallet API offline
+        </span>
+      </div>
+    </HeaderTooltip>
+  );
+}

--- a/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
+++ b/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
@@ -87,10 +87,22 @@ export const useIncomingPaymentRequests = () => {
         // mounted (e.g. the wallet-api sign-in backfill) are not re-emitted.
         refresh();
 
+        // The SDK list is the source of truth: on incoming AND on resolution
+        // (paid / rejected / expired), the SDK advances the request's status in
+        // its own list, then emits. Re-reading drops a request resolved
+        // elsewhere (another window — or this wallet's other session) out of
+        // the actionable (PENDING) state, so its Pay/Decline buttons disappear:
+        // the UI half of the cross-session-sync fix.
         const handler = () => refresh();
         sphere.on('payment_request:incoming', handler);
+        sphere.on('payment_request:paid', handler);
+        sphere.on('payment_request:rejected', handler);
+        sphere.on('payment_request:expired', handler);
         return () => {
             sphere.off('payment_request:incoming', handler);
+            sphere.off('payment_request:paid', handler);
+            sphere.off('payment_request:rejected', handler);
+            sphere.off('payment_request:expired', handler);
         };
     }, [sphere, refresh]);
 

--- a/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
+++ b/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
@@ -6,10 +6,21 @@ export const PaymentRequestStatus = {
     PENDING: 'PENDING',
     ACCEPTED: 'ACCEPTED',
     REJECTED: 'REJECTED',
-    PAID: 'PAID'
+    PAID: 'PAID',
+    // Backend model is open → paid | declined | expired (§16): a stale request
+    // can expire server-side; a pay/reject attempt on it surfaces a 409.
+    EXPIRED: 'EXPIRED'
 } as const;
 
 export type PaymentRequestStatus = typeof PaymentRequestStatus[keyof typeof PaymentRequestStatus];
+
+const STATUS_MAP: Record<SDKPaymentRequest['status'], PaymentRequestStatus> = {
+    pending: PaymentRequestStatus.PENDING,
+    accepted: PaymentRequestStatus.ACCEPTED,
+    rejected: PaymentRequestStatus.REJECTED,
+    paid: PaymentRequestStatus.PAID,
+    expired: PaymentRequestStatus.EXPIRED,
+};
 
 export interface IncomingPaymentRequest {
     id: string;
@@ -37,70 +48,89 @@ function bridgeRequest(sdk: SDKPaymentRequest): IncomingPaymentRequest {
         recipientNametag: sdk.senderNametag ?? '',
         requestId: sdk.requestId,
         timestamp: sdk.timestamp,
-        status: PaymentRequestStatus.PENDING,
+        status: STATUS_MAP[sdk.status] ?? PaymentRequestStatus.PENDING,
     };
 }
 
+/**
+ * Incoming payment requests, driven by the PaymentsModule (the SDK list is
+ * the source of truth — statuses are read back after every action, never
+ * flipped optimistically):
+ *
+ * - `accept` — local status only; the wallet-api backend has no 'accepted'
+ *   state (§16 models open → paid | declined | expired), so the requester is
+ *   NOT notified until the request is actually paid.
+ * - `reject` — server-confirmed on the wallet-api path: the §16 'declined'
+ *   respond happens BEFORE the local flip, and a server rejection (403
+ *   non-addressee / 409 non-open, e.g. expired) propagates to the caller —
+ *   surface it, the local status stays pending.
+ * - `pay` — `payments.payPaymentRequest`: sends the transfer, then links the
+ *   transferId in the 'paid' respond. A failed respond after a successful
+ *   send is logged by the SDK, never reported as a payment failure.
+ */
 export const useIncomingPaymentRequests = () => {
     const { sphere } = useSphereContext();
     const [requests, setRequests] = useState<IncomingPaymentRequest[]>([]);
 
-    useEffect(() => {
+    const refresh = useCallback(() => {
         if (!sphere) return;
+        setRequests(sphere.payments.getPaymentRequests().map(bridgeRequest));
+    }, [sphere]);
 
-        const handler = (sdkReq: SDKPaymentRequest) => {
-            setRequests(prev => [...prev, bridgeRequest(sdkReq)]);
-        };
+    useEffect(() => {
+        if (!sphere) {
+            setRequests([]);
+            return;
+        }
 
+        // Seed from the module: requests that arrived before this hook
+        // mounted (e.g. the wallet-api sign-in backfill) are not re-emitted.
+        refresh();
+
+        const handler = () => refresh();
         sphere.on('payment_request:incoming', handler);
-
         return () => {
             sphere.off('payment_request:incoming', handler);
         };
-    }, [sphere]);
-
-    const updateStatus = useCallback(async (
-        request: IncomingPaymentRequest,
-        status: typeof PaymentRequestStatus[keyof typeof PaymentRequestStatus],
-        responseType: 'accepted' | 'rejected' | 'paid',
-    ) => {
-        if (!sphere) return;
-        const transport = sphere.getTransport();
-        if (transport.sendPaymentRequestResponse) {
-            await transport.sendPaymentRequestResponse(request.senderPubkey, {
-                requestId: request.requestId,
-                responseType,
-            });
-        }
-        setRequests(prev =>
-            prev.map(r => r.id === request.id ? { ...r, status } : r)
-        );
-    }, [sphere]);
+    }, [sphere, refresh]);
 
     const pendingCount = useMemo(
         () => requests.filter(r => r.status === PaymentRequestStatus.PENDING).length,
         [requests],
     );
 
-    const accept = useCallback(
-        (request: IncomingPaymentRequest) => updateStatus(request, PaymentRequestStatus.ACCEPTED, 'accepted'),
-        [updateStatus],
-    );
+    const accept = useCallback(async (request: IncomingPaymentRequest) => {
+        if (!sphere) return;
+        try {
+            await sphere.payments.acceptPaymentRequest(request.id);
+        } finally {
+            refresh();
+        }
+    }, [sphere, refresh]);
 
-    const reject = useCallback(
-        (request: IncomingPaymentRequest) => updateStatus(request, PaymentRequestStatus.REJECTED, 'rejected'),
-        [updateStatus],
-    );
+    const reject = useCallback(async (request: IncomingPaymentRequest) => {
+        if (!sphere) return;
+        try {
+            await sphere.payments.rejectPaymentRequest(request.id);
+        } finally {
+            refresh();
+        }
+    }, [sphere, refresh]);
 
-    const paid = useCallback(
-        (request: IncomingPaymentRequest) => updateStatus(request, PaymentRequestStatus.PAID, 'paid'),
-        [updateStatus],
-    );
+    const pay = useCallback(async (request: IncomingPaymentRequest) => {
+        if (!sphere) return;
+        try {
+            await sphere.payments.payPaymentRequest(request.id);
+        } finally {
+            refresh();
+        }
+    }, [sphere, refresh]);
 
-    const clearProcessed = useCallback(
-        () => setRequests(prev => prev.filter(r => r.status === PaymentRequestStatus.PENDING)),
-        [],
-    );
+    const clearProcessed = useCallback(() => {
+        if (!sphere) return;
+        sphere.payments.clearProcessedPaymentRequests();
+        refresh();
+    }, [sphere, refresh]);
 
-    return { requests, pendingCount, accept, reject, paid, clearProcessed };
+    return { requests, pendingCount, accept, reject, pay, clearProcessed };
 };

--- a/src/components/wallet/L3/modals/PaymentRequestModal.tsx
+++ b/src/components/wallet/L3/modals/PaymentRequestModal.tsx
@@ -1,6 +1,5 @@
 import { Check, Sparkles, Trash2, Loader2, XIcon, ArrowRight, Clock, Receipt, AlertCircle } from 'lucide-react';
 import { type IncomingPaymentRequest, PaymentRequestStatus } from '../hooks/useIncomingPaymentRequests';
-import { useTransfer } from '../../../../sdk';
 import { getErrorMessage } from '../../../../sdk/errors';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useState } from 'react';
@@ -13,13 +12,14 @@ interface PaymentRequestsModalProps {
   onClose: () => void;
   requests: IncomingPaymentRequest[];
   pendingCount: number;
+  /** Server-confirmed on wallet-api — 403/409 rejections throw and are surfaced here. */
   reject: (request: IncomingPaymentRequest) => Promise<void>;
-  paid: (request: IncomingPaymentRequest) => Promise<void>;
+  /** Pays via payments.payPaymentRequest (send + linked 'paid' respond). */
+  pay: (request: IncomingPaymentRequest) => Promise<void>;
   clearProcessed: () => void;
 }
 
-export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, reject, clearProcessed, paid }: PaymentRequestsModalProps) {
-  const { transfer } = useTransfer();
+export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, reject, clearProcessed, pay }: PaymentRequestsModalProps) {
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -33,18 +33,14 @@ export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, 
     }
   };
 
-  const handlePay = async (req: IncomingPaymentRequest) => {
+  /** Run a request action; failures (e.g. 403/409 on reject, send failures
+   *  on pay) land in the per-request error slot — never silent, never an
+   *  optimistic status flip. */
+  const handleAction = async (req: IncomingPaymentRequest, action: (r: IncomingPaymentRequest) => Promise<void>) => {
     setProcessingId(req.id);
     setErrors(prev => ({ ...prev, [req.id]: '' }));
     try {
-      const recipient = req.recipientNametag ? `@${req.recipientNametag}` : req.senderPubkey;
-      if (import.meta.env.DEV) console.log(`Initiating payment for request ${req.requestId} to ${recipient}`);
-      await transfer({
-        recipient,
-        amount: req.amount.toString(),
-        coinId: req.coinId,
-      });
-      paid(req);
+      await action(req);
     } catch (error: unknown) {
       setErrors(prev => ({ ...prev, [req.id]: getErrorMessage(error) }));
     } finally {
@@ -90,8 +86,8 @@ export function PaymentRequestsModal({ isOpen, onClose, requests, pendingCount, 
                 key={req.id}
                 req={req}
                 error={errors[req.id]}
-                onPay={() => handlePay(req)}
-                onReject={() => reject(req)}
+                onPay={() => handleAction(req, pay)}
+                onReject={() => handleAction(req, reject)}
                 isProcessing={processingId === req.id}
                 isGlobalDisabled={isGlobalProcessing}
               />
@@ -133,11 +129,12 @@ function RequestCard({ req, error, onPay, onReject, isProcessing, isGlobalDisabl
   const amountDisplay = AmountFormatUtils.formatDisplayAmount(req.amount.toString(), req.coinId);
   const timeAgo = getTimeAgo(req.timestamp);
 
-  // Стиль статуса
+  // Status styling
   const statusConfig = {
     [PaymentRequestStatus.ACCEPTED]: { color: 'text-emerald-500', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20', icon: Check, label: 'Payment Sent' },
     [PaymentRequestStatus.PAID]: { color: 'text-emerald-500', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20', icon: Check, label: 'Paid Successfully' },
     [PaymentRequestStatus.REJECTED]: { color: 'text-red-500', bg: 'bg-red-500/10', border: 'border-red-500/20', icon: XIcon, label: 'Request Declined' },
+    [PaymentRequestStatus.EXPIRED]: { color: 'text-neutral-500', bg: 'bg-neutral-500/10', border: 'border-neutral-500/20', icon: Clock, label: 'Request Expired' },
     [PaymentRequestStatus.PENDING]: { color: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/20', icon: Clock, label: 'Awaiting Payment' },
   };
 

--- a/src/components/wallet/L3/modals/SwapModal.tsx
+++ b/src/components/wallet/L3/modals/SwapModal.tsx
@@ -66,7 +66,7 @@ export function SwapModal({ isOpen, onClose }: SwapModalProps) {
         return {
           coinId: def.id, symbol, name: def.name,
           totalAmount: '0', decimals: def.decimals || 0, tokenCount: 0,
-          confirmedAmount: '0', unconfirmedAmount: '0',
+          confirmedAmount: '0', unconfirmedAmount: '0', transferringAmount: '0',
           confirmedTokenCount: 0, unconfirmedTokenCount: 0, transferringTokenCount: 0,
           iconUrl: iconUrl ?? undefined,
           priceUsd: priceData?.priceUsd || fallback?.priceUsd || 1.0,

--- a/src/components/wallet/L3/views/L3WalletView.tsx
+++ b/src/components/wallet/L3/views/L3WalletView.tsx
@@ -127,7 +127,7 @@ interface L3WalletViewProps {
   paymentRequests: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest[];
   paymentRequestsPendingCount: number;
   paymentRequestsReject: (request: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest) => Promise<void>;
-  paymentRequestsPaid: (request: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest) => Promise<void>;
+  paymentRequestsPay: (request: import('../hooks/useIncomingPaymentRequests').IncomingPaymentRequest) => Promise<void>;
   paymentRequestsClearProcessed: () => void;
 }
 
@@ -144,7 +144,7 @@ export function L3WalletView({
   paymentRequests,
   paymentRequestsPendingCount,
   paymentRequestsReject,
-  paymentRequestsPaid,
+  paymentRequestsPay,
   paymentRequestsClearProcessed,
 }: L3WalletViewProps) {
   const navigate = useNavigate();
@@ -510,7 +510,7 @@ export function L3WalletView({
         requests={paymentRequests}
         pendingCount={paymentRequestsPendingCount}
         reject={paymentRequestsReject}
-        paid={paymentRequestsPaid}
+        pay={paymentRequestsPay}
         clearProcessed={paymentRequestsClearProcessed}
       />
       <SeedPhraseModal

--- a/src/components/wallet/L3/views/L3WalletView.tsx
+++ b/src/components/wallet/L3/views/L3WalletView.tsx
@@ -249,6 +249,7 @@ export function L3WalletView({
       tokenCount: 1,
       confirmedAmount: totalAmount,
       unconfirmedAmount: '0',
+      transferringAmount: '0',
       confirmedTokenCount: 1,
       unconfirmedTokenCount: 0,
       transferringTokenCount: 0,

--- a/src/components/wallet/WalletPanel.tsx
+++ b/src/components/wallet/WalletPanel.tsx
@@ -60,7 +60,11 @@ export function WalletPanel() {
           </div>
           <div className="space-y-1">
             <p className="text-sm font-medium text-neutral-900 dark:text-[#fefefe]">Initialization error</p>
-            <p className="text-xs text-neutral-500 dark:text-[rgba(255,255,255,0.45)]">Please reload the page</p>
+            {/* Show the actual message: composition asserts (#351) name the
+                misconfigured env vars — a generic "reload" hides the cause. */}
+            <p className="text-xs text-neutral-500 dark:text-[rgba(255,255,255,0.45)] break-words">
+              {walletError.message || 'Please reload the page'}
+            </p>
           </div>
           <motion.button
             whileHover={{ scale: 1.02 }}

--- a/src/components/wallet/WalletPanel.tsx
+++ b/src/components/wallet/WalletPanel.tsx
@@ -22,7 +22,7 @@ export function WalletPanel() {
   const { isLoading: isWalletLoading, walletExists, error: walletError } = useWalletStatus();
   const { identity, nametag, isLoading: isLoadingIdentity } = useIdentity();
   const { initProgress } = useSphereContext();
-  const { pendingCount, requests, reject, paid, clearProcessed } = useIncomingPaymentRequests();
+  const { pendingCount, requests, reject, pay, clearProcessed } = useIncomingPaymentRequests();
   const { setFullscreen } = useUIState();
 
   // Track previous pending count to detect new requests
@@ -252,7 +252,7 @@ export function WalletPanel() {
           paymentRequests={requests}
           paymentRequestsPendingCount={pendingCount}
           paymentRequestsReject={reject}
-          paymentRequestsPaid={paid}
+          paymentRequestsPay={pay}
           paymentRequestsClearProcessed={clearProcessed}
         />
       </div>

--- a/src/config/activities.ts
+++ b/src/config/activities.ts
@@ -53,8 +53,6 @@ const allAgents: AgentConfig[] = [
     color: 'from-indigo-500 to-purple-500',
     type: 'chat',
     requiresWallet: true,
-    // Group Chat is currently disabled — hidden from the desktop and not openable.
-    enabled: false,
   },
   {
     id: 'custom',

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -34,6 +34,10 @@ export const STORAGE_KEYS = {
   // Dev Settings
   DEV_AGGREGATOR_URL: 'sphere_dev_aggregator_url',
   DEV_SKIP_TRUST_BASE: 'sphere_dev_skip_trust_base',
+
+  // wallet-api device label — one session row per (owner, device) on the
+  // backend; the SDK stores the refresh token under it (ARCHITECTURE §4).
+  WALLET_API_DEVICE_ID: 'sphere_wallet_api_device_id',
 } as const;
 
 const STORAGE_PREFIX = 'sphere_';
@@ -55,3 +59,20 @@ export function clearAllSphereData(): void {
 }
 
 export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];
+
+/**
+ * Stable per-device label for the wallet-api session (ARCHITECTURE §4: one
+ * session row per (owner, device); the refresh token is stored under it).
+ * Persisted so reloads reuse the session instead of forcing a fresh
+ * challenge sign-in and a new server session row per page load.
+ *
+ * The key carries the `sphere_` prefix, so `clearAllSphereData()` (wallet
+ * deletion) resets the device identity together with everything else.
+ */
+export function getOrCreateWalletApiDeviceId(): string {
+  const existing = localStorage.getItem(STORAGE_KEYS.WALLET_API_DEVICE_ID);
+  if (existing) return existing;
+  const deviceId = `sphere-web-${crypto.randomUUID()}`;
+  localStorage.setItem(STORAGE_KEYS.WALLET_API_DEVICE_ID, deviceId);
+  return deviceId;
+}

--- a/src/config/walletApi.ts
+++ b/src/config/walletApi.ts
@@ -25,16 +25,49 @@ function resolveUrl(value: string): string {
   return new URL(value, window.location.origin).toString();
 }
 
-/** Backend base URL when wallet-api mode is enabled; null otherwise. */
+/**
+ * True when this bundle declares wallet-api intent (`VITE_REQUIRE_WALLET_API`).
+ * Set by deployments whose custody model is wallet-api (the Pages workflow):
+ * any value other than empty/`false`/`0` counts as set.
+ */
+export function isWalletApiRequired(): boolean {
+  const raw = import.meta.env.VITE_REQUIRE_WALLET_API as string | undefined;
+  return !!raw && raw !== 'false' && raw !== '0';
+}
+
+/**
+ * Backend base URL when wallet-api mode is enabled; null otherwise.
+ *
+ * #351 assert (2026-06-12 incident): a bundle built with
+ * `VITE_REQUIRE_WALLET_API` but without `VITE_WALLET_API_URL` must fail at
+ * provider composition instead of silently falling back to the legacy
+ * local-custody composition — a missing URL would otherwise CHANGE the
+ * custody model, not just degrade a feature.
+ */
 export function getWalletApiBaseUrl(): string | null {
   const raw = import.meta.env.VITE_WALLET_API_URL as string | undefined;
-  if (!raw) return null;
+  if (!raw) {
+    if (isWalletApiRequired()) {
+      throw new Error(
+        'VITE_REQUIRE_WALLET_API is set but VITE_WALLET_API_URL is missing or empty — ' +
+          'this build declares wallet-api custody, so composing the legacy local-custody ' +
+          'bundle instead would silently change the custody model. Bake VITE_WALLET_API_URL ' +
+          'into the build, or unset VITE_REQUIRE_WALLET_API for an intentionally legacy deployment.',
+      );
+    }
+    return null;
+  }
   return resolveUrl(raw);
 }
 
-/** True when the asset path rides wallet-api (drives IPFS-off, UI hints). */
+/**
+ * True when the asset path rides wallet-api (drives IPFS-off, UI hints).
+ * Reads the raw env (no #351 assert) so render paths never throw: the assert
+ * fires once, at provider composition (`buildProviders`), where
+ * SphereProvider catches it and surfaces a visible initialization error.
+ */
 export function isWalletApiEnabled(): boolean {
-  return getWalletApiBaseUrl() !== null;
+  return !!(import.meta.env.VITE_WALLET_API_URL as string | undefined);
 }
 
 /**

--- a/src/config/walletApi.ts
+++ b/src/config/walletApi.ts
@@ -1,0 +1,60 @@
+/**
+ * wallet-api composition config (S4 provider swap).
+ *
+ * The ASSET path moves to the wallet-api backend when `VITE_WALLET_API_URL`
+ * is set; messaging, DMs and nametags stay on Nostr. When unset, the app
+ * keeps the legacy local-custody composition (IndexedDB + Nostr asset
+ * delivery) unchanged.
+ *
+ * URLs may be relative (e.g. `/wallet-api`): they resolve against the app
+ * origin, which is how the dev/preview proxy in vite.config.ts is reached —
+ * the backend serves no CORS headers, so cross-origin browser calls need the
+ * local proxy (production deployments must solve this at the edge).
+ */
+
+/** Engine override for the LOCAL compose stack (smoke tests / local dev). */
+export interface EngineOverrideConfig {
+  /** Aggregator gateway URL (the mock aggregator of the dev stack). */
+  aggregatorUrl: string;
+  /** Trust base JSON URL — MUST be the trustbase the same gateway serves. */
+  trustBaseUrl: string;
+}
+
+/** Resolve an env URL; relative values resolve against the app origin. */
+function resolveUrl(value: string): string {
+  return new URL(value, window.location.origin).toString();
+}
+
+/** Backend base URL when wallet-api mode is enabled; null otherwise. */
+export function getWalletApiBaseUrl(): string | null {
+  const raw = import.meta.env.VITE_WALLET_API_URL as string | undefined;
+  if (!raw) return null;
+  return resolveUrl(raw);
+}
+
+/** True when the asset path rides wallet-api (drives IPFS-off, UI hints). */
+export function isWalletApiEnabled(): boolean {
+  return getWalletApiBaseUrl() !== null;
+}
+
+/**
+ * Aggregator + trustbase override for the LOCAL dev stack. Both URLs must be
+ * set together: the trustbase is the engine's source of truth for the
+ * network id, and mixing a gateway with another network's trustbase would
+ * make the engine reject every proof (or worse, accept the wrong network).
+ */
+export function getEngineOverride(): EngineOverrideConfig | null {
+  const aggregatorUrl = import.meta.env.VITE_AGGREGATOR_URL as string | undefined;
+  const trustBaseUrl = import.meta.env.VITE_TRUSTBASE_URL as string | undefined;
+  if (!aggregatorUrl && !trustBaseUrl) return null;
+  if (!aggregatorUrl || !trustBaseUrl) {
+    throw new Error(
+      'VITE_AGGREGATOR_URL and VITE_TRUSTBASE_URL must be set together — ' +
+        'a gateway must be paired with the trustbase it serves (never mix trustbases).',
+    );
+  }
+  return {
+    aggregatorUrl: resolveUrl(aggregatorUrl),
+    trustBaseUrl: resolveUrl(trustBaseUrl),
+  };
+}

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -1,10 +1,19 @@
 import { createContext } from 'react';
 import type { Sphere, PeerInfo, InitProgress } from '@unicitylabs/sphere-sdk';
 import type { BrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
+import type { WalletApiProviderExtras } from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+
+/**
+ * The app's provider bundle: the browser base, plus — when the asset path
+ * rides wallet-api (VITE_WALLET_API_URL set) — the S4 extras (`delivery`,
+ * `walletApi`). The extras are additive: helpers taking `BrowserProviders`
+ * keep working unchanged.
+ */
+export type SphereAppProviders = BrowserProviders & Partial<WalletApiProviderExtras>;
 
 export interface SphereContextValue {
   sphere: Sphere | null;
-  providers: BrowserProviders | null;
+  providers: SphereAppProviders | null;
 
   isLoading: boolean;
   isInitialized: boolean;
@@ -36,6 +45,13 @@ export interface SphereContextValue {
   ipfsEnabled: boolean;
   /** Toggle IPFS sync on/off (persists to localStorage, triggers reinitialize) */
   toggleIpfs: () => void;
+
+  /**
+   * True when the asset path rides the wallet-api backend (S4 composition).
+   * IPFS token sync is unavailable in this mode — server inventory custody
+   * and a second token-storage mirror have undefined handoff semantics.
+   */
+  walletApiEnabled: boolean;
 }
 
 export interface CreateWalletOptions {

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -12,9 +12,19 @@ import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
 import {
   createBrowserProviders,
+  createUnicityAggregatorProvider,
   type BrowserProviders,
 } from '@unicitylabs/sphere-sdk/impl/browser';
-import { SphereContext } from './SphereContext';
+import {
+  createSphereProviders,
+  createWalletApiProviders,
+} from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+import { SphereContext, type SphereAppProviders } from './SphereContext';
+import {
+  getEngineOverride,
+  getWalletApiBaseUrl,
+  isWalletApiEnabled,
+} from '../config/walletApi';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
   ? '/coingecko'
@@ -26,7 +36,11 @@ import type {
   ImportFromFileOptions,
   ImportFromFileResult,
 } from './SphereContext';
-import { clearAllSphereData, STORAGE_KEYS } from '../config/storageKeys';
+import {
+  clearAllSphereData,
+  getOrCreateWalletApiDeviceId,
+  STORAGE_KEYS,
+} from '../config/storageKeys';
 import { migrateApprovedSessions } from '../utils/connected-sites';
 
 // One-time migration from old approved sessions format (idempotent)
@@ -56,6 +70,10 @@ function isIpfsEnabled(): boolean {
 }
 
 function getIpfsConfig() {
+  // wallet-api mode: server inventory custody — a second token-storage
+  // mirror (IPFS) has undefined ownership-handoff/tombstone semantics, so
+  // token sync is forced off (the toggle is hidden too).
+  if (isWalletApiEnabled()) return {};
   if (!isIpfsEnabled()) return {};
   return {
     tokenSync: {
@@ -79,11 +97,54 @@ async function disconnectTransport(providers: BrowserProviders): Promise<void> {
 
 /** Add IPFS storage provider and trigger initial sync (fire-and-forget) */
 function setupIpfsSync(instance: Sphere, providers: BrowserProviders): void {
+  if (isWalletApiEnabled()) return; // see getIpfsConfig()
   if (providers.ipfsTokenStorage) {
     instance.addTokenStorageProvider(providers.ipfsTokenStorage)
       .then(() => instance.sync())
       .catch(err => logger.warn('SphereProvider', 'IPFS sync failed', err));
   }
+}
+
+/**
+ * Compose the app's provider bundle (S4): the browser base, an optional
+ * engine-port override (LOCAL dev stack: mock aggregator + the trustbase it
+ * serves), and — when VITE_WALLET_API_URL is set — the wallet-api preset:
+ * thin server-custody token storage + mailbox delivery + the S1 client.
+ * Composing `delivery` moves ASSETS to wallet-api; messaging, group chat and
+ * nametags stay on the Nostr transport in the base bundle.
+ */
+function buildProviders(network: NetworkType): SphereAppProviders {
+  const base = createBrowserProviders({
+    network,
+    // v2 token engine: aggregator URL + trust base come from the network
+    // preset; only the apiKey is injected (non-secret on testnet2).
+    oracle: { apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY },
+    price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
+    // Group chat (NIP-29) is disabled: the UI is already hidden (PR #339), and
+    // skipping the module here stops the SDK from connecting to NIP-29 relays.
+    groupChat: false,
+    market: true,
+    ...getIpfsConfig(),
+  });
+
+  const engineOverride = getEngineOverride();
+  const withEngine = engineOverride
+    ? createSphereProviders(base, {
+        engine: createUnicityAggregatorProvider({
+          url: engineOverride.aggregatorUrl,
+          trustBaseUrl: engineOverride.trustBaseUrl,
+          network,
+        }),
+      })
+    : base;
+
+  const walletApiBaseUrl = getWalletApiBaseUrl();
+  if (!walletApiBaseUrl) return withEngine;
+  return createWalletApiProviders(withEngine, {
+    baseUrl: walletApiBaseUrl,
+    network,
+    deviceId: getOrCreateWalletApiDeviceId(),
+  });
 }
 
 /** Clean up persisted wallet data on creation/import failure */
@@ -110,7 +171,7 @@ export function SphereProvider({
 }: SphereProviderProps) {
   const queryClient = useQueryClient();
   const [sphere, setSphere] = useState<Sphere | null>(null);
-  const [providers, setProviders] = useState<BrowserProviders | null>(null);
+  const [providers, setProviders] = useState<SphereAppProviders | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [walletExists, setWalletExists] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -130,18 +191,7 @@ export function SphereProvider({
       if (!skipLoading) setIsLoading(true);
       setError(null);
 
-      const browserProviders = createBrowserProviders({
-        network,
-        // v2 token engine: aggregator URL + trust base (networkId 4) come from the
-        // testnet2 network preset; only the apiKey is injected (non-secret on testnet2).
-        oracle: { apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY },
-        price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
-        // Group chat (NIP-29) is disabled: the UI is already hidden (PR #339), and
-        // skipping the module here stops the SDK from connecting to NIP-29 relays.
-        groupChat: false,
-        market: true,
-        ...getIpfsConfig(),
-      });
+      const browserProviders = buildProviders(network);
       // Debug logging is off by default; enable at runtime via: logger.configure({ debug: true })
       setProviders(browserProviders);
 
@@ -366,6 +416,15 @@ export function SphereProvider({
     // Notify connected dApps before destroying — ConnectPage/IframeAgent listen for this
     window.dispatchEvent(new CustomEvent('sphere:wallet-logout'));
 
+    // Best-effort wallet-api session revoke (S4 auth lifecycle): the SDK only
+    // calls walletApi.logout() on address switch, not on destroy — without
+    // this the server session row would outlive wallet deletion.
+    if (providers?.walletApi) {
+      await providers.walletApi.logout().catch((err) => {
+        logger.warn('SphereProvider', 'wallet-api logout failed (best effort)', err);
+      });
+    }
+
     // Destroy sphere to close SDK connections (Nostr, IndexedDB handles, etc.)
     if (sphereRef.current) {
       await sphereRef.current.destroy();
@@ -459,6 +518,7 @@ export function SphereProvider({
     reinitialize: initialize,
     ipfsEnabled,
     toggleIpfs,
+    walletApiEnabled: isWalletApiEnabled(),
   };
 
   return (

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -112,6 +112,11 @@ function setupIpfsSync(instance: Sphere, providers: BrowserProviders): void {
  * thin server-custody token storage + mailbox delivery + the S1 client.
  * Composing `delivery` moves ASSETS to wallet-api; messaging, group chat and
  * nametags stay on the Nostr transport in the base bundle.
+ *
+ * Fail-closed (#351): on builds with VITE_REQUIRE_WALLET_API set,
+ * getWalletApiBaseUrl() throws when VITE_WALLET_API_URL is missing — the
+ * error is caught by initialize() and surfaced as a visible init error
+ * instead of silently composing the legacy local-custody bundle.
  */
 function buildProviders(network: NetworkType): SphereAppProviders {
   const base = createBrowserProviders({

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -125,9 +125,7 @@ function buildProviders(network: NetworkType): SphereAppProviders {
     // preset; only the apiKey is injected (non-secret on testnet2).
     oracle: { apiKey: import.meta.env.VITE_AGGREGATOR_API_KEY },
     price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
-    // Group chat (NIP-29) is disabled: the UI is already hidden (PR #339), and
-    // skipping the module here stops the SDK from connecting to NIP-29 relays.
-    groupChat: false,
+    groupChat: true,
     market: true,
     ...getIpfsConfig(),
   });

--- a/src/sdk/hooks/core/useRealtimeStatus.ts
+++ b/src/sdk/hooks/core/useRealtimeStatus.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { useSphereContext } from './useSphere';
+
+/**
+ * Wake-socket liveness (sphere-sdk `realtime:status`): the true state of the
+ * §9 realtime wake channel — DISTINCT from the wallet-api sign-in session
+ * (`walletapi:session`). A window can be signed-in while its wake socket is
+ * dead, so cross-session updates would only land via the slower poll backstop.
+ */
+export type RealtimeStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed' | null;
+
+export interface UseRealtimeStatusReturn {
+  /** null until the first `realtime:status` event arrives (no SDK getter). */
+  status: RealtimeStatus;
+}
+
+/**
+ * Mirrors the SDK `realtime:status` event into React so the Header can reflect
+ * real wake-socket health (connected vs reconnecting/closed) rather than just
+ * sign-in state. The wake is only a nudge — this is a liveness indicator, never
+ * a correctness gate (the poll backstop carries correctness while reconnecting).
+ */
+export function useRealtimeStatus(): UseRealtimeStatusReturn {
+  const { sphere } = useSphereContext();
+  const [status, setStatus] = useState<RealtimeStatus>(null);
+
+  useEffect(() => {
+    if (!sphere) {
+      setStatus(null);
+      return;
+    }
+
+    // No SDK getter for the current wake-socket state — seed from the event.
+    // The socket emits 'connecting'/'connected' on (re)establish, so the
+    // indicator converges within one wake-channel lifecycle.
+    const handleStatus = (data: { status: Exclude<RealtimeStatus, null> }) => {
+      setStatus(data.status);
+    };
+
+    sphere.on('realtime:status', handleStatus);
+    return () => {
+      sphere.off('realtime:status', handleStatus);
+    };
+  }, [sphere]);
+
+  return { status };
+}

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -98,6 +98,10 @@ export function useSphereEvents(): void {
     };
 
     const handleIdentityChange = () => {
+      // New identity = new transfer stream (wallet-api sessions are
+      // per-identity): clear the toast dedup set so the new address's
+      // transfers are never swallowed by ids seen under the old one.
+      seenTransferIdsRef.current.clear();
       refreshIdentityCache();
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.identity.all });
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.payments.all });

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useSphereContext } from './useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { formatAmount } from '../../index';
-import { showTransferToast } from '../../../components/ui/toast-utils';
+import { showToast, showTransferToast } from '../../../components/ui/toast-utils';
 import { CHAT_KEYS, GROUP_CHAT_KEYS, type DmReceivedDetail } from '../../../components/chat/data/chatTypes';
 import { sendWelcomeDM } from '../../welcomeDM';
 import type { IncomingTransfer } from '@unicitylabs/sphere-sdk';
@@ -167,6 +167,17 @@ export function useSphereEvents(): void {
       });
     };
 
+    // sphere-sdk#515 F2: a background custody save failed — the active
+    // custody provider rejected a write. Surface it (never log-only); the
+    // SEND pipeline already fails hard on its own writes.
+    const handleStorageDegraded = (data: { providerId: string; error: string }) => {
+      showToast(
+        `Token storage degraded (${data.providerId}): a background save failed — ${data.error}`,
+        'error',
+        10000,
+      );
+    };
+
     sphere.on('transfer:incoming', handleIncomingTransfer);
     sphere.on('transfer:confirmed', handleTransferConfirmed);
     sphere.on('history:updated', handleHistoryUpdated);
@@ -179,6 +190,7 @@ export function useSphereEvents(): void {
     sphere.on('message:read', handleMessageRead);
     sphere.on('composing:started', handleComposingStarted);
     sphere.on('payment_request:incoming', handlePaymentRequestIncoming);
+    sphere.on('storage:degraded', handleStorageDegraded);
 
     return () => {
       if (invalidateTimerRef.current) {
@@ -197,6 +209,7 @@ export function useSphereEvents(): void {
       sphere.off('message:read', handleMessageRead);
       sphere.off('composing:started', handleComposingStarted);
       sphere.off('payment_request:incoming', handlePaymentRequestIncoming);
+      sphere.off('storage:degraded', handleStorageDegraded);
     };
   }, [sphere, queryClient]);
 }

--- a/src/sdk/hooks/core/useWalletApiSession.ts
+++ b/src/sdk/hooks/core/useWalletApiSession.ts
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import { useSphereContext } from './useSphere';
+
+export type WalletApiSessionStatus = 'online' | 'offline' | null;
+
+export interface UseWalletApiSessionReturn {
+  /** null until the first sign-in attempt resolves, then 'online'/'offline'. */
+  status: WalletApiSessionStatus;
+  /** Error string from the last 'offline' transition; null while online. */
+  lastError: string | null;
+}
+
+/**
+ * wallet-api session health (#351 / sphere-sdk#515 F3): the SDK records a
+ * failed wallet-api sign-in (`walletapi:session` event +
+ * `sphere.walletApiSessionStatus`) instead of silently degrading. This hook
+ * mirrors that state into React so the Header can show an offline badge.
+ */
+export function useWalletApiSession(): UseWalletApiSessionReturn {
+  const { sphere } = useSphereContext();
+  const [status, setStatus] = useState<WalletApiSessionStatus>(null);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sphere) {
+      setStatus(null);
+      setLastError(null);
+      return;
+    }
+
+    // Seed from the getter — the event may have fired during Sphere.init,
+    // before this hook mounted.
+    setStatus(sphere.walletApiSessionStatus);
+
+    const handleSession = (data: { status: 'online' | 'offline'; error?: string }) => {
+      setStatus(data.status);
+      setLastError(
+        data.status === 'offline' ? (data.error ?? 'wallet-api sign-in failed') : null,
+      );
+    };
+
+    sphere.on('walletapi:session', handleSession);
+    return () => {
+      sphere.off('walletapi:session', handleSession);
+    };
+  }, [sphere]);
+
+  return { status, lastError };
+}

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -9,6 +9,8 @@ export type { UseNametagReturn } from './core/useNametag';
 export { useSphereEvents } from './core/useSphereEvents';
 export { useIpfsSync } from './core/useIpfsSync';
 export type { IpfsSyncStatus, IpfsSyncState, UseIpfsSyncReturn } from './core/useIpfsSync';
+export { useWalletApiSession } from './core/useWalletApiSession';
+export type { WalletApiSessionStatus, UseWalletApiSessionReturn } from './core/useWalletApiSession';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -11,6 +11,8 @@ export { useIpfsSync } from './core/useIpfsSync';
 export type { IpfsSyncStatus, IpfsSyncState, UseIpfsSyncReturn } from './core/useIpfsSync';
 export { useWalletApiSession } from './core/useWalletApiSession';
 export type { WalletApiSessionStatus, UseWalletApiSessionReturn } from './core/useWalletApiSession';
+export { useRealtimeStatus } from './core/useRealtimeStatus';
+export type { RealtimeStatus, UseRealtimeStatusReturn } from './core/useRealtimeStatus';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/src/sdk/hooks/payments/useAssets.ts
+++ b/src/sdk/hooks/payments/useAssets.ts
@@ -23,7 +23,7 @@ export interface UseAssetsReturn {
 }
 
 export function useAssets(): UseAssetsReturn {
-  const { sphere } = useSphereContext();
+  const { sphere, walletApiEnabled } = useSphereContext();
   const registryReady = useRegistryReady();
   const queryClient = useQueryClient();
 
@@ -35,6 +35,10 @@ export function useAssets(): UseAssetsReturn {
     },
     enabled: !!sphere,
     staleTime: 30_000,
+    // wallet-api mode: refetch on focus so a tab backgrounded with a dead wake
+    // socket refreshes on return (realtime invalidation is the primary path;
+    // TanStack dedupes). Local-only mode keeps the global default (no server).
+    refetchOnWindowFocus: walletApiEnabled,
   });
 
   // If the token registry finishes loading AFTER the first getAssets() call,

--- a/src/sdk/hooks/payments/useBalance.ts
+++ b/src/sdk/hooks/payments/useBalance.ts
@@ -18,7 +18,7 @@ export interface UseBalanceReturn {
  * @param coinId - Coin ID to get balance for, or undefined for total portfolio value in USD
  */
 export function useBalance(coinId?: string): UseBalanceReturn {
-  const { sphere } = useSphereContext();
+  const { sphere, walletApiEnabled } = useSphereContext();
 
   const query = useQuery({
     queryKey: coinId
@@ -40,6 +40,11 @@ export function useBalance(coinId?: string): UseBalanceReturn {
     },
     enabled: !!sphere,
     staleTime: 30_000,
+    // wallet-api mode: realtime inventory wakes drive invalidation, but a tab
+    // backgrounded with a dead wake socket can miss them — refetch on focus as
+    // a cheap backstop (TanStack dedupes against the realtime path). Local-only
+    // mode keeps the global refetchOnWindowFocus:false (no server to re-poll).
+    refetchOnWindowFocus: walletApiEnabled,
   });
 
   const asset = (coinId && query.data && typeof query.data !== 'number') ? query.data as Asset : null;

--- a/src/sphere-sdk-browser.d.ts
+++ b/src/sphere-sdk-browser.d.ts
@@ -46,4 +46,31 @@ declare module '@unicitylabs/sphere-sdk/impl/browser' {
   export function createBrowserProviders(
     config?: BrowserProvidersConfig,
   ): BrowserProviders;
+
+  /**
+   * Browser oracle (network-config) provider factory. Used to select the
+   * engine port at composition time (createSphereProviders) when the app
+   * must point at a non-preset gateway + the trustbase it serves — e.g. the
+   * LOCAL dev-stack mock aggregator in the two-profile smoke.
+   */
+  export interface BrowserAggregatorProviderConfig {
+    /** Aggregator (gateway) URL */
+    url: string;
+    /** API key for authentication */
+    apiKey?: string;
+    /** Request timeout (ms) */
+    timeout?: number;
+    /** Skip trust base loading (dev only) */
+    skipVerification?: boolean;
+    /** Enable debug logging */
+    debug?: boolean;
+    /** Trust base JSON URL (fetched by the browser loader) */
+    trustBaseUrl?: string;
+    /** Embedded-fallback network (required when trustBaseUrl is set) */
+    network?: NetworkType;
+  }
+
+  export function createUnicityAggregatorProvider(
+    config: BrowserAggregatorProviderConfig,
+  ): OracleProvider;
 }

--- a/tests/e2e/two-profile-smoke.spec.ts
+++ b/tests/e2e/two-profile-smoke.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Two-profile wallet-api smoke (LOCAL-ONLY — see playwright.config.ts for
+ * the required dev stack and the run command).
+ *
+ * Two isolated browser contexts = two wallets (separate IndexedDB,
+ * localStorage, deviceIds). One pass exercises the whole S4 surface against
+ * the REAL backend: challenge sign-in, open minting via the mock aggregator,
+ * blob upload (presigned PUT), inventory deposit, mailbox delivery + claim
+ * with the §6 inventory handoff, and §16 payment requests end-to-end:
+ *
+ *   A creates + funds a wallet → sends UCT to B → B sees the balance →
+ *   B sends A a payment request → A pays it → both UIs converge.
+ *
+ * Nametags ride Nostr (unchanged by this integration) and are REQUIRED for
+ * recipient resolution: the engine send path needs the recipient's published
+ * chain pubkey, so both profiles register one during onboarding.
+ *
+ * Triage rule (wallet-api ARCHITECTURE §18): infra failures (stack down,
+ * 5xx, relay timeouts) are retried/blocked on — they never license test
+ * weakening. Only deterministic failures are code defects.
+ */
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+/** The app renders mobile+desktop duplicates; assert/click the visible one. */
+function visible(page: Page, text: string): Locator {
+  return page.getByText(text).filter({ visible: true }).first();
+}
+
+function visibleButton(page: Page, name: string): Locator {
+  return page.getByRole('button', { name, exact: true }).filter({ visible: true }).first();
+}
+
+/** The visible WalletScreen overlay (send/request modals) containing `text`. */
+function modalScreen(page: Page, text: string): Locator {
+  return page
+    .locator('div.absolute.inset-0.z-10')
+    .filter({ hasText: text })
+    .filter({ visible: true })
+    .last();
+}
+
+// One run-unique suffix; nametags are first-seen-wins on the public relays,
+// so they must never repeat across runs.
+const runId = Math.random().toString(36).slice(2, 8);
+const TAG_A = `smka${runId}`;
+const TAG_B = `smkb${runId}`;
+
+/** Walk onboarding: create wallet + register a nametag + ack the mnemonic. */
+async function createWallet(page: Page, tag: string): Promise<void> {
+  await page.goto('/home');
+  // Tutorial overlay shows on first visit only.
+  await page
+    .getByText('Skip tutorial')
+    .first()
+    .click({ timeout: 15_000 })
+    .catch(() => {});
+  await page.getByRole('button', { name: 'Create New Wallet' }).first().click();
+
+  // "Choose Unicity ID" — register the nametag (publishes the Nostr binding
+  // the other profile resolves; mints the nametag token via the engine).
+  await page.locator('input').first().fill(tag);
+  const cont = page.getByRole('button', { name: 'Continue' });
+  await expect(cont).toBeEnabled({ timeout: 30_000 });
+  await cont.click();
+
+  // Mnemonic backup → wallet view (creation + nametag mint happen here).
+  await page
+    .getByRole('button', { name: "I've Saved My Recovery Phrase" })
+    .click({ timeout: 180_000 });
+  await expect(page.getByText(`@${tag}`).filter({ visible: true }).first()).toBeVisible({
+    timeout: 180_000,
+  });
+}
+
+/** Open mint via Top Up (UCT/BTC/SOL/ETH basket) and wait for the deposit. */
+async function topUp(page: Page): Promise<void> {
+  await visibleButton(page, 'Top Up').click();
+  await visible(page, 'Get test tokens').click();
+  // Mint (mock aggregator) + §6 deposit (upload-urls → PUT → apply) for the
+  // whole basket; the assets list then shows the UCT balance.
+  await expect(visible(page, '100.0000 UCT')).toBeVisible({ timeout: 240_000 });
+}
+
+test('two profiles converge over wallet-api: fund, send, request, pay', async ({ browser }) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  const a = await ctxA.newPage();
+  const b = await ctxB.newPage();
+
+  // ── Onboard both profiles (A funds itself via open minting) ─────────────
+  await createWallet(a, TAG_A);
+  await createWallet(b, TAG_B);
+  await topUp(a);
+
+  // ── A sends 10 UCT to @B (mailbox delivery + B's claim/handoff) ─────────
+  await visibleButton(a, 'Send').click();
+  await a.getByRole('button', { name: /^UCT / }).filter({ visible: true }).first().click();
+  await a.getByPlaceholder("Recipient's Unicity ID").fill(TAG_B);
+  await a.locator('input[inputmode="decimal"]').fill('10');
+  // Nametag resolution hits public relays — retry while the binding settles.
+  await expect(async () => {
+    await a.getByRole('button', { name: 'Review' }).click();
+    await expect(a.getByText('You are sending')).toBeVisible({ timeout: 15_000 });
+  }).toPass({ timeout: 120_000, intervals: [5_000] });
+  // Scope to the confirm screen — the wallet panel has its own 'Send' button.
+  await modalScreen(a, 'You are sending')
+    .getByRole('button', { name: 'Send', exact: true })
+    .click();
+  await expect(visible(a, 'Success!')).toBeVisible({ timeout: 180_000 });
+  await visibleButton(a, 'Close').click();
+  await expect(visible(a, '90.0000 UCT')).toBeVisible({ timeout: 60_000 });
+
+  // ── B receives: wake → mailbox claim → inventory custody → balance ──────
+  await expect(visible(b, '10.0000 UCT')).toBeVisible({ timeout: 240_000 });
+
+  // ── B requests 5 UCT from @A (§16 payment request) ──────────────────────
+  await visibleButton(b, 'Top Up').click();
+  await visible(b, 'Payment Request').click();
+  await b.getByRole('button', { name: /^UCT/ }).filter({ visible: true }).first().click();
+  await b.getByPlaceholder('Who should pay you?').fill(TAG_A);
+  await b.locator('input[inputmode="decimal"]').fill('5');
+  await b.getByPlaceholder('Message (optional)').fill('smoke: lunch money');
+  await expect(async () => {
+    await b.getByRole('button', { name: 'Review' }).click();
+    await expect(b.getByRole('button', { name: 'Send Request' })).toBeVisible({ timeout: 15_000 });
+  }).toPass({ timeout: 120_000, intervals: [5_000] });
+  await visibleButton(b, 'Send Request').click();
+  await expect(visible(b, 'Request Sent!')).toBeVisible({ timeout: 120_000 });
+  await visibleButton(b, 'Close').click();
+
+  // ── A pays it (payPaymentRequest: send + linked 'paid' respond) ─────────
+  // The requests modal auto-opens on the incoming request (wake push).
+  await expect(visible(a, 'smoke: lunch money')).toBeVisible({ timeout: 240_000 });
+  await visibleButton(a, 'Pay Now').click();
+  await expect(visible(a, 'Paid Successfully')).toBeVisible({ timeout: 240_000 });
+
+  // ── Convergence: B holds 15 UCT, A holds 85 ─────────────────────────────
+  await expect(visible(b, '15.0000 UCT')).toBeVisible({ timeout: 240_000 });
+  await expect(visible(a, '85.0000 UCT')).toBeVisible({ timeout: 60_000 });
+
+  await ctxA.close();
+  await ctxB.close();
+});

--- a/tests/e2e/two-profile-smoke.spec.ts
+++ b/tests/e2e/two-profile-smoke.spec.ts
@@ -2,19 +2,42 @@
  * Two-profile wallet-api smoke (LOCAL-ONLY — see playwright.config.ts for
  * the required dev stack and the run command).
  *
- * Two isolated browser contexts = two wallets (separate IndexedDB,
- * localStorage, deviceIds). One pass exercises the whole S4 surface against
- * the REAL backend: challenge sign-in, open minting via the mock aggregator,
- * blob upload (presigned PUT), inventory deposit, mailbox delivery + claim
- * with the §6 inventory handoff, and §16 payment requests end-to-end:
+ * Two persistent browser profiles = two wallets (separate user-data-dirs, so
+ * separate IndexedDB, localStorage, deviceIds). One pass exercises the whole
+ * S4 surface against the REAL backend: challenge sign-in, open minting via the
+ * mock aggregator, blob upload (presigned PUT), inventory deposit, mailbox
+ * delivery + claim with the §6 inventory handoff, and §16 payment requests
+ * end-to-end:
  *
  *   A creates + funds a wallet → sends UCT to B → B sees the balance →
  *   B sends A a payment request → A pays it → both UIs converge.
  *
- * Each profile is hard-reloaded (F5) right after its first balance
- * assertion: reload drops all in-memory engine state, so re-asserting the
- * SAME balance proves it survives a full pull from wallet-api (the
- * sphere-sdk#521 regression — fixed in 0.9.1-dev.9 — lost it here).
+ * RELOAD-CLASS COVERAGE (issue #356 — the browser layer where the #521 /
+ * #549 / #550 bugs actually bit, and where the SDK reload tests passed while
+ * production broke). Both profiles run on `launchPersistentContext`, so a real
+ * browser close+reopen replays storage from disk — not an in-memory
+ * `newContext`. After the key state transitions we assert that state survives
+ * the FULL pull from wallet-api on a fresh engine:
+ *
+ *   • F5 reload (dev.9): minted/received balance survives `page.reload()`
+ *     (sphere-sdk#521 lost it here).
+ *   • G4 — second tab: `context.newPage()` on A's context right after the send
+ *     (same context = shared storage, a true second tab) shows identical
+ *     post-send state — balance + the SENT history record + its memo — to the
+ *     first tab, read from the full pull (no live wake-push dependency).
+ *   • G1 + J12 — ONE real close+reopen of A at the END of the live flow: A's
+ *     session stays continuous through send→request→pay (so the incoming
+ *     request's wake push lands on a live Nostr subscription), then A's context
+ *     is CLOSED and REOPENED over the same user-data-dir. On the fresh engine
+ *     we re-assert the FULL post-flow state replays from wallet-api:
+ *       - G1 (dev.11): the balance AND the SENT transaction history (the SENT
+ *         record + its memo) — the assertion that catches the history-reload
+ *         bug (#549/#550); a `page.reload()` alone never replayed persisted
+ *         history this way.
+ *       - J12: the resolved payment-request status "Paid Successfully" survives
+ *         the reopen. In this app the resolved payment-request status view lives
+ *         on the PAYER's side (the requester has no outgoing-request response
+ *         view wired in), so J12 is asserted on A, the only party holding one.
  *
  * Nametags ride Nostr (unchanged by this integration) and are REQUIRED for
  * recipient resolution: the engine send path needs the recipient's published
@@ -24,7 +47,10 @@
  * 5xx, relay timeouts) are retried/blocked on — they never license test
  * weakening. Only deterministic failures are code defects.
  */
-import { test, expect, type Locator, type Page } from '@playwright/test';
+import { test, expect, chromium, type BrowserContext, type Locator, type Page } from '@playwright/test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 /** The app renders mobile+desktop duplicates; assert/click the visible one. */
 function visible(page: Page, text: string): Locator {
@@ -49,6 +75,49 @@ function modalScreen(page: Page, text: string): Locator {
 const runId = Math.random().toString(36).slice(2, 8);
 const TAG_A = `smka${runId}`;
 const TAG_B = `smkb${runId}`;
+const MEMO_SEND = `smoke: rent ${runId}`;
+
+const baseURL = process.env.SMOKE_BASE_URL || 'http://localhost:4317';
+
+/**
+ * A persistent profile: a real on-disk user-data-dir so storage (IndexedDB +
+ * localStorage) survives a context close+reopen, exactly like a browser the
+ * user quits and relaunches. `reopen()` closes the live context and launches a
+ * fresh one over the SAME dir — a true close/reopen, not `page.reload()`.
+ */
+class Profile {
+  readonly userDataDir: string;
+  context!: BrowserContext;
+  page!: Page;
+
+  constructor(label: string) {
+    this.userDataDir = mkdtempSync(join(tmpdir(), `smoke-${label}-`));
+  }
+
+  async open(): Promise<Page> {
+    this.context = await chromium.launchPersistentContext(this.userDataDir, { baseURL });
+    this.page = this.context.pages()[0] ?? (await this.context.newPage());
+    return this.page;
+  }
+
+  /**
+   * Real close + reopen over the same user-data-dir (fresh in-memory engine).
+   * A relaunched persistent context opens a blank tab — Chromium does not
+   * restore the last URL under automation — so navigate back to /home, the
+   * same entry point the user lands on after relaunching the app.
+   */
+  async reopen(): Promise<Page> {
+    await this.context.close();
+    const page = await this.open();
+    await page.goto('/home');
+    return page;
+  }
+
+  async dispose(): Promise<void> {
+    await this.context.close().catch(() => {});
+    rmSync(this.userDataDir, { recursive: true, force: true });
+  }
+}
 
 /** Walk onboarding: create wallet + register a nametag + ack the mnemonic. */
 async function createWallet(page: Page, tag: string): Promise<void> {
@@ -96,25 +165,46 @@ async function topUp(page: Page): Promise<void> {
   await expect(visible(page, '100.0000 UCT')).toBeVisible({ timeout: 240_000 });
 }
 
-test('two profiles converge over wallet-api: fund, send, request, pay', async ({ browser }) => {
-  const ctxA = await browser.newContext();
-  const ctxB = await browser.newContext();
-  const a = await ctxA.newPage();
-  const b = await ctxB.newPage();
+/**
+ * Open the Transaction History modal and assert the SENT record for `tag`
+ * with its memo. History amounts strip trailing zeros (`-10 UCT`), unlike the
+ * balance list — match the sign+amount loosely. This replays from the full
+ * pull on a fresh engine: the path sphere-sdk#549/#550 broke on reload.
+ */
+async function expectSentInHistory(page: Page, tag: string, memo: string): Promise<void> {
+  await page.getByTitle('Transaction history').filter({ visible: true }).first().click();
+  await expect(visible(page, 'Transaction History')).toBeVisible({ timeout: 30_000 });
+  // Anchor on the memo (unique per run) to find this one record card, then
+  // assert the SENT direction + recipient + sign/amount all live in it. The
+  // title renders 'Sent' and 'to @tag' as adjacent inline nodes with no text
+  // whitespace between them (DOM text is "Sentto @tag"), so match it with a
+  // \s* regex rather than a literal space.
+  const record = page
+    .locator('div.cursor-pointer')
+    .filter({ hasText: memo })
+    .filter({ visible: true })
+    .first();
+  await expect(record).toBeVisible({ timeout: 60_000 });
+  await expect(record.getByText(new RegExp(`Sent\\s*to @${tag}`)).first()).toBeVisible({ timeout: 30_000 });
+  await expect(record.getByText(/-\s*10\s*UCT/).first()).toBeVisible({ timeout: 30_000 });
+}
 
-  // ── Onboard both profiles (A funds itself via open minting) ─────────────
-  await createWallet(a, TAG_A);
-  await createWallet(b, TAG_B);
-  await topUp(a);
+/** Close the visible Transaction History modal (header close button). */
+async function closeHistory(page: Page): Promise<void> {
+  await modalScreen(page, 'Transaction History')
+    .getByRole('button')
+    .first()
+    .click()
+    .catch(() => {});
+}
 
-  // ── A reloads (F5): minted balance must survive the full pull ───────────
-  await reloadAndExpectBalance(a, '100.0000 UCT');
-
-  // ── A sends 10 UCT to @B (mailbox delivery + B's claim/handoff) ─────────
+/** A sends 10 UCT to @B with `memo`; ends with A's balance at 90 UCT. */
+async function sendToB(a: Page): Promise<void> {
   await visibleButton(a, 'Send').click();
   await a.getByRole('button', { name: /^UCT / }).filter({ visible: true }).first().click();
   await a.getByPlaceholder("Recipient's Unicity ID").fill(TAG_B);
   await a.locator('input[inputmode="decimal"]').fill('10');
+  await a.getByPlaceholder('Memo (optional)').fill(MEMO_SEND);
   // Nametag resolution hits public relays — retry while the binding settles.
   await expect(async () => {
     await a.getByRole('button', { name: 'Review' }).click();
@@ -127,38 +217,87 @@ test('two profiles converge over wallet-api: fund, send, request, pay', async ({
   await expect(visible(a, 'Success!')).toBeVisible({ timeout: 180_000 });
   await visibleButton(a, 'Close').click();
   await expect(visible(a, '90.0000 UCT')).toBeVisible({ timeout: 60_000 });
+}
 
-  // ── B receives: wake → mailbox claim → inventory custody → balance ──────
-  await expect(visible(b, '10.0000 UCT')).toBeVisible({ timeout: 240_000 });
+test('two profiles converge over wallet-api: fund, send, request, pay', async () => {
+  const profileA = new Profile('a');
+  const profileB = new Profile('b');
+  let a = await profileA.open();
+  const b = await profileB.open();
 
-  // ── B reloads (F5): received balance must survive the full pull ─────────
-  await reloadAndExpectBalance(b, '10.0000 UCT');
+  try {
+    // ── Onboard both profiles (A funds itself via open minting) ───────────
+    await createWallet(a, TAG_A);
+    await createWallet(b, TAG_B);
+    await topUp(a);
 
-  // ── B requests 5 UCT from @A (§16 payment request) ──────────────────────
-  await visibleButton(b, 'Top Up').click();
-  await visible(b, 'Payment Request').click();
-  await b.getByRole('button', { name: /^UCT/ }).filter({ visible: true }).first().click();
-  await b.getByPlaceholder('Who should pay you?').fill(TAG_A);
-  await b.locator('input[inputmode="decimal"]').fill('5');
-  await b.getByPlaceholder('Message (optional)').fill('smoke: lunch money');
-  await expect(async () => {
-    await b.getByRole('button', { name: 'Review' }).click();
-    await expect(b.getByRole('button', { name: 'Send Request' })).toBeVisible({ timeout: 15_000 });
-  }).toPass({ timeout: 120_000, intervals: [5_000] });
-  await visibleButton(b, 'Send Request').click();
-  await expect(visible(b, 'Request Sent!')).toBeVisible({ timeout: 120_000 });
-  await visibleButton(b, 'Close').click();
+    // ── A reloads (F5): minted balance must survive the full pull ─────────
+    await reloadAndExpectBalance(a, '100.0000 UCT');
 
-  // ── A pays it (payPaymentRequest: send + linked 'paid' respond) ─────────
-  // The requests modal auto-opens on the incoming request (wake push).
-  await expect(visible(a, 'smoke: lunch money')).toBeVisible({ timeout: 240_000 });
-  await visibleButton(a, 'Pay Now').click();
-  await expect(visible(a, 'Paid Successfully')).toBeVisible({ timeout: 240_000 });
+    // ── A sends 10 UCT to @B (mailbox delivery + B's claim/handoff) ───────
+    await sendToB(a);
 
-  // ── Convergence: B holds 15 UCT, A holds 85 ─────────────────────────────
-  await expect(visible(b, '15.0000 UCT')).toBeVisible({ timeout: 240_000 });
-  await expect(visible(a, '85.0000 UCT')).toBeVisible({ timeout: 60_000 });
+    // ── G4: a second tab on A's context (shared storage) shows identical ──
+    //    post-send state — balance + the SENT history record with its memo.
+    //    Same context = a true second tab over shared storage; reads from the
+    //    full pull, no dependency on a live wake push.
+    const a2 = await profileA.context.newPage();
+    await a2.goto('/home');
+    await expect(visible(a2, '90.0000 UCT')).toBeVisible({ timeout: 240_000 });
+    await expectSentInHistory(a2, TAG_B, MEMO_SEND);
+    await closeHistory(a2);
+    await a2.close();
 
-  await ctxA.close();
-  await ctxB.close();
+    // ── B receives: wake → mailbox claim → inventory custody → balance ────
+    await expect(visible(b, '10.0000 UCT')).toBeVisible({ timeout: 240_000 });
+
+    // ── B reloads (F5): received balance must survive the full pull ───────
+    await reloadAndExpectBalance(b, '10.0000 UCT');
+
+    // ── B requests 5 UCT from @A (§16 payment request) ────────────────────
+    await visibleButton(b, 'Top Up').click();
+    await visible(b, 'Payment Request').click();
+    await b.getByRole('button', { name: /^UCT/ }).filter({ visible: true }).first().click();
+    await b.getByPlaceholder('Who should pay you?').fill(TAG_A);
+    await b.locator('input[inputmode="decimal"]').fill('5');
+    await b.getByPlaceholder('Message (optional)').fill('smoke: lunch money');
+    await expect(async () => {
+      await b.getByRole('button', { name: 'Review' }).click();
+      await expect(b.getByRole('button', { name: 'Send Request' })).toBeVisible({ timeout: 15_000 });
+    }).toPass({ timeout: 120_000, intervals: [5_000] });
+    await visibleButton(b, 'Send Request').click();
+    await expect(visible(b, 'Request Sent!')).toBeVisible({ timeout: 120_000 });
+    await visibleButton(b, 'Close').click();
+
+    // ── A pays it (payPaymentRequest: send + linked 'paid' respond) ───────
+    // The requests modal auto-opens on the incoming request (wake push).
+    await expect(visible(a, 'smoke: lunch money')).toBeVisible({ timeout: 240_000 });
+    await visibleButton(a, 'Pay Now').click();
+    await expect(visible(a, 'Paid Successfully')).toBeVisible({ timeout: 240_000 });
+
+    // ── Convergence: B holds 15 UCT, A holds 85 ───────────────────────────
+    await expect(visible(b, '15.0000 UCT')).toBeVisible({ timeout: 240_000 });
+    await expect(visible(a, '85.0000 UCT')).toBeVisible({ timeout: 60_000 });
+
+    // ── G1 + J12: ONE real close+reopen of A over the same user-data-dir,
+    //    on a fresh in-memory engine, must replay the FULL post-flow state
+    //    from wallet-api:
+    //      • balance 85 UCT (the running balance survives the reopen),
+    //      • G1 — the SENT history record + its memo (sphere-sdk#549/#550),
+    //      • J12 — the resolved payment-request status "Paid Successfully".
+    //    The reopen sits at the end of the live flow on purpose: A's session
+    //    stays continuous through send→request→pay (so the incoming-request
+    //    wake push and its message land on a live Nostr subscription), and the
+    //    reopen then proves all three survive a real browser quit+relaunch.
+    a = await profileA.reopen();
+    await expect(visible(a, '85.0000 UCT')).toBeVisible({ timeout: 240_000 });
+    await expectSentInHistory(a, TAG_B, MEMO_SEND);
+    await closeHistory(a);
+    await a.getByTitle('Payment requests').filter({ visible: true }).first().click();
+    await expect(visible(a, 'Payment Requests')).toBeVisible({ timeout: 30_000 });
+    await expect(visible(a, 'Paid Successfully')).toBeVisible({ timeout: 240_000 });
+  } finally {
+    await profileA.dispose();
+    await profileB.dispose();
+  }
 });

--- a/tests/e2e/two-profile-smoke.spec.ts
+++ b/tests/e2e/two-profile-smoke.spec.ts
@@ -11,6 +11,11 @@
  *   A creates + funds a wallet → sends UCT to B → B sees the balance →
  *   B sends A a payment request → A pays it → both UIs converge.
  *
+ * Each profile is hard-reloaded (F5) right after its first balance
+ * assertion: reload drops all in-memory engine state, so re-asserting the
+ * SAME balance proves it survives a full pull from wallet-api (the
+ * sphere-sdk#521 regression — fixed in 0.9.1-dev.9 — lost it here).
+ *
  * Nametags ride Nostr (unchanged by this integration) and are REQUIRED for
  * recipient resolution: the engine send path needs the recipient's published
  * chain pubkey, so both profiles register one during onboarding.
@@ -72,6 +77,16 @@ async function createWallet(page: Page, tag: string): Promise<void> {
   });
 }
 
+/**
+ * F5 and re-assert the same balance. Reload discards all in-memory state,
+ * so the balance can only come back via the full pull from wallet-api —
+ * exactly the path sphere-sdk#521 broke (fixed in 0.9.1-dev.9).
+ */
+async function reloadAndExpectBalance(page: Page, balance: string): Promise<void> {
+  await page.reload();
+  await expect(visible(page, balance)).toBeVisible({ timeout: 240_000 });
+}
+
 /** Open mint via Top Up (UCT/BTC/SOL/ETH basket) and wait for the deposit. */
 async function topUp(page: Page): Promise<void> {
   await visibleButton(page, 'Top Up').click();
@@ -91,6 +106,9 @@ test('two profiles converge over wallet-api: fund, send, request, pay', async ({
   await createWallet(a, TAG_A);
   await createWallet(b, TAG_B);
   await topUp(a);
+
+  // ── A reloads (F5): minted balance must survive the full pull ───────────
+  await reloadAndExpectBalance(a, '100.0000 UCT');
 
   // ── A sends 10 UCT to @B (mailbox delivery + B's claim/handoff) ─────────
   await visibleButton(a, 'Send').click();
@@ -112,6 +130,9 @@ test('two profiles converge over wallet-api: fund, send, request, pay', async ({
 
   // ── B receives: wake → mailbox claim → inventory custody → balance ──────
   await expect(visible(b, '10.0000 UCT')).toBeVisible({ timeout: 240_000 });
+
+  // ── B reloads (F5): received balance must survive the full pull ─────────
+  await reloadAndExpectBalance(b, '10.0000 UCT');
 
   // ── B requests 5 UCT from @A (§16 payment request) ──────────────────────
   await visibleButton(b, 'Top Up').click();

--- a/tests/unit/config/storageKeys.test.ts
+++ b/tests/unit/config/storageKeys.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   STORAGE_KEYS,
   clearAllSphereData,
+  getOrCreateWalletApiDeviceId,
 } from "../../../src/config/storageKeys";
 
 // ==========================================
@@ -120,5 +121,55 @@ describe("clearAllSphereData", () => {
     );
 
     consoleSpy.mockRestore();
+  });
+});
+
+// ==========================================
+// Test: getOrCreateWalletApiDeviceId
+// ==========================================
+
+describe("getOrCreateWalletApiDeviceId", () => {
+  let localStorageMock: { [key: string]: string };
+
+  beforeEach(() => {
+    localStorageMock = {};
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => localStorageMock[key] || null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageMock[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete localStorageMock[key];
+      }),
+      key: vi.fn((index: number) => Object.keys(localStorageMock)[index] || null),
+      get length() {
+        return Object.keys(localStorageMock).length;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("generates a device id once and persists it under the sphere_ key", () => {
+    const first = getOrCreateWalletApiDeviceId();
+
+    expect(first).toMatch(/^sphere-web-/);
+    expect(localStorageMock[STORAGE_KEYS.WALLET_API_DEVICE_ID]).toBe(first);
+
+    // Stable across calls — one (owner, device) session row, not one per load
+    expect(getOrCreateWalletApiDeviceId()).toBe(first);
+  });
+
+  it("resets the device identity when sphere data is cleared (wallet deletion)", () => {
+    const first = getOrCreateWalletApiDeviceId();
+
+    clearAllSphereData();
+    expect(localStorageMock[STORAGE_KEYS.WALLET_API_DEVICE_ID]).toBeUndefined();
+
+    const second = getOrCreateWalletApiDeviceId();
+    expect(second).toMatch(/^sphere-web-/);
+    expect(second).not.toBe(first);
   });
 });

--- a/tests/unit/config/walletApi.test.ts
+++ b/tests/unit/config/walletApi.test.ts
@@ -3,6 +3,7 @@ import {
   getWalletApiBaseUrl,
   getEngineOverride,
   isWalletApiEnabled,
+  isWalletApiRequired,
 } from "../../../src/config/walletApi";
 
 afterEach(() => {
@@ -12,6 +13,7 @@ afterEach(() => {
 describe("getWalletApiBaseUrl / isWalletApiEnabled", () => {
   it("is disabled when VITE_WALLET_API_URL is unset", () => {
     vi.stubEnv("VITE_WALLET_API_URL", "");
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", ""); // isolate from local .env (#351 assert)
     expect(getWalletApiBaseUrl()).toBeNull();
     expect(isWalletApiEnabled()).toBe(false);
   });
@@ -25,6 +27,55 @@ describe("getWalletApiBaseUrl / isWalletApiEnabled", () => {
   it("resolves relative URLs (dev/preview proxy paths) against the app origin", () => {
     vi.stubEnv("VITE_WALLET_API_URL", "/wallet-api");
     expect(getWalletApiBaseUrl()).toBe(`${window.location.origin}/wallet-api`);
+  });
+});
+
+describe("VITE_REQUIRE_WALLET_API composition assert (#351)", () => {
+  it("flag unset + URL unset → legacy composition allowed (null, no throw)", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "");
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(isWalletApiRequired()).toBe(false);
+    expect(getWalletApiBaseUrl()).toBeNull();
+  });
+
+  it("flag set + URL unset → throws naming BOTH vars (never silently legacy)", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "true");
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(isWalletApiRequired()).toBe(true);
+    expect(() => getWalletApiBaseUrl()).toThrow(/VITE_REQUIRE_WALLET_API/);
+    expect(() => getWalletApiBaseUrl()).toThrow(/VITE_WALLET_API_URL/);
+    expect(() => getWalletApiBaseUrl()).toThrow(/custody/);
+  });
+
+  it("any non-false flag value arms the assert ('1', 'yes')", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    for (const value of ["1", "yes"]) {
+      vi.stubEnv("VITE_REQUIRE_WALLET_API", value);
+      expect(isWalletApiRequired()).toBe(true);
+      expect(() => getWalletApiBaseUrl()).toThrow(/VITE_WALLET_API_URL/);
+    }
+  });
+
+  it("explicit opt-outs 'false' and '0' disarm the assert", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    for (const value of ["false", "0"]) {
+      vi.stubEnv("VITE_REQUIRE_WALLET_API", value);
+      expect(isWalletApiRequired()).toBe(false);
+      expect(getWalletApiBaseUrl()).toBeNull();
+    }
+  });
+
+  it("flag set + URL set → normal wallet-api composition (no throw)", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "true");
+    vi.stubEnv("VITE_WALLET_API_URL", "https://wallet-api.staging.unicity.network");
+    expect(getWalletApiBaseUrl()).toBe("https://wallet-api.staging.unicity.network/");
+    expect(isWalletApiEnabled()).toBe(true);
+  });
+
+  it("isWalletApiEnabled never throws (render-path safety): misconfigured build reports false", () => {
+    vi.stubEnv("VITE_REQUIRE_WALLET_API", "true");
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(isWalletApiEnabled()).toBe(false);
   });
 });
 

--- a/tests/unit/config/walletApi.test.ts
+++ b/tests/unit/config/walletApi.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  getWalletApiBaseUrl,
+  getEngineOverride,
+  isWalletApiEnabled,
+} from "../../../src/config/walletApi";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getWalletApiBaseUrl / isWalletApiEnabled", () => {
+  it("is disabled when VITE_WALLET_API_URL is unset", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "");
+    expect(getWalletApiBaseUrl()).toBeNull();
+    expect(isWalletApiEnabled()).toBe(false);
+  });
+
+  it("passes absolute URLs through", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "http://127.0.0.1:3000");
+    expect(getWalletApiBaseUrl()).toBe("http://127.0.0.1:3000/");
+    expect(isWalletApiEnabled()).toBe(true);
+  });
+
+  it("resolves relative URLs (dev/preview proxy paths) against the app origin", () => {
+    vi.stubEnv("VITE_WALLET_API_URL", "/wallet-api");
+    expect(getWalletApiBaseUrl()).toBe(`${window.location.origin}/wallet-api`);
+  });
+});
+
+describe("getEngineOverride", () => {
+  it("is null when neither override is set", () => {
+    vi.stubEnv("VITE_AGGREGATOR_URL", "");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "");
+    expect(getEngineOverride()).toBeNull();
+  });
+
+  it("resolves both URLs when both are set", () => {
+    vi.stubEnv("VITE_AGGREGATOR_URL", "/local-agg");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "/local-agg/trustbase.json");
+    expect(getEngineOverride()).toEqual({
+      aggregatorUrl: `${window.location.origin}/local-agg`,
+      trustBaseUrl: `${window.location.origin}/local-agg/trustbase.json`,
+    });
+  });
+
+  it("fails loud when only one of the pair is set (trustbase mixing guard)", () => {
+    vi.stubEnv("VITE_AGGREGATOR_URL", "/local-agg");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "");
+    expect(() => getEngineOverride()).toThrow(/must be set together/);
+
+    vi.stubEnv("VITE_AGGREGATOR_URL", "");
+    vi.stubEnv("VITE_TRUSTBASE_URL", "/local-agg/trustbase.json");
+    expect(() => getEngineOverride()).toThrow(/must be set together/);
+  });
+});

--- a/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
+++ b/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
@@ -81,6 +81,15 @@ function makeFakeSphere(initial: FakeSdkRequest[] = []) {
       requests.unshift(r);
       listeners.get("payment_request:incoming")?.forEach((fn) => fn({ ...r }));
     },
+    // Simulate a resolution driven elsewhere (another window / this wallet's
+    // other session): the SDK advances the status in its own list, THEN emits
+    // the matching event. Mirrors sphere-sdk's paid/rejected/expired surface.
+    _resolveRemote: (id: string, status: "paid" | "rejected" | "expired") => {
+      const r = find(id);
+      if (r) r.status = status;
+      const evt = `payment_request:${status}`;
+      listeners.get(evt)?.forEach((fn) => fn(r ? { ...r } : { id, status }));
+    },
   };
   return sphere;
 }
@@ -122,6 +131,30 @@ describe("useIncomingPaymentRequests", () => {
     await waitFor(() => expect(result.current.requests).toHaveLength(1));
     expect(result.current.pendingCount).toBe(1);
   });
+
+  it.each([
+    ["paid", PaymentRequestStatus.PAID],
+    ["rejected", PaymentRequestStatus.REJECTED],
+    ["expired", PaymentRequestStatus.EXPIRED],
+  ] as const)(
+    "drops a request from the actionable view on payment_request:%s (cross-session)",
+    async (sdkStatus, uiStatus) => {
+      fakeSphere = makeFakeSphere([makeRequest("a")]);
+      const { result } = renderHook(() => useIncomingPaymentRequests());
+      expect(result.current.pendingCount).toBe(1);
+      expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+
+      // Another window (or this wallet's other session) resolves the request.
+      act(() => {
+        fakeSphere!._resolveRemote("a", sdkStatus);
+      });
+
+      // The request leaves the actionable (PENDING) state — its Pay/Decline
+      // buttons disappear — and the status reflects the resolution.
+      await waitFor(() => expect(result.current.requests[0].status).toBe(uiStatus));
+      expect(result.current.pendingCount).toBe(0);
+    },
+  );
 
   it("pays through payments.payPaymentRequest (no raw transfer + paid flip)", async () => {
     fakeSphere = makeFakeSphere([makeRequest("a")]);

--- a/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
+++ b/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  useIncomingPaymentRequests,
+  PaymentRequestStatus,
+} from "../../../src/components/wallet/L3/hooks/useIncomingPaymentRequests";
+
+// ============================================================================
+// Fake sphere: implements exactly the PaymentsModule surface the hook is
+// allowed to use. There is deliberately NO getTransport() — the legacy
+// implementation bypassed the module via the transport, which silently
+// no-ops on the wallet-api path; any regression to it throws here.
+// ============================================================================
+
+type SdkStatus = "pending" | "accepted" | "rejected" | "paid" | "expired";
+
+interface FakeSdkRequest {
+  id: string;
+  senderPubkey: string;
+  senderNametag?: string;
+  amount: string;
+  coinId: string;
+  symbol: string;
+  message?: string;
+  requestId: string;
+  timestamp: number;
+  status: SdkStatus;
+}
+
+function makeRequest(id: string, status: SdkStatus = "pending"): FakeSdkRequest {
+  return {
+    id,
+    senderPubkey: "02".padEnd(66, "a"),
+    senderNametag: "alice",
+    amount: "1000",
+    coinId: "coin-1",
+    symbol: "UCT",
+    requestId: `req-${id}`,
+    timestamp: Date.now(),
+    status,
+  };
+}
+
+function makeFakeSphere(initial: FakeSdkRequest[] = []) {
+  const requests = [...initial];
+  const listeners = new Map<string, Set<(data: unknown) => void>>();
+
+  const find = (id: string) => requests.find((r) => r.id === id);
+
+  const sphere = {
+    on: (evt: string, fn: (data: unknown) => void) => {
+      if (!listeners.has(evt)) listeners.set(evt, new Set());
+      listeners.get(evt)!.add(fn);
+    },
+    off: (evt: string, fn: (data: unknown) => void) => {
+      listeners.get(evt)?.delete(fn);
+    },
+    payments: {
+      getPaymentRequests: vi.fn(() => requests.map((r) => ({ ...r }))),
+      acceptPaymentRequest: vi.fn(async (id: string) => {
+        const r = find(id);
+        if (r) r.status = "accepted";
+      }),
+      rejectPaymentRequest: vi.fn(async (id: string) => {
+        const r = find(id);
+        if (r) r.status = "rejected";
+      }),
+      payPaymentRequest: vi.fn(async (id: string) => {
+        const r = find(id);
+        if (r) r.status = "paid";
+        return { success: true, id: "transfer-1" };
+      }),
+      clearProcessedPaymentRequests: vi.fn(() => {
+        for (let i = requests.length - 1; i >= 0; i--) {
+          if (requests[i].status !== "pending") requests.splice(i, 1);
+        }
+      }),
+    },
+    // Test-side helpers
+    _receive: (r: FakeSdkRequest) => {
+      requests.unshift(r);
+      listeners.get("payment_request:incoming")?.forEach((fn) => fn({ ...r }));
+    },
+  };
+  return sphere;
+}
+
+let fakeSphere: ReturnType<typeof makeFakeSphere> | null = null;
+
+vi.mock("../../../src/sdk/hooks/core/useSphere", () => ({
+  useSphereContext: () => ({ sphere: fakeSphere }),
+}));
+
+beforeEach(() => {
+  fakeSphere = null;
+});
+
+describe("useIncomingPaymentRequests", () => {
+  it("seeds from payments.getPaymentRequests() on mount (sign-in backfill)", () => {
+    fakeSphere = makeFakeSphere([makeRequest("a"), makeRequest("b", "expired")]);
+
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    expect(result.current.requests).toHaveLength(2);
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+    expect(result.current.requests[1].status).toBe(PaymentRequestStatus.EXPIRED);
+    expect(result.current.pendingCount).toBe(1);
+    // Legacy bridge fields preserved
+    expect(result.current.requests[0].amount).toBe(1000n);
+    expect(result.current.requests[0].recipientNametag).toBe("alice");
+  });
+
+  it("adds requests on payment_request:incoming", async () => {
+    fakeSphere = makeFakeSphere();
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+    expect(result.current.requests).toHaveLength(0);
+
+    act(() => {
+      fakeSphere!._receive(makeRequest("live-1"));
+    });
+
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+    expect(result.current.pendingCount).toBe(1);
+  });
+
+  it("pays through payments.payPaymentRequest (no raw transfer + paid flip)", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await act(() => result.current.pay(result.current.requests[0]));
+
+    expect(fakeSphere.payments.payPaymentRequest).toHaveBeenCalledWith("a");
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PAID);
+  });
+
+  it("rejects through payments.rejectPaymentRequest (server-confirmed)", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await act(() => result.current.reject(result.current.requests[0]));
+
+    expect(fakeSphere.payments.rejectPaymentRequest).toHaveBeenCalledWith("a");
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.REJECTED);
+  });
+
+  it("propagates a server reject failure and does NOT flip the status", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    // 403 non-addressee / 409 non-open propagate from the module — the
+    // request must stay pending locally (the respond IS the state change).
+    fakeSphere.payments.rejectPaymentRequest.mockRejectedValueOnce(
+      new Error("HTTP 409: request is not open"),
+    );
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await expect(
+      act(() => result.current.reject(result.current.requests[0])),
+    ).rejects.toThrow(/409/);
+
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+  });
+
+  it("propagates a pay failure and leaves the request pending", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    fakeSphere.payments.payPaymentRequest.mockRejectedValueOnce(
+      new Error("INSUFFICIENT_FUNDS"),
+    );
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await expect(
+      act(() => result.current.pay(result.current.requests[0])),
+    ).rejects.toThrow(/INSUFFICIENT_FUNDS/);
+
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+  });
+
+  it("clearProcessed delegates to the module and keeps pending requests", async () => {
+    fakeSphere = makeFakeSphere([makeRequest("a"), makeRequest("b", "paid")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+    expect(result.current.requests).toHaveLength(2);
+
+    act(() => result.current.clearProcessed());
+
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+    expect(result.current.requests[0].id).toBe("a");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,26 @@ export default defineConfig(({ mode }) => {
   // the SPA HTML fallback — a proxied URL without a "." (e.g.
   // /coingecko/simple/price?ids=bitcoin) would otherwise be rewritten to
   // index.html and never reach the proxy (the SDK then gets HTML, not JSON).
-  const proxyPaths = ['/rpc', '/dev-rpc', '/coingecko'];
+  const proxyPaths = ['/rpc', '/dev-rpc', '/coingecko', '/wallet-api', '/local-agg'];
+
+  // wallet-api backend + LOCAL dev-stack aggregator (docker-compose.dev.yml
+  // in the wallet-api repo). Neither serves CORS headers, so the browser app
+  // reaches them through this same-origin proxy in dev/preview (set
+  // VITE_WALLET_API_URL=/wallet-api etc.); production deployments must solve
+  // CORS/edge routing on the backend side.
+  const localStackProxy = {
+    '/wallet-api': {
+      target: env.WALLET_API_PROXY_TARGET || 'http://127.0.0.1:3000',
+      changeOrigin: true,
+      ws: true, // the SDK's wake socket (/v1/ws) rides the same base URL
+      rewrite: (p: string) => p.replace(/^\/wallet-api/, ''),
+    },
+    '/local-agg': {
+      target: env.AGGREGATOR_PROXY_TARGET || 'http://127.0.0.1:3001',
+      changeOrigin: true,
+      rewrite: (p: string) => p.replace(/^\/local-agg/, ''),
+    },
+  };
 
   return {
     plugins: [
@@ -101,8 +120,14 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: true,
           rewrite: (path) => path.replace(/^\/coingecko/, ''),
-        }
+        },
+        ...localStackProxy,
       }
+    },
+    // `vite preview` (used by the Playwright smoke) needs the same
+    // same-origin route to the local stack as the dev server.
+    preview: {
+      proxy: { ...localStackProxy },
     },
     // Ensure polyfill shims resolve correctly for symlinked file: dependencies
     resolve: {


### PR DESCRIPTION
## What this delivers

The sphere (frontend) side of the wallet-api integration — pins **sphere-sdk `0.10.0`** (the stable wallet-api integration release) and wires the app onto it.

- **wallet-api provider swap (S4):** provider composition, auth lifecycle, module-routed payment requests, two-profile smoke (#348).
- **Fail-closed** on wallet-api-intended builds; surfaces session + storage degradation in the UI (#351/#352).
- Pages branch deploys bake the staging wallet-api URL into the bundle (#350).
- Cross-session UI sync: drop resolved payment requests on resolution, wake-socket liveness.
- Re-enabled **Group Chat** (desktop button + NIP-29 SDK module) now that the SDK's member handling is fixed (sphere-sdk #586/#589).
- Reload/history/payment-request fixes ride the SDK bumps (dev.9 → 0.10.0).

Sphere `main` was merged in to clear the SDK version-pin conflict; `tsc -b` is clean against `0.10.0`.
