### PR TITLE
feat(wallet): opt-in token-api vault backup + courier delivery (env-gated, OFF by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 VITE_WELCOME_AGENT_NAMETAG=kbbot
 VITE_WELCOME_DELAY_MS=4000
 
+# Token-Vault v2 (opt-in, OFF by default). Leave unset for today's behavior:
+# no remote backup, Nostr-only delivery. Set ENABLED=true to turn each on; the
+# URL is optional and defaults to NETWORKS[network].vaultUrl (point it at a local
+# token-api for dev, e.g. http://localhost:3000).
+#   VITE_VAULT_ENABLED=true        # encrypted remote token backup + reserved-address restore
+#   VITE_VAULT_URL=http://localhost:3000
+#   VITE_COURIER_ENABLED=true      # store-and-forward v2 token delivery (courier-primary, Nostr fallback)
+#   VITE_COURIER_URL=http://localhost:3000
+
 # Dev server HTTPS (optional)
 SSL_CERT_PATH=
 HMR_HOST=

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "^0.9.0-dev.0",
+        "@unicitylabs/sphere-sdk": "file:../sphere-sdk",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -50,6 +50,79 @@
         "vite": "^7.3.1",
         "vite-plugin-node-polyfills": "^0.24.0",
         "vitest": "^4.0.15"
+      }
+    },
+    "../sphere-sdk": {
+      "name": "@unicitylabs/sphere-sdk",
+      "version": "0.9.0-dev.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.5.0",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0",
+        "elliptic": "^6.6.1"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@libp2p/bootstrap": "^12.0.11",
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/interface": "^3.1.0",
+        "@libp2p/peer-id": "^6.0.4",
+        "@types/crypto-js": "^4.2.2",
+        "@types/elliptic": "^6.4.18",
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
+        "@typescript-eslint/eslint-plugin": "^8.54.0",
+        "@typescript-eslint/parser": "^8.54.0",
+        "eslint": "^9.39.2",
+        "fake-indexeddb": "^6.2.5",
+        "multiformats": "^13.4.2",
+        "testcontainers": "^11.11.0",
+        "tsup": "^8.5.1",
+        "tsx": "^4.21.0",
+        "typescript": "~5.6.0",
+        "typescript-eslint": "^8.54.0",
+        "vitest": "^2.0.0",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@acemir/cssom": {
@@ -406,13 +479,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@chainsafe/is-ip": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
-      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -604,20 +670,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnsquery/dns-packet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
-      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@leichtgewicht/ip-codec": "^2.0.4",
-        "utf8-codec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1308,183 +1360,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
-      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/crypto": {
-      "version": "5.1.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.19.tgz",
-      "integrity": "sha512-hYNeHQpUSwLPopWCgDf6OklOvVwJPS/vYZOiBG3VXPIzx5AkONBOfdkgVwB4YsIBH2V6z+TMgMH0yXUZsMurPA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.3",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "protons-runtime": "^6.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/interface": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.3.tgz",
-      "integrity": "sha512-OKZFrY+x8IYl4Fr/YWjh4s6+uks5zQBIAdg2cl+zaRUpPORfk1ELI4r+eB+fUlXR9mHDsQylSSzmAqi0drDfiA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@multiformats/dns": "^1.0.6",
-        "@multiformats/multiaddr": "^13.0.3",
-        "main-event": "^1.0.1",
-        "multiformats": "^14.0.0",
-        "progress-events": "^1.1.0",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/logger": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.8.tgz",
-      "integrity": "sha512-oPTkWJhYvhk8fjInH1ySyUDC/LLuqHsVqpNprtImd/64lnRHInV0EbwpRYwjdPNXAxYXDU/eQJzyqMWUNnN4+A==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/interface": "^3.2.3",
-        "@multiformats/multiaddr": "^13.0.3",
-        "interface-datastore": "^9.0.1",
-        "multiformats": "^14.0.0",
-        "weald": "^1.1.0"
-      }
-    },
-    "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@libp2p/peer-id": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.10.tgz",
-      "integrity": "sha512-FgXeraxl932zim/K+vipCkscjLNMsyNVBh1NpGcJ+y8DQi/jgFXV4YZ0M2JuWM20GTcVCqDT5P10A0DJHRjecg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.1.19",
-        "@libp2p/interface": "^3.2.3",
-        "multiformats": "^14.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@multiformats/dns": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
-      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@dnsquery/dns-packet": "^6.1.1",
-        "@libp2p/interface": "^3.1.0",
-        "hashlru": "^2.3.0",
-        "p-queue": "^9.0.0",
-        "progress-events": "^1.0.0",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
-      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "multiformats": "^14.0.0",
-        "uint8-varint": "^3.0.0",
-        "uint8arrays": "^6.1.1"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/curves": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
-      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "2.2.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1862,15 +1737,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2695,97 +2561,9 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
-      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "^1.0.0",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/base": "^1.1.9",
-        "libphonenumber-js": "^1.11.14"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.0-dev.0.tgz",
-      "integrity": "sha512-yjRmXEpjS7B2vBnPixqJSXv0zPX2x5IEy4c7LBy+ujvxTUKB6U4Y/DQuEVC9LDT5EhVeAgYoL9rwT3xCxac7Mw==",
-      "dependencies": {
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.5.0",
-        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0",
-        "elliptic": "^6.6.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
+      "resolved": "../sphere-sdk",
+      "link": true
     },
     "node_modules/@unicitylabs/sphere-ui": {
       "version": "0.1.23",
@@ -2852,31 +2630,6 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
       "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
-    },
-    "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.0-rc.6027e82",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.6027e82.tgz",
-      "integrity": "sha512-PV6lHwJOCjpICG0Vd7Ty+5mZa7migGtopa1QVBjp9xRRtfNXDAvf8YPzXE6PQOtKCVP5ymmKuWKRKkNoNOw2zA==",
-      "dependencies": {
-        "@noble/curves": "2.2.0",
-        "@noble/hashes": "2.2.0",
-        "uuid": "14.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@unicitylabs/state-transition-sdk/node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -3187,6 +2940,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3224,27 +2978,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
-      }
-    },
-    "node_modules/bip39/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/bn.js": {
@@ -3461,30 +3194,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -3579,28 +3288,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canonicalize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
-      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "canonicalize": "bin/canonicalize.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/cborg": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
-      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "cborg": "lib/bin.js"
-      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -4367,13 +4054,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4753,13 +4433,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4836,6 +4509,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4894,63 +4568,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/interface-datastore": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
-      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "interface-store": "^7.0.0",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/interface-store": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
-      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
-    "node_modules/ipns": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
-      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "@libp2p/crypto": "^5.0.0",
-        "@libp2p/interface": "^3.0.2",
-        "@libp2p/logger": "^6.0.4",
-        "cborg": "^5.1.0",
-        "interface-datastore": "^9.0.2",
-        "multiformats": "^13.2.2",
-        "protons-runtime": "^6.0.1",
-        "timestamp-nano": "^1.0.1",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -5279,12 +4896,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
-      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
-      "license": "MIT"
-    },
     "node_modules/lightningcss": {
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
@@ -5607,13 +5218,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/main-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
-      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5703,13 +5307,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/multiformats": {
-      "version": "13.4.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
-      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5952,36 +5549,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "eventemitter3": "^5.0.4",
-        "p-timeout": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -6215,13 +5782,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/progress-events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
-      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6238,39 +5798,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/protons-runtime": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
-      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/protons-runtime/node_modules/uint8-varint": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
-      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/protons-runtime/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -6992,16 +6519,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/timestamp-nano": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
-      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7198,64 +6715,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/uint8-varint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
-      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^3.0.1",
-        "uint8arrays": "^6.1.0"
-      }
-    },
-    "node_modules/uint8-varint/node_modules/uint8arraylist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
-      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^6.0.0"
-      }
-    },
-    "node_modules/uint8arraylist": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
-      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/uint8arraylist/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/uint8arrays": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
-      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^14.0.0"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -7324,13 +6783,6 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/utf8-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
-      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -7559,40 +7011,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/weald": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
-      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^4.0.0-nightly.202508271359",
-        "supports-color": "^10.0.0"
-      }
-    },
-    "node_modules/weald/node_modules/ms": {
-      "version": "4.0.0-nightly.202508271359",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
-      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/weald/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -7696,7 +7114,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "file:../sphere-sdk",
+        "@unicitylabs/sphere-sdk": "0.9.2-dev.0",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -50,79 +50,6 @@
         "vite": "^7.3.1",
         "vite-plugin-node-polyfills": "^0.24.0",
         "vitest": "^4.0.15"
-      }
-    },
-    "../sphere-sdk": {
-      "name": "@unicitylabs/sphere-sdk",
-      "version": "0.9.0-dev.0",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "2.2.0",
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.5.0",
-        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
-        "bip39": "^3.1.0",
-        "buffer": "^6.0.3",
-        "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0",
-        "elliptic": "^6.6.1"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.39.2",
-        "@libp2p/bootstrap": "^12.0.11",
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/interface": "^3.1.0",
-        "@libp2p/peer-id": "^6.0.4",
-        "@types/crypto-js": "^4.2.2",
-        "@types/elliptic": "^6.4.18",
-        "@types/node": "^22.0.0",
-        "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.54.0",
-        "@typescript-eslint/parser": "^8.54.0",
-        "eslint": "^9.39.2",
-        "fake-indexeddb": "^6.2.5",
-        "multiformats": "^13.4.2",
-        "testcontainers": "^11.11.0",
-        "tsup": "^8.5.1",
-        "tsx": "^4.21.0",
-        "typescript": "~5.6.0",
-        "typescript-eslint": "^8.54.0",
-        "vitest": "^2.0.0",
-        "ws": "^8.18.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "optionalDependencies": {
-        "@libp2p/crypto": "^5.1.13",
-        "@libp2p/peer-id": "^6.0.4",
-        "ipns": "^10.0.0",
-        "multiformats": "^13.4.2"
-      },
-      "peerDependencies": {
-        "@libp2p/crypto": ">=5.0.0",
-        "@libp2p/peer-id": ">=6.0.0",
-        "ipns": ">=10.0.0",
-        "multiformats": ">=13.0.0",
-        "ws": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@libp2p/crypto": {
-          "optional": true
-        },
-        "@libp2p/peer-id": {
-          "optional": true
-        },
-        "ipns": {
-          "optional": true
-        },
-        "multiformats": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@acemir/cssom": {
@@ -479,6 +406,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -670,6 +604,20 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1360,6 +1308,205 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.20.tgz",
+      "integrity": "sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.4",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/crypto/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.4.tgz",
+      "integrity": "sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.9.tgz",
+      "integrity": "sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/interface": "^3.2.4",
+        "@multiformats/multiaddr": "^13.0.3",
+        "interface-datastore": "^10.0.1",
+        "multiformats": "^14.0.0",
+        "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.11.tgz",
+      "integrity": "sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.20",
+        "@libp2p/interface": "^3.2.4",
+        "multiformats": "^14.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/peer-id/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
+      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1737,6 +1884,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2561,9 +2717,111 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@unicitylabs/nostr-js-sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
+      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/base": "^1.1.9",
+        "libphonenumber-js": "^1.11.14"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "resolved": "../sphere-sdk",
-      "link": true
+      "version": "0.9.2-dev.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.2-dev.0.tgz",
+      "integrity": "sha512-+Yejqo7O1rp+dKSyi8tdGQy8sxyGnHe0VtM98LUWcNdRXyx58f55vmqhgiIoAmf91dERKdkor5TXf2NBIpCCnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "2.2.0",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@unicitylabs/nostr-js-sdk": "^0.5.0",
+        "@unicitylabs/state-transition-sdk": "2.0.0-rc.6027e82",
+        "bip39": "^3.1.0",
+        "buffer": "^6.0.3",
+        "canonicalize": "^3.0.0",
+        "crypto-js": "^4.2.0",
+        "elliptic": "^6.6.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@libp2p/crypto": "^5.1.13",
+        "@libp2p/peer-id": "^6.0.4",
+        "ipns": "^10.0.0",
+        "multiformats": "^13.4.2"
+      },
+      "peerDependencies": {
+        "@libp2p/crypto": ">=5.0.0",
+        "@libp2p/peer-id": ">=6.0.0",
+        "ipns": ">=10.0.0",
+        "multiformats": ">=13.0.0",
+        "ws": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@libp2p/crypto": {
+          "optional": true
+        },
+        "@libp2p/peer-id": {
+          "optional": true
+        },
+        "ipns": {
+          "optional": true
+        },
+        "multiformats": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@unicitylabs/sphere-ui": {
       "version": "0.1.23",
@@ -2630,6 +2888,33 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
       "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
+    },
+    "node_modules/@unicitylabs/state-transition-sdk": {
+      "version": "2.0.0-rc.6027e82",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.6027e82.tgz",
+      "integrity": "sha512-PV6lHwJOCjpICG0Vd7Ty+5mZa7migGtopa1QVBjp9xRRtfNXDAvf8YPzXE6PQOtKCVP5ymmKuWKRKkNoNOw2zA==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "uuid": "14.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@unicitylabs/state-transition-sdk/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -2774,6 +3059,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2940,7 +3232,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2978,6 +3269,27 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/bn.js": {
@@ -3194,6 +3506,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -3288,6 +3624,28 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
+      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -4054,6 +4412,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -4433,6 +4798,13 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4509,7 +4881,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4568,6 +4939,96 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/interface-datastore": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-9.0.3.tgz",
+      "integrity": "sha512-NLZa7Mp+0qn48nSwIY/C36da4uVIKzwG2tuEIpaSJArsuB2RrdyDWwkoDUyjsJ+VrMntXz38VSk9vXTx/ZUpAw==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "interface-store": "^7.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-7.0.2.tgz",
+      "integrity": "sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
+    "node_modules/ipns": {
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.1.6.tgz",
+      "integrity": "sha512-mTACIdTBBXY5kbCo3t/M3ycNWbjajLrSXhTvjD0MEGyOUaI3uMv94JbJSHGaJ2xxRlpOrRk1ifToOsyPZiglnA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^3.0.2",
+        "@libp2p/logger": "^6.0.4",
+        "cborg": "^5.1.0",
+        "interface-datastore": "^9.0.2",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^6.0.1",
+        "timestamp-nano": "^1.0.1",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -4896,6 +5357,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
+      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
+      "license": "MIT"
+    },
     "node_modules/lightningcss": {
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
@@ -5218,6 +5685,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5307,6 +5781,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5549,6 +6030,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -5782,6 +6293,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5798,6 +6316,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/protons-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
+      }
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -6519,6 +7049,16 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6715,6 +7255,44 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays/node_modules/multiformats": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
+      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -6783,6 +7361,13 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -7011,6 +7596,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/weald": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.1.3.tgz",
+      "integrity": "sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^4.0.0-nightly.202508271359",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/weald/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -7114,7 +7733,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.2-dev.0",
+        "@unicitylabs/sphere-sdk": "0.9.2-dev.1",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2773,9 +2773,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.2-dev.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.2-dev.0.tgz",
-      "integrity": "sha512-+Yejqo7O1rp+dKSyi8tdGQy8sxyGnHe0VtM98LUWcNdRXyx58f55vmqhgiIoAmf91dERKdkor5TXf2NBIpCCnA==",
+      "version": "0.9.2-dev.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.2-dev.1.tgz",
+      "integrity": "sha512-bQYCCHvLSCLTPvrwGeXHON/LxYkRN6GiEtxcQ7G7ap+CLUZWPVL4bGRXJRVn/Z6C/22oFlA0WT7fvz2VF29qYA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.2-dev.0",
+    "@unicitylabs/sphere-sdk": "0.9.2-dev.1",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "^0.9.0-dev.0",
+    "@unicitylabs/sphere-sdk": "file:../sphere-sdk",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "file:../sphere-sdk",
+    "@unicitylabs/sphere-sdk": "0.9.2-dev.0",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import { useState } from 'react';
 import { Header } from './Header';
+import { OfflineBanner } from './OfflineBanner';
 import { MiniChatBubbles } from '../chat/mini';
 import { useUIState } from '../../hooks/useUIState';
 import { useDesktopState } from '../../hooks/useDesktopState';
@@ -58,6 +59,7 @@ export function DashboardLayout() {
       {/* Content — above background layers */}
       <div className="relative z-10 flex flex-col h-full">
         {!isFullscreen && <Header />}
+        {!isFullscreen && <OfflineBanner />}
         <div className={`flex-1 min-h-0 flex ${!isAgentPage ? 'overflow-y-auto overflow-x-hidden' : ''}`}>
           <div className={`flex-1 w-full ${isFullscreen ? 'p-0' : isAgentPage ? 'px-0 sm:px-12 lg:px-28 pb-0' : 'px-0 sm:px-12 lg:px-28 pt-4 pb-0 md:pt-8 lg:pb-8'} ${
             isMinePage ? 'bg-neutral-100 dark:bg-transparent' : ''

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,6 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 // import { ThemeToggle } from '../theme';
 import { STORAGE_KEYS } from '../../config/storageKeys';
-import { IpfsSyncIndicator } from './IpfsSyncIndicator';
 import { VaultSyncIndicator } from './VaultSyncIndicator';
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { DiscordIcon, XIcon } from '../icons/SocialIcons';
@@ -153,11 +152,9 @@ export function Header() {
                 </div>
               )}
 
-              {/* Desktop: sync indicators (IPFS + cloud Vault) */}
+              {/* Desktop: single cloud-Vault sync status (IPFS/Nostr toggles live in Settings → Vault). */}
               <div className="hidden lg:flex items-center gap-3">
-                <IpfsSyncIndicator />
                 <VaultSyncIndicator />
-                {/* <ThemeToggle /> */}
               </div>
             </div>
 
@@ -235,9 +232,8 @@ export function Header() {
               )
             ))}
 
-            {/* IPFS + Vault sync + Social links — mobile only */}
+            {/* Vault sync status + Social links — mobile only (IPFS/Nostr toggles in Settings → Vault) */}
             <div className="px-4 py-3 border-t border-neutral-200 dark:border-brand-orange-border mt-1 flex items-center">
-              <IpfsSyncIndicator />
               <VaultSyncIndicator />
               <div className="flex-1" />
               <div className="flex items-center gap-5">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 // import { ThemeToggle } from '../theme';
 import { STORAGE_KEYS } from '../../config/storageKeys';
 import { IpfsSyncIndicator } from './IpfsSyncIndicator';
+import { VaultSyncIndicator } from './VaultSyncIndicator';
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { DiscordIcon, XIcon } from '../icons/SocialIcons';
 
@@ -152,9 +153,10 @@ export function Header() {
                 </div>
               )}
 
-              {/* Desktop: IPFS sync indicator */}
+              {/* Desktop: sync indicators (IPFS + cloud Vault) */}
               <div className="hidden lg:flex items-center gap-3">
                 <IpfsSyncIndicator />
+                <VaultSyncIndicator />
                 {/* <ThemeToggle /> */}
               </div>
             </div>
@@ -233,9 +235,10 @@ export function Header() {
               )
             ))}
 
-            {/* IPFS sync + Social links — mobile only */}
+            {/* IPFS + Vault sync + Social links — mobile only */}
             <div className="px-4 py-3 border-t border-neutral-200 dark:border-brand-orange-border mt-1 flex items-center">
               <IpfsSyncIndicator />
+              <VaultSyncIndicator />
               <div className="flex-1" />
               <div className="flex items-center gap-5">
                 {[

--- a/src/components/layout/OfflineBanner.tsx
+++ b/src/components/layout/OfflineBanner.tsx
@@ -1,0 +1,23 @@
+import { WifiOff } from 'lucide-react';
+import { useSphereContext } from '../../sdk/hooks';
+
+/**
+ * A thin full-width banner shown when the Nostr peer transport is OFF (full-offline
+ * mode — toggled in Settings → Vault). It makes the degraded state explicit: the
+ * wallet works local-only, but peer send/receive and messaging are unavailable until
+ * Nostr is re-enabled. Renders nothing in the normal (online) case.
+ */
+export function OfflineBanner() {
+  const { nostrEnabled } = useSphereContext();
+  if (nostrEnabled) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-2 px-4 py-1.5 bg-amber-500/10 border-b border-amber-500/20 text-amber-700 dark:text-amber-300 text-xs font-medium">
+      <WifiOff className="w-3.5 h-3.5 shrink-0" />
+      <span className="text-center">
+        Offline mode — peer messaging &amp; delivery are off. Your tokens stay on this device.
+        Re-enable Nostr in Settings → Vault.
+      </span>
+    </div>
+  );
+}

--- a/src/components/layout/VaultSyncIndicator.tsx
+++ b/src/components/layout/VaultSyncIndicator.tsx
@@ -24,6 +24,29 @@ function getStatusText(enabled: boolean, status: string, lastSynced: number | nu
 }
 
 /**
+ * Map a raw vault sync error (an SDK reason code or a transport message) to a
+ * concrete human cause, so the header pill explains WHY rather than a bare
+ * "Sync failed" the user can't act on.
+ */
+function describeVaultError(raw: string | null): string {
+  const e = (raw ?? '').toLowerCase();
+  if (!e) return 'Vault sync failed';
+  if (e.includes('awaiting') || e.includes('initial-load') || e.includes('initial load'))
+    return 'Vault backup starting — finishing first sync';
+  if (e.includes('rollback') || e.includes('regress') || e.includes('baseline'))
+    return 'Vault state mismatch (rollback protection)';
+  if (
+    e.includes('econnrefused') || e.includes('failed to fetch') || e.includes('networkerror') ||
+    e.includes('network') || e.includes('fetch') || e.includes('timeout') || e.includes('timed out') ||
+    e.includes('econn') || e.includes('enotfound') || e.includes('503') || e.includes('502')
+  )
+    return "Can't reach vault — is the store online?";
+  if (e.includes('401') || e.includes('403') || e.includes('unauthor') || e.includes('auth'))
+    return 'Vault sign-in failed';
+  return `Vault sync failed: ${raw}`;
+}
+
+/**
  * VaultSyncIndicator — header status pill for the cloud Vault backup/sync.
  *
  * When the vault is ENABLED the pill is an ACTION: clicking it runs a sync — which
@@ -58,7 +81,7 @@ export function VaultSyncIndicator() {
     : isSyncing
       ? 'Syncing your vault…'
       : isError
-        ? `Vault sync failed${lastError ? `: ${lastError}` : ''} — click to retry`
+        ? `${describeVaultError(lastError)} — click to retry`
         : lastSynced
           ? `Vault synced ${formatLastSynced(lastSynced)} — click to sync now`
           : 'Cloud backup & sync (Vault) — click to sync now';

--- a/src/components/layout/VaultSyncIndicator.tsx
+++ b/src/components/layout/VaultSyncIndicator.tsx
@@ -1,0 +1,117 @@
+import { ShieldCheck, ShieldOff, Loader2, ShieldAlert } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useVaultSync } from '../../sdk/hooks';
+import { HeaderTooltip } from './HeaderTooltip';
+
+function formatLastSynced(ts: number | null): string {
+  if (!ts) return '';
+  const diffMs = Date.now() - ts;
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function getStatusText(
+  enabled: boolean,
+  status: string,
+  lastSynced: number | null,
+): string {
+  if (!enabled) return 'Vault off';
+  if (status === 'syncing') return 'Vault: syncing…';
+  if (status === 'error') return 'Vault: error';
+  if (lastSynced) return 'Vault: synced';
+  return 'Vault';
+}
+
+/**
+ * VaultSyncIndicator — header status pill for the cloud Vault backup/sync,
+ * mirroring IpfsSyncIndicator. Read-only (the Vault server choice lives in
+ * Settings → Vault); the tooltip points users there.
+ */
+export function VaultSyncIndicator() {
+  const { enabled, status, lastSynced, lastError } = useVaultSync();
+  const isSyncing = enabled && status === 'syncing';
+  const isError = enabled && status === 'error';
+  const statusText = getStatusText(enabled, status, lastSynced);
+
+  const iconClass = 'w-4 h-4 sm:w-5 sm:h-5';
+
+  const tooltip = !enabled
+    ? 'Cloud backup off — configure in Settings → Vault'
+    : isError
+      ? `Vault sync error${lastError ? `: ${lastError}` : ''}`
+      : lastSynced
+        ? `Vault synced ${formatLastSynced(lastSynced)}`
+        : 'Cloud backup & sync (Vault)';
+
+  return (
+    <HeaderTooltip label={tooltip}>
+      <span
+        className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl"
+      >
+        <AnimatePresence mode="wait">
+          {!enabled ? (
+            <motion.div
+              key="disabled"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.15 }}
+            >
+              <ShieldOff className={`${iconClass} text-neutral-400 dark:text-neutral-500`} />
+            </motion.div>
+          ) : isSyncing ? (
+            <motion.div
+              key="syncing"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.15 }}
+            >
+              <Loader2 className={`${iconClass} text-orange-500 animate-spin`} />
+            </motion.div>
+          ) : isError ? (
+            <motion.div
+              key="error"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.15 }}
+              className="relative"
+            >
+              <ShieldAlert className={`${iconClass} text-red-400 dark:text-red-500`} />
+              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="idle"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.15 }}
+            >
+              <ShieldCheck className={`${iconClass} ${
+                lastSynced
+                  ? 'text-green-500/70 dark:text-green-400/70'
+                  : 'text-neutral-400 dark:text-neutral-500'
+              }`} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <span className={`text-xs font-medium ${
+          !enabled ? 'text-neutral-400 dark:text-neutral-500' :
+          isError ? 'text-red-400 dark:text-red-500' :
+          isSyncing ? 'text-orange-500' :
+          lastSynced ? 'text-green-500/70 dark:text-green-400/70' :
+          'text-neutral-400 dark:text-neutral-500'
+        }`}>
+          {statusText}
+        </span>
+      </span>
+    </HeaderTooltip>
+  );
+}

--- a/src/components/layout/VaultSyncIndicator.tsx
+++ b/src/components/layout/VaultSyncIndicator.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback } from 'react';
 import { ShieldCheck, ShieldOff, Loader2, ShieldAlert } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useVaultSync } from '../../sdk/hooks';
@@ -14,104 +15,110 @@ function formatLastSynced(ts: number | null): string {
   return new Date(ts).toLocaleDateString();
 }
 
-function getStatusText(
-  enabled: boolean,
-  status: string,
-  lastSynced: number | null,
-): string {
+function getStatusText(enabled: boolean, status: string, lastSynced: number | null): string {
   if (!enabled) return 'Vault off';
-  if (status === 'syncing') return 'Vault: syncing…';
-  if (status === 'error') return 'Vault: error';
-  if (lastSynced) return 'Vault: synced';
-  return 'Vault';
+  if (status === 'syncing') return 'Syncing…';
+  if (status === 'error') return 'Retry sync';
+  if (lastSynced) return 'Synced';
+  return 'Sync now';
 }
 
 /**
- * VaultSyncIndicator — header status pill for the cloud Vault backup/sync,
- * mirroring IpfsSyncIndicator. Read-only (the Vault server choice lives in
- * Settings → Vault); the tooltip points users there.
+ * VaultSyncIndicator — header status pill for the cloud Vault backup/sync.
+ *
+ * When the vault is ENABLED the pill is an ACTION: clicking it runs a sync — which
+ * is the recovery path for an error (the old pill showed a dead "Vault: error" with
+ * no recourse). While the wallet is offline/degraded a sync error is expected; one
+ * tap retries. When the vault is OFF the pill is inert and the tooltip points to
+ * Settings → Vault.
  */
 export function VaultSyncIndicator() {
-  const { enabled, status, lastSynced, lastError } = useVaultSync();
-  const isSyncing = enabled && status === 'syncing';
-  const isError = enabled && status === 'error';
-  const statusText = getStatusText(enabled, status, lastSynced);
+  const { enabled, status, lastSynced, lastError, triggerSync } = useVaultSync();
+  const [retrying, setRetrying] = useState(false);
 
+  const isSyncing = enabled && (status === 'syncing' || retrying);
+  const isError = enabled && status === 'error' && !retrying;
+  const statusText = getStatusText(enabled, retrying ? 'syncing' : status, lastSynced);
   const iconClass = 'w-4 h-4 sm:w-5 sm:h-5';
+
+  const handleSync = useCallback(async () => {
+    if (!enabled || isSyncing) return;
+    setRetrying(true);
+    try {
+      await triggerSync();
+    } catch {
+      /* the error surfaces via the sync:provider event → status='error' */
+    } finally {
+      setRetrying(false);
+    }
+  }, [enabled, isSyncing, triggerSync]);
 
   const tooltip = !enabled
     ? 'Cloud backup off — configure in Settings → Vault'
-    : isError
-      ? `Vault sync error${lastError ? `: ${lastError}` : ''}`
-      : lastSynced
-        ? `Vault synced ${formatLastSynced(lastSynced)}`
-        : 'Cloud backup & sync (Vault)';
+    : isSyncing
+      ? 'Syncing your vault…'
+      : isError
+        ? `Vault sync failed${lastError ? `: ${lastError}` : ''} — click to retry`
+        : lastSynced
+          ? `Vault synced ${formatLastSynced(lastSynced)} — click to sync now`
+          : 'Cloud backup & sync (Vault) — click to sync now';
+
+  const icon = (
+    <AnimatePresence mode="wait">
+      {!enabled ? (
+        <motion.div key="disabled" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.15 }}>
+          <ShieldOff className={`${iconClass} text-neutral-400 dark:text-neutral-500`} />
+        </motion.div>
+      ) : isSyncing ? (
+        <motion.div key="syncing" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.15 }}>
+          <Loader2 className={`${iconClass} text-orange-500 animate-spin`} />
+        </motion.div>
+      ) : isError ? (
+        <motion.div key="error" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.15 }} className="relative">
+          <ShieldAlert className={`${iconClass} text-red-400 dark:text-red-500`} />
+          <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+        </motion.div>
+      ) : (
+        <motion.div key="idle" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.15 }}>
+          <ShieldCheck className={`${iconClass} ${lastSynced ? 'text-green-500/70 dark:text-green-400/70' : 'text-neutral-400 dark:text-neutral-500'}`} />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+
+  const label = (
+    <span className={`text-xs font-medium ${
+      !enabled ? 'text-neutral-400 dark:text-neutral-500' :
+      isError ? 'text-red-400 dark:text-red-500' :
+      isSyncing ? 'text-orange-500' :
+      lastSynced ? 'text-green-500/70 dark:text-green-400/70' :
+      'text-neutral-400 dark:text-neutral-500'
+    }`}>
+      {statusText}
+    </span>
+  );
+
+  const pillBase = 'relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl';
 
   return (
     <HeaderTooltip label={tooltip}>
-      <span
-        className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl"
-      >
-        <AnimatePresence mode="wait">
-          {!enabled ? (
-            <motion.div
-              key="disabled"
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.15 }}
-            >
-              <ShieldOff className={`${iconClass} text-neutral-400 dark:text-neutral-500`} />
-            </motion.div>
-          ) : isSyncing ? (
-            <motion.div
-              key="syncing"
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.15 }}
-            >
-              <Loader2 className={`${iconClass} text-orange-500 animate-spin`} />
-            </motion.div>
-          ) : isError ? (
-            <motion.div
-              key="error"
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.15 }}
-              className="relative"
-            >
-              <ShieldAlert className={`${iconClass} text-red-400 dark:text-red-500`} />
-              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
-            </motion.div>
-          ) : (
-            <motion.div
-              key="idle"
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.15 }}
-            >
-              <ShieldCheck className={`${iconClass} ${
-                lastSynced
-                  ? 'text-green-500/70 dark:text-green-400/70'
-                  : 'text-neutral-400 dark:text-neutral-500'
-              }`} />
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        <span className={`text-xs font-medium ${
-          !enabled ? 'text-neutral-400 dark:text-neutral-500' :
-          isError ? 'text-red-400 dark:text-red-500' :
-          isSyncing ? 'text-orange-500' :
-          lastSynced ? 'text-green-500/70 dark:text-green-400/70' :
-          'text-neutral-400 dark:text-neutral-500'
-        }`}>
-          {statusText}
+      {enabled ? (
+        <button
+          type="button"
+          onClick={handleSync}
+          disabled={isSyncing}
+          aria-label={tooltip}
+          className={`${pillBase} transition-colors hover:bg-neutral-100 dark:hover:bg-white/8 disabled:cursor-default`}
+        >
+          {icon}
+          {label}
+        </button>
+      ) : (
+        <span className={pillBase}>
+          {icon}
+          {label}
         </span>
-      </span>
+      )}
     </HeaderTooltip>
   );
 }

--- a/src/components/wallet/L3/modals/SendModal.tsx
+++ b/src/components/wallet/L3/modals/SendModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowRight, Loader2, User, CheckCircle, Coins, Hash, Copy, Check } from 'lucide-react';
+import { ArrowRight, Loader2, User, CheckCircle, Coins, Hash, Copy, Check, WifiOff } from 'lucide-react';
 import type { Asset } from '@unicitylabs/sphere-sdk';
 import { toSmallestUnit } from '@unicitylabs/sphere-sdk';
 import { useAssets, useTransfer, formatAmount } from '../../../../sdk';
@@ -29,7 +29,7 @@ interface SendModalProps {
 export function SendModal({ isOpen, onClose, prefill, asModal }: SendModalProps) {
   const { assets: sdkAssets } = useAssets();
   const { transfer, isLoading: isTransferring } = useTransfer();
-  const { sphere } = useSphereContext();
+  const { sphere, nostrEnabled } = useSphereContext();
 
   const assets = sdkAssets;
 
@@ -205,6 +205,16 @@ export function SendModal({ isOpen, onClose, prefill, asModal }: SendModalProps)
       <ModalHeader variant="screen" title={getTitle()} onClose={getBackHandler()} />
 
       <div className="px-6 py-8 flex-1 overflow-y-auto">
+        {/* Offline notice — peer send needs Nostr to resolve + deliver to the recipient. */}
+        {!nostrEnabled && step !== 'success' && step !== 'processing' && (
+          <div className="mb-4 flex items-start gap-2 px-3 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/20 text-amber-700 dark:text-amber-300 text-xs">
+            <WifiOff className="w-4 h-4 shrink-0 mt-px" />
+            <span>
+              Offline mode (Nostr off) — peer send needs the relay network to resolve the
+              recipient and deliver. Re-enable Nostr in Settings → Vault to send.
+            </span>
+          </div>
+        )}
         <AnimatePresence mode="wait">
 
           {/* 1. ASSET SELECTION */}

--- a/src/components/wallet/L3/modals/SettingsModal.tsx
+++ b/src/components/wallet/L3/modals/SettingsModal.tsx
@@ -1,10 +1,19 @@
 import { useState } from 'react';
-import { Settings, Layers, Download, LogOut, Key, AtSign, Link } from 'lucide-react';
+import { Settings, Layers, Download, LogOut, Key, AtSign, Link, Cloud } from 'lucide-react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, MenuButton } from '../../ui';
 import { LookupModal } from './LookupModal';
 import { AddressManagerModal } from './AddressManagerModal';
 import { ConnectedSitesModal } from './ConnectedSitesModal';
+import { VaultSettingsModal } from './VaultSettingsModal';
+import { getVaultStore, DEFAULT_VAULT_STORE } from '../../../../config/vaultStore';
+
+function vaultSubtitle(): string {
+  const setting = getVaultStore() ?? DEFAULT_VAULT_STORE;
+  if (setting.mode === 'off') return 'Off';
+  if (setting.mode === 'custom') return 'Custom server';
+  return 'Default (Unicity)';
+}
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -27,6 +36,7 @@ export function SettingsModal({
   const [isLookupOpen, setIsLookupOpen] = useState(false);
   const [isAddressManagerOpen, setIsAddressManagerOpen] = useState(false);
   const [isConnectedSitesOpen, setIsConnectedSitesOpen] = useState(false);
+  const [isVaultOpen, setIsVaultOpen] = useState(false);
 
   return (
     <>
@@ -73,6 +83,14 @@ export function SettingsModal({
           />
 
           <MenuButton
+            icon={Cloud}
+            color="blue"
+            label="Vault"
+            subtitle={vaultSubtitle()}
+            onClick={() => setIsVaultOpen(true)}
+          />
+
+          <MenuButton
             icon={Download}
             color="green"
             label="Backup Wallet"
@@ -110,6 +128,11 @@ export function SettingsModal({
       <ConnectedSitesModal
         isOpen={isConnectedSitesOpen}
         onClose={() => setIsConnectedSitesOpen(false)}
+      />
+
+      <VaultSettingsModal
+        isOpen={isVaultOpen}
+        onClose={() => setIsVaultOpen(false)}
       />
     </>
   );

--- a/src/components/wallet/L3/modals/VaultSettingsModal.tsx
+++ b/src/components/wallet/L3/modals/VaultSettingsModal.tsx
@@ -1,14 +1,16 @@
 import { useState, useEffect } from 'react';
-import { Cloud, Check } from 'lucide-react';
+import { Cloud, Check, Plus, Trash2, Server } from 'lucide-react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader } from '../../ui';
 import {
   getVaultStore,
   setVaultStore,
   isValidVaultUrl,
+  genStoreId,
+  hostLabel,
   DEFAULT_VAULT_STORE,
-  type VaultStoreMode,
   type VaultStoreSetting,
+  type CustomStore,
 } from '../../../../config/vaultStore';
 
 interface VaultSettingsModalProps {
@@ -16,48 +18,86 @@ interface VaultSettingsModalProps {
   onClose: () => void;
 }
 
-const OPTIONS: { mode: VaultStoreMode; title: string; description: string }[] = [
-  {
-    mode: 'default',
-    title: 'Default (Unicity)',
-    description: "Back up to Unicity's hosted token-api. Recommended.",
-  },
-  {
-    mode: 'custom',
-    title: 'Custom server',
-    description: 'Back up to your own token-api instance.',
-  },
-  {
-    mode: 'off',
-    title: 'Off',
-    description: 'No cloud backup — your tokens stay on this device only.',
-  },
-];
+/** Shared card chrome — a selectable option row (matches the wallet's radio-card style). */
+function selectableCardClass(selected: boolean): string {
+  return `w-full flex items-start gap-3 p-3.5 rounded-2xl border text-left transition-colors ${
+    selected
+      ? 'border-orange-500 bg-orange-500/5'
+      : 'border-neutral-200 dark:border-white/8 bg-neutral-50 dark:bg-white/4 hover:bg-neutral-100 dark:hover:bg-white/6'
+  }`;
+}
+
+function Radio({ selected }: { selected: boolean }) {
+  return (
+    <span
+      className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
+        selected ? 'border-orange-500 bg-orange-500' : 'border-neutral-300 dark:border-white/25'
+      }`}
+    >
+      {selected && <Check className="w-3 h-3 text-white" />}
+    </span>
+  );
+}
 
 export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps) {
-  const [mode, setMode] = useState<VaultStoreMode>('default');
-  const [customUrl, setCustomUrl] = useState('');
+  const [setting, setSetting] = useState<VaultStoreSetting>(DEFAULT_VAULT_STORE);
   const [saved, setSaved] = useState(false);
+  // Add-server inline form state.
+  const [addOpen, setAddOpen] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [newUrl, setNewUrl] = useState('');
 
   // Load the persisted setting whenever the modal opens.
   useEffect(() => {
     if (!isOpen) return;
-    const current = getVaultStore() ?? DEFAULT_VAULT_STORE;
-    setMode(current.mode);
-    setCustomUrl(current.customUrl ?? '');
+    setSetting(getVaultStore() ?? DEFAULT_VAULT_STORE);
     setSaved(false);
+    setAddOpen(false);
+    setNewLabel('');
+    setNewUrl('');
   }, [isOpen]);
 
-  const customUrlInvalid =
-    mode === 'custom' && customUrl.trim().length > 0 && !isValidVaultUrl(customUrl);
-  const canSave = mode !== 'custom' || isValidVaultUrl(customUrl);
+  const stores: CustomStore[] = setting.customStores ?? [];
+  const newUrlInvalid = newUrl.trim().length > 0 && !isValidVaultUrl(newUrl);
+  const canAdd = isValidVaultUrl(newUrl);
+
+  const selectDefault = () => setSetting((s) => ({ ...s, mode: 'default' }));
+  const selectOff = () => setSetting((s) => ({ ...s, mode: 'off' }));
+  const selectCustom = (id: string) => setSetting((s) => ({ ...s, mode: 'custom', activeCustomId: id }));
+
+  const addServer = () => {
+    if (!canAdd) return;
+    const url = newUrl.trim();
+    // Reuse an existing entry with the same URL instead of duplicating it.
+    const existing = stores.find((s) => s.url === url);
+    const id = existing?.id ?? genStoreId();
+    const next: CustomStore[] = existing
+      ? stores
+      : [...stores, { id, label: newLabel.trim() || hostLabel(url), url, addedAt: Date.now() }];
+    setSetting((s) => ({ ...s, mode: 'custom', activeCustomId: id, customStores: next }));
+    setAddOpen(false);
+    setNewLabel('');
+    setNewUrl('');
+  };
+
+  const removeServer = (id: string) => {
+    setSetting((s) => {
+      const next = (s.customStores ?? []).filter((x) => x.id !== id);
+      const wasActive = s.mode === 'custom' && s.activeCustomId === id;
+      return {
+        ...s,
+        customStores: next,
+        // If we removed the active store: pick another custom, else fall back to default.
+        ...(wasActive
+          ? next.length
+            ? { mode: 'custom' as const, activeCustomId: next[0].id }
+            : { mode: 'default' as const, activeCustomId: undefined }
+          : {}),
+      };
+    });
+  };
 
   const handleSave = () => {
-    if (!canSave) return;
-    const setting: VaultStoreSetting =
-      mode === 'custom'
-        ? { mode, customUrl: customUrl.trim() }
-        : { mode };
     setVaultStore(setting);
     setSaved(true);
     // Apply by reloading — the chosen server is wired into Sphere.init on boot.
@@ -66,94 +106,127 @@ export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps)
 
   return (
     <WalletScreen isOpen={isOpen} onClose={onClose}>
-      <ModalHeader
-        variant="screen"
-        title="Vault"
-        icon={Cloud}
-        iconVariant="neutral"
-        onClose={onClose}
-      />
+      <ModalHeader variant="screen" title="Vault" icon={Cloud} iconVariant="neutral" onClose={onClose} />
 
       <div className="overflow-y-auto flex-1 p-4 space-y-4">
         <p className="text-xs font-medium text-neutral-500 dark:text-white/45 uppercase tracking-wider">
           Cloud backup &amp; sync (Vault)
         </p>
 
-        {/* Options */}
         <div className="space-y-2">
-          {OPTIONS.map((opt) => {
-            const selected = mode === opt.mode;
+          {/* Default (Unicity) */}
+          <button onClick={selectDefault} className={selectableCardClass(setting.mode === 'default')}>
+            <Radio selected={setting.mode === 'default'} />
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-semibold text-neutral-900 dark:text-white">Default (Unicity)</span>
+              <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">
+                Back up to Unicity&apos;s hosted token-api. Recommended.
+              </span>
+            </span>
+          </button>
+
+          {/* Saved custom servers */}
+          {stores.map((s) => {
+            const selected = setting.mode === 'custom' && setting.activeCustomId === s.id;
             return (
-              <button
-                key={opt.mode}
-                onClick={() => setMode(opt.mode)}
-                className={`w-full flex items-start gap-3 p-3.5 rounded-2xl border text-left transition-colors ${
-                  selected
-                    ? 'border-orange-500 bg-orange-500/5'
-                    : 'border-neutral-200 dark:border-white/8 bg-neutral-50 dark:bg-white/4 hover:bg-neutral-100 dark:hover:bg-white/6'
-                }`}
-              >
-                <span
-                  className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
-                    selected
-                      ? 'border-orange-500 bg-orange-500'
-                      : 'border-neutral-300 dark:border-white/25'
-                  }`}
+              <div key={s.id} className={selectableCardClass(selected)}>
+                <button onClick={() => selectCustom(s.id)} className="flex items-start gap-3 flex-1 min-w-0 text-left">
+                  <Radio selected={selected} />
+                  <span className="flex-1 min-w-0">
+                    <span className="flex items-center gap-1.5 text-sm font-semibold text-neutral-900 dark:text-white">
+                      <Server className="w-3.5 h-3.5 shrink-0 opacity-60" />
+                      <span className="truncate">{s.label}</span>
+                    </span>
+                    <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5 truncate font-mono">
+                      {s.url}
+                    </span>
+                  </span>
+                </button>
+                <button
+                  onClick={() => removeServer(s.id)}
+                  aria-label={`Remove ${s.label}`}
+                  className="shrink-0 p-1.5 -m-1 rounded-lg text-neutral-400 hover:text-red-500 hover:bg-red-500/10 transition-colors"
                 >
-                  {selected && <Check className="w-3 h-3 text-white" />}
-                </span>
-                <span className="flex-1 min-w-0">
-                  <span className="block text-sm font-semibold text-neutral-900 dark:text-white">
-                    {opt.title}
-                  </span>
-                  <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">
-                    {opt.description}
-                  </span>
-                </span>
-              </button>
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
             );
           })}
-        </div>
 
-        {/* Custom URL field */}
-        {mode === 'custom' && (
-          <div className="space-y-1.5">
-            <label className="text-xs font-medium text-neutral-500 dark:text-white/45">
-              Your token-api URL
-            </label>
-            <input
-              type="url"
-              inputMode="url"
-              autoComplete="off"
-              spellCheck={false}
-              value={customUrl}
-              onChange={(e) => setCustomUrl(e.target.value)}
-              placeholder="https://your-token-api.example"
-              className={`w-full px-3 py-2.5 text-sm font-mono bg-neutral-100 dark:bg-white/4 text-neutral-900 dark:text-white placeholder-neutral-400 rounded-xl border focus:outline-none transition-colors ${
-                customUrlInvalid
-                  ? 'border-red-400 focus:border-red-500'
-                  : 'border-neutral-200 dark:border-white/8 focus:border-orange-500'
-              }`}
-            />
-            {customUrlInvalid && (
-              <p className="text-xs text-red-500 dark:text-red-400">
-                Enter a valid http(s) URL.
-              </p>
-            )}
-          </div>
-        )}
+          {/* Add server (inline form) */}
+          {addOpen ? (
+            <div className="p-3.5 rounded-2xl border border-neutral-200 dark:border-white/8 bg-neutral-50 dark:bg-white/4 space-y-2">
+              <input
+                type="text"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="Name (optional)"
+                className="w-full px-3 py-2 text-sm bg-neutral-100 dark:bg-white/4 text-neutral-900 dark:text-white placeholder-neutral-400 rounded-xl border border-neutral-200 dark:border-white/8 focus:outline-none focus:border-orange-500 transition-colors"
+              />
+              <input
+                type="url"
+                inputMode="url"
+                autoComplete="off"
+                spellCheck={false}
+                value={newUrl}
+                onChange={(e) => setNewUrl(e.target.value)}
+                placeholder="https://your-token-api.example"
+                className={`w-full px-3 py-2 text-sm font-mono bg-neutral-100 dark:bg-white/4 text-neutral-900 dark:text-white placeholder-neutral-400 rounded-xl border focus:outline-none transition-colors ${
+                  newUrlInvalid
+                    ? 'border-red-400 focus:border-red-500'
+                    : 'border-neutral-200 dark:border-white/8 focus:border-orange-500'
+                }`}
+              />
+              {newUrlInvalid && <p className="text-xs text-red-500 dark:text-red-400">Enter a valid http(s) URL.</p>}
+              <div className="flex gap-2 pt-0.5">
+                <button
+                  onClick={addServer}
+                  disabled={!canAdd}
+                  className="flex-1 px-3 py-2 rounded-xl bg-orange-500 text-white text-sm font-semibold disabled:opacity-50 hover:bg-orange-600 transition-colors"
+                >
+                  Add server
+                </button>
+                <button
+                  onClick={() => { setAddOpen(false); setNewLabel(''); setNewUrl(''); }}
+                  className="px-3 py-2 rounded-xl bg-neutral-100 dark:bg-white/6 text-neutral-700 dark:text-white/70 text-sm font-medium hover:bg-neutral-200 dark:hover:bg-white/10 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setAddOpen(true)}
+              className="w-full flex items-center gap-2 p-3.5 rounded-2xl border border-dashed border-neutral-300 dark:border-white/15 text-sm font-medium text-neutral-600 dark:text-white/60 hover:border-orange-500 hover:text-orange-500 transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              Add your own token-api server
+            </button>
+          )}
+
+          {/* Off */}
+          <button onClick={selectOff} className={selectableCardClass(setting.mode === 'off')}>
+            <Radio selected={setting.mode === 'off'} />
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-semibold text-neutral-900 dark:text-white">Off</span>
+              <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">
+                No cloud backup — your tokens stay on this device only.
+              </span>
+            </span>
+          </button>
+        </div>
 
         {/* Helper / privacy note */}
         <p className="text-xs text-neutral-500 dark:text-white/45 leading-relaxed">
-          Your tokens are end-to-end encrypted; the server only stores ciphertext.
-          &ldquo;Custom&rdquo; points at your own token-api instance. The same server
-          handles backup and token delivery. Changes apply on reload.
+          Your tokens are end-to-end encrypted; the server only stores ciphertext. Add your own
+          token-api servers and switch between them — one is active at a time. The active server
+          handles both backup and token delivery. Changes apply on reload.
         </p>
 
         {/* Save */}
         <button
           onClick={handleSave}
-          disabled={!canSave || saved}
+          disabled={saved}
           className="w-full px-4 py-3 rounded-xl bg-orange-500 text-white text-sm font-semibold disabled:opacity-50 hover:bg-orange-600 transition-colors"
         >
           {saved ? 'Saved — reloading…' : 'Save'}

--- a/src/components/wallet/L3/modals/VaultSettingsModal.tsx
+++ b/src/components/wallet/L3/modals/VaultSettingsModal.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { Cloud, Check, Plus, Trash2, Server } from 'lucide-react';
+import { Cloud, Check, Plus, Trash2, Server, Database, Radio } from 'lucide-react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader } from '../../ui';
+import { useSphereContext } from '../../../../sdk/hooks';
 import {
   getVaultStore,
   setVaultStore,
@@ -27,7 +28,7 @@ function selectableCardClass(selected: boolean): string {
   }`;
 }
 
-function Radio({ selected }: { selected: boolean }) {
+function RadioDot({ selected }: { selected: boolean }) {
   return (
     <span
       className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
@@ -39,7 +40,49 @@ function Radio({ selected }: { selected: boolean }) {
   );
 }
 
+/** A labelled on/off toggle row for a provider (IPFS / Nostr). */
+function ToggleRow({
+  icon: Icon,
+  title,
+  description,
+  on,
+  onToggle,
+}: {
+  icon: typeof Database;
+  title: string;
+  description: string;
+  on: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 p-3.5 rounded-2xl border border-neutral-200 dark:border-white/8 bg-neutral-50 dark:bg-white/4">
+      <Icon className={`w-4 h-4 shrink-0 ${on ? 'text-orange-500' : 'text-neutral-400 dark:text-white/35'}`} />
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-semibold text-neutral-900 dark:text-white">{title}</span>
+        <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">{description}</span>
+      </span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-label={title}
+        onClick={onToggle}
+        className={`relative w-10 h-6 rounded-full shrink-0 transition-colors ${
+          on ? 'bg-orange-500' : 'bg-neutral-300 dark:bg-white/15'
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${
+            on ? 'translate-x-4' : 'translate-x-0'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
 export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps) {
+  const { ipfsEnabled, toggleIpfs, nostrEnabled, toggleNostr } = useSphereContext();
   const [setting, setSetting] = useState<VaultStoreSetting>(DEFAULT_VAULT_STORE);
   const [saved, setSaved] = useState(false);
   // Add-server inline form state.
@@ -116,7 +159,7 @@ export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps)
         <div className="space-y-2">
           {/* Default (Unicity) */}
           <button onClick={selectDefault} className={selectableCardClass(setting.mode === 'default')}>
-            <Radio selected={setting.mode === 'default'} />
+            <RadioDot selected={setting.mode === 'default'} />
             <span className="flex-1 min-w-0">
               <span className="block text-sm font-semibold text-neutral-900 dark:text-white">Default (Unicity)</span>
               <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">
@@ -131,7 +174,7 @@ export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps)
             return (
               <div key={s.id} className={selectableCardClass(selected)}>
                 <button onClick={() => selectCustom(s.id)} className="flex items-start gap-3 flex-1 min-w-0 text-left">
-                  <Radio selected={selected} />
+                  <RadioDot selected={selected} />
                   <span className="flex-1 min-w-0">
                     <span className="flex items-center gap-1.5 text-sm font-semibold text-neutral-900 dark:text-white">
                       <Server className="w-3.5 h-3.5 shrink-0 opacity-60" />
@@ -206,7 +249,7 @@ export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps)
 
           {/* Off */}
           <button onClick={selectOff} className={selectableCardClass(setting.mode === 'off')}>
-            <Radio selected={setting.mode === 'off'} />
+            <RadioDot selected={setting.mode === 'off'} />
             <span className="flex-1 min-w-0">
               <span className="block text-sm font-semibold text-neutral-900 dark:text-white">Off</span>
               <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">
@@ -222,6 +265,27 @@ export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps)
           token-api servers and switch between them — one is active at a time. The active server
           handles both backup and token delivery. Changes apply on reload.
         </p>
+
+        {/* Other sync & delivery providers — instant toggles (no reload). */}
+        <p className="text-xs font-medium text-neutral-500 dark:text-white/45 uppercase tracking-wider pt-1">
+          Sync &amp; delivery
+        </p>
+        <div className="space-y-2">
+          <ToggleRow
+            icon={Database}
+            title="IPFS backup"
+            description="Decentralized, end-to-end-encrypted backup of your tokens."
+            on={ipfsEnabled}
+            onToggle={toggleIpfs}
+          />
+          <ToggleRow
+            icon={Radio}
+            title="Peer messaging & delivery (Nostr)"
+            description="Relays for DMs and token send/receive. Off = offline mode (local only)."
+            on={nostrEnabled}
+            onToggle={toggleNostr}
+          />
+        </div>
 
         {/* Save */}
         <button

--- a/src/components/wallet/L3/modals/VaultSettingsModal.tsx
+++ b/src/components/wallet/L3/modals/VaultSettingsModal.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from 'react';
+import { Cloud, Check } from 'lucide-react';
+import { WalletScreen } from '../../ui/WalletScreen';
+import { ModalHeader } from '../../ui';
+import {
+  getVaultStore,
+  setVaultStore,
+  isValidVaultUrl,
+  DEFAULT_VAULT_STORE,
+  type VaultStoreMode,
+  type VaultStoreSetting,
+} from '../../../../config/vaultStore';
+
+interface VaultSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const OPTIONS: { mode: VaultStoreMode; title: string; description: string }[] = [
+  {
+    mode: 'default',
+    title: 'Default (Unicity)',
+    description: "Back up to Unicity's hosted token-api. Recommended.",
+  },
+  {
+    mode: 'custom',
+    title: 'Custom server',
+    description: 'Back up to your own token-api instance.',
+  },
+  {
+    mode: 'off',
+    title: 'Off',
+    description: 'No cloud backup — your tokens stay on this device only.',
+  },
+];
+
+export function VaultSettingsModal({ isOpen, onClose }: VaultSettingsModalProps) {
+  const [mode, setMode] = useState<VaultStoreMode>('default');
+  const [customUrl, setCustomUrl] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  // Load the persisted setting whenever the modal opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    const current = getVaultStore() ?? DEFAULT_VAULT_STORE;
+    setMode(current.mode);
+    setCustomUrl(current.customUrl ?? '');
+    setSaved(false);
+  }, [isOpen]);
+
+  const customUrlInvalid =
+    mode === 'custom' && customUrl.trim().length > 0 && !isValidVaultUrl(customUrl);
+  const canSave = mode !== 'custom' || isValidVaultUrl(customUrl);
+
+  const handleSave = () => {
+    if (!canSave) return;
+    const setting: VaultStoreSetting =
+      mode === 'custom'
+        ? { mode, customUrl: customUrl.trim() }
+        : { mode };
+    setVaultStore(setting);
+    setSaved(true);
+    // Apply by reloading — the chosen server is wired into Sphere.init on boot.
+    setTimeout(() => window.location.reload(), 400);
+  };
+
+  return (
+    <WalletScreen isOpen={isOpen} onClose={onClose}>
+      <ModalHeader
+        variant="screen"
+        title="Vault"
+        icon={Cloud}
+        iconVariant="neutral"
+        onClose={onClose}
+      />
+
+      <div className="overflow-y-auto flex-1 p-4 space-y-4">
+        <p className="text-xs font-medium text-neutral-500 dark:text-white/45 uppercase tracking-wider">
+          Cloud backup &amp; sync (Vault)
+        </p>
+
+        {/* Options */}
+        <div className="space-y-2">
+          {OPTIONS.map((opt) => {
+            const selected = mode === opt.mode;
+            return (
+              <button
+                key={opt.mode}
+                onClick={() => setMode(opt.mode)}
+                className={`w-full flex items-start gap-3 p-3.5 rounded-2xl border text-left transition-colors ${
+                  selected
+                    ? 'border-orange-500 bg-orange-500/5'
+                    : 'border-neutral-200 dark:border-white/8 bg-neutral-50 dark:bg-white/4 hover:bg-neutral-100 dark:hover:bg-white/6'
+                }`}
+              >
+                <span
+                  className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
+                    selected
+                      ? 'border-orange-500 bg-orange-500'
+                      : 'border-neutral-300 dark:border-white/25'
+                  }`}
+                >
+                  {selected && <Check className="w-3 h-3 text-white" />}
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block text-sm font-semibold text-neutral-900 dark:text-white">
+                    {opt.title}
+                  </span>
+                  <span className="block text-xs text-neutral-500 dark:text-white/45 mt-0.5">
+                    {opt.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Custom URL field */}
+        {mode === 'custom' && (
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-neutral-500 dark:text-white/45">
+              Your token-api URL
+            </label>
+            <input
+              type="url"
+              inputMode="url"
+              autoComplete="off"
+              spellCheck={false}
+              value={customUrl}
+              onChange={(e) => setCustomUrl(e.target.value)}
+              placeholder="https://your-token-api.example"
+              className={`w-full px-3 py-2.5 text-sm font-mono bg-neutral-100 dark:bg-white/4 text-neutral-900 dark:text-white placeholder-neutral-400 rounded-xl border focus:outline-none transition-colors ${
+                customUrlInvalid
+                  ? 'border-red-400 focus:border-red-500'
+                  : 'border-neutral-200 dark:border-white/8 focus:border-orange-500'
+              }`}
+            />
+            {customUrlInvalid && (
+              <p className="text-xs text-red-500 dark:text-red-400">
+                Enter a valid http(s) URL.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Helper / privacy note */}
+        <p className="text-xs text-neutral-500 dark:text-white/45 leading-relaxed">
+          Your tokens are end-to-end encrypted; the server only stores ciphertext.
+          &ldquo;Custom&rdquo; points at your own token-api instance. The same server
+          handles backup and token delivery. Changes apply on reload.
+        </p>
+
+        {/* Save */}
+        <button
+          onClick={handleSave}
+          disabled={!canSave || saved}
+          className="w-full px-4 py-3 rounded-xl bg-orange-500 text-white text-sm font-semibold disabled:opacity-50 hover:bg-orange-600 transition-colors"
+        >
+          {saved ? 'Saved — reloading…' : 'Save'}
+        </button>
+      </div>
+    </WalletScreen>
+  );
+}

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -25,6 +25,10 @@ export const STORAGE_KEYS = {
   // IPFS
   IPFS_ENABLED: 'sphere_ipfs_enabled',
 
+  // Cloud backup & sync (token-api Vault + courier). Holds a JSON
+  // VaultStoreSetting ({ mode, customUrl? }) — see config/vaultStore.ts.
+  VAULT_STORE: 'sphere_vault_store',
+
   // Desktop state (open tabs, active tab)
   DESKTOP_STATE: 'sphere_desktop_state',
 

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -29,6 +29,12 @@ export const STORAGE_KEYS = {
   // VaultStoreSetting ({ mode, customUrl? }) — see config/vaultStore.ts.
   VAULT_STORE: 'sphere_vault_store',
 
+  // Stable per-browser device id for the vault auth session. token-api keys ONE
+  // session per (ownerId, deviceId); without a distinct id every browser used the
+  // SDK default 'sphere-vault', so a 2nd browser's login rotated the 1st's session
+  // and its next /v1/auth/refresh got 401. A persisted UUID = one session/browser.
+  VAULT_DEVICE_ID: 'sphere_vault_device_id',
+
   // Desktop state (open tabs, active tab)
   DESKTOP_STATE: 'sphere_desktop_state',
 

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -25,6 +25,10 @@ export const STORAGE_KEYS = {
   // IPFS
   IPFS_ENABLED: 'sphere_ipfs_enabled',
 
+  // Nostr peer transport (messaging + token delivery). 'false' = full-offline mode
+  // (the wallet boots local-only; peer send/receive unavailable until re-enabled).
+  NOSTR_ENABLED: 'sphere_nostr_enabled',
+
   // Cloud backup & sync (token-api Vault + courier). Holds a JSON
   // VaultStoreSetting ({ mode, customUrl? }) — see config/vaultStore.ts.
   VAULT_STORE: 'sphere_vault_store',

--- a/src/config/vaultStore.ts
+++ b/src/config/vaultStore.ts
@@ -1,0 +1,68 @@
+/**
+ * Vault store setting — which token-api server (if any) the wallet uses for
+ * cloud backup & sync.
+ *
+ * The Vault is durable, operator-blind (AEAD-ciphertext-only) multi-device
+ * backup/sync of the user's OWN tokens. It sits ON TOP of the local IndexedDB
+ * working copy — it is NOT a "pick one of N stores". The user choice here is
+ * only which vault SERVER (and whether to use one at all). The courier delivery
+ * channel shares the SAME server URL, so a single choice covers vault + courier.
+ *
+ *  - `default` — Unicity's company token-api (the per-network default URL,
+ *    `NETWORKS[network].vaultUrl`). ON by default.
+ *  - `custom`  — the user's own token-api instance (they enter its http(s) URL).
+ *  - `off`     — no cloud backup; local-only (today's behavior).
+ *
+ * Persisted as JSON under STORAGE_KEYS.VAULT_STORE. When no setting has been
+ * saved yet, callers fall back to the env flags (VITE_VAULT_ENABLED etc.) so a
+ * fresh wallet still respects a build-time opt-in.
+ */
+import { STORAGE_KEYS } from './storageKeys';
+
+export type VaultStoreMode = 'default' | 'custom' | 'off';
+
+export interface VaultStoreSetting {
+  mode: VaultStoreMode;
+  /** Only meaningful when mode === 'custom'. The user's own token-api base URL. */
+  customUrl?: string;
+}
+
+export const DEFAULT_VAULT_STORE: VaultStoreSetting = { mode: 'default' };
+
+/** True when the string is a syntactically valid http(s) URL. */
+export function isValidVaultUrl(url: string | undefined | null): url is string {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the persisted vault-store setting. Returns `null` (not the default) when
+ * nothing has ever been saved, so callers can distinguish "user has not chosen"
+ * (→ fall back to env flags) from "user chose default".
+ */
+export function getVaultStore(): VaultStoreSetting | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.VAULT_STORE);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<VaultStoreSetting>;
+    if (parsed.mode === 'default' || parsed.mode === 'custom' || parsed.mode === 'off') {
+      return {
+        mode: parsed.mode,
+        ...(typeof parsed.customUrl === 'string' ? { customUrl: parsed.customUrl } : {}),
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the vault-store setting. */
+export function setVaultStore(setting: VaultStoreSetting): void {
+  localStorage.setItem(STORAGE_KEYS.VAULT_STORE, JSON.stringify(setting));
+}

--- a/src/config/vaultStore.ts
+++ b/src/config/vaultStore.ts
@@ -66,3 +66,23 @@ export function getVaultStore(): VaultStoreSetting | null {
 export function setVaultStore(setting: VaultStoreSetting): void {
   localStorage.setItem(STORAGE_KEYS.VAULT_STORE, JSON.stringify(setting));
 }
+
+/**
+ * A stable, per-browser device id for the vault auth session. token-api keys ONE
+ * session per (ownerId, deviceId); without a distinct id every browser used the
+ * SDK default 'sphere-vault', so a second browser's login rotated the first's
+ * session and its next /v1/auth/refresh got a 401. A persisted random UUID gives
+ * each browser its own session (so multiple devices can stay authed at once).
+ */
+export function getVaultDeviceId(): string {
+  try {
+    let id = localStorage.getItem(STORAGE_KEYS.VAULT_DEVICE_ID);
+    if (!id) {
+      id = crypto?.randomUUID?.() ?? `dev-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      localStorage.setItem(STORAGE_KEYS.VAULT_DEVICE_ID, id);
+    }
+    return id;
+  } catch {
+    return 'sphere-vault';
+  }
+}

--- a/src/config/vaultStore.ts
+++ b/src/config/vaultStore.ts
@@ -1,29 +1,47 @@
 /**
  * Vault store setting — which token-api server (if any) the wallet uses for
- * cloud backup & sync.
+ * cloud backup & sync, and the user's saved list of custom servers.
  *
  * The Vault is durable, operator-blind (AEAD-ciphertext-only) multi-device
  * backup/sync of the user's OWN tokens. It sits ON TOP of the local IndexedDB
- * working copy — it is NOT a "pick one of N stores". The user choice here is
- * only which vault SERVER (and whether to use one at all). The courier delivery
- * channel shares the SAME server URL, so a single choice covers vault + courier.
+ * working copy. ONE server is active at a time; the courier delivery channel
+ * shares the SAME server URL, so a single active choice covers vault + courier.
  *
  *  - `default` — Unicity's company token-api (the per-network default URL,
  *    `NETWORKS[network].vaultUrl`). ON by default.
- *  - `custom`  — the user's own token-api instance (they enter its http(s) URL).
+ *  - `custom`  — one of the user's saved `customStores`, selected by
+ *    `activeCustomId`. The user can keep SEVERAL custom token-api servers and
+ *    switch between them (one active at a time).
  *  - `off`     — no cloud backup; local-only (today's behavior).
  *
  * Persisted as JSON under STORAGE_KEYS.VAULT_STORE. When no setting has been
  * saved yet, callers fall back to the env flags (VITE_VAULT_ENABLED etc.) so a
- * fresh wallet still respects a build-time opt-in.
+ * fresh wallet still respects a build-time opt-in. A legacy single-URL setting
+ * (`{ mode:'custom', customUrl }`) is migrated into `customStores` on read.
  */
 import { STORAGE_KEYS } from './storageKeys';
 
 export type VaultStoreMode = 'default' | 'custom' | 'off';
 
+/** A saved custom token-api server the user can switch to. */
+export interface CustomStore {
+  /** Stable id (selection key; survives label/url edits). */
+  id: string;
+  /** User-friendly name (defaults to the host). */
+  label: string;
+  /** token-api base URL (http/https). */
+  url: string;
+  /** Unix ms when added (display only). */
+  addedAt: number;
+}
+
 export interface VaultStoreSetting {
   mode: VaultStoreMode;
-  /** Only meaningful when mode === 'custom'. The user's own token-api base URL. */
+  /** When mode === 'custom', the id of the active store in `customStores`. */
+  activeCustomId?: string;
+  /** Saved custom token-api servers (the user can keep several and switch). */
+  customStores?: CustomStore[];
+  /** @deprecated legacy single custom URL; migrated into `customStores` on read. */
   customUrl?: string;
 }
 
@@ -40,31 +58,100 @@ export function isValidVaultUrl(url: string | undefined | null): url is string {
   }
 }
 
+/** A stable id for a new custom store (uuid, with a non-crypto fallback). */
+export function genStoreId(): string {
+  try {
+    return crypto?.randomUUID?.() ?? `store-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  } catch {
+    return `store-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+/** A friendly default label derived from a URL's host (falls back to the raw url). */
+export function hostLabel(url: string): string {
+  try {
+    return new URL(url.trim()).host || url.trim();
+  } catch {
+    return url.trim();
+  }
+}
+
+function isCustomStore(v: unknown): v is CustomStore {
+  if (!v || typeof v !== 'object') return false;
+  const s = v as Partial<CustomStore>;
+  return typeof s.id === 'string' && typeof s.url === 'string' && isValidVaultUrl(s.url);
+}
+
+/**
+ * Normalize a parsed setting: validate the custom-store list, migrate a legacy
+ * single `customUrl` into the list, and pick a sane `activeCustomId`. Pure — no
+ * persistence; callers that want to lock in a migration should `setVaultStore`.
+ */
+function normalize(parsed: Partial<VaultStoreSetting>): VaultStoreSetting {
+  const stores: CustomStore[] = Array.isArray(parsed.customStores)
+    ? parsed.customStores.filter(isCustomStore).map((s) => ({
+        id: s.id,
+        label: typeof s.label === 'string' && s.label.trim() ? s.label.trim() : hostLabel(s.url),
+        url: s.url.trim(),
+        addedAt: typeof s.addedAt === 'number' ? s.addedAt : Date.now(),
+      }))
+    : [];
+
+  // Migrate a legacy single customUrl into the list (dedup by url).
+  if (isValidVaultUrl(parsed.customUrl) && !stores.some((s) => s.url === parsed.customUrl!.trim())) {
+    stores.unshift({
+      id: genStoreId(),
+      label: hostLabel(parsed.customUrl),
+      url: parsed.customUrl.trim(),
+      addedAt: Date.now(),
+    });
+  }
+
+  // Active id: keep if it still resolves, else first store.
+  let activeCustomId = parsed.activeCustomId;
+  if (!activeCustomId || !stores.some((s) => s.id === activeCustomId)) {
+    activeCustomId = stores[0]?.id;
+  }
+
+  const setting: VaultStoreSetting = { mode: parsed.mode as VaultStoreMode };
+  if (stores.length) setting.customStores = stores;
+  if (activeCustomId) setting.activeCustomId = activeCustomId;
+  return setting;
+}
+
 /**
  * Read the persisted vault-store setting. Returns `null` (not the default) when
  * nothing has ever been saved, so callers can distinguish "user has not chosen"
- * (→ fall back to env flags) from "user chose default".
+ * (→ fall back to env flags) from "user chose default". A legacy `customUrl`
+ * setting is migrated into `customStores` on read.
  */
 export function getVaultStore(): VaultStoreSetting | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEYS.VAULT_STORE);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<VaultStoreSetting>;
-    if (parsed.mode === 'default' || parsed.mode === 'custom' || parsed.mode === 'off') {
-      return {
-        mode: parsed.mode,
-        ...(typeof parsed.customUrl === 'string' ? { customUrl: parsed.customUrl } : {}),
-      };
-    }
-    return null;
+    if (parsed.mode !== 'default' && parsed.mode !== 'custom' && parsed.mode !== 'off') return null;
+    return normalize(parsed);
   } catch {
     return null;
   }
 }
 
-/** Persist the vault-store setting. */
+/** Persist the vault-store setting (normalized — drops the legacy customUrl). */
 export function setVaultStore(setting: VaultStoreSetting): void {
-  localStorage.setItem(STORAGE_KEYS.VAULT_STORE, JSON.stringify(setting));
+  localStorage.setItem(STORAGE_KEYS.VAULT_STORE, JSON.stringify(normalize(setting)));
+}
+
+/**
+ * The URL of the active custom store (mode === 'custom'), or `undefined` when not
+ * in custom mode / no valid active store. The resolver SphereProvider uses to
+ * wire vault + courier for a custom server.
+ */
+export function getActiveCustomUrl(setting: VaultStoreSetting): string | undefined {
+  if (setting.mode !== 'custom') return undefined;
+  const stores = setting.customStores ?? [];
+  const active = stores.find((s) => s.id === setting.activeCustomId) ?? stores[0];
+  return active && isValidVaultUrl(active.url) ? active.url.trim() : undefined;
 }
 
 /**

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -36,6 +36,13 @@ export interface SphereContextValue {
   ipfsEnabled: boolean;
   /** Toggle IPFS sync on/off (persists to localStorage, triggers reinitialize) */
   toggleIpfs: () => void;
+
+  /** Whether the Nostr peer transport (messaging + delivery) is currently enabled.
+   *  When false the wallet is in full-offline mode (local-only). */
+  nostrEnabled: boolean;
+  /** Toggle the Nostr transport on/off (persists; disables/enables the provider at
+   *  runtime — no reload). Off = offline mode; on = reconnects to relays. */
+  toggleNostr: () => void;
 }
 
 export interface CreateWalletOptions {

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -56,6 +56,14 @@ function isIpfsEnabled(): boolean {
   return stored !== 'false'; // enabled by default
 }
 
+/** The Nostr transport provider id (NostrTransportProvider.id). */
+const NOSTR_PROVIDER_ID = 'nostr';
+
+function isNostrEnabled(): boolean {
+  const stored = localStorage.getItem(STORAGE_KEYS.NOSTR_ENABLED);
+  return stored !== 'false'; // enabled by default
+}
+
 function getIpfsConfig() {
   if (!isIpfsEnabled()) return {};
   return {
@@ -214,6 +222,7 @@ export function SphereProvider({
   const [walletExists, setWalletExists] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [ipfsEnabled, setIpfsEnabled] = useState(isIpfsEnabled);
+  const [nostrEnabled, setNostrEnabled] = useState(isNostrEnabled);
   const [isDiscoveringAddresses, setIsDiscoveringAddresses] = useState(false);
   const [initProgress, setInitProgress] = useState<InitProgress | null>(null);
   const sphereRef = useRef<Sphere | null>(null);
@@ -545,6 +554,29 @@ export function SphereProvider({
     initialize();
   }, [initialize]);
 
+  // Toggle the Nostr peer transport (messaging + delivery) at runtime — no reload.
+  // OFF = full-offline mode: disableProvider disconnects the relay transport so the
+  // wallet runs local-only (peer send/receive unavailable); ON reconnects. The setting
+  // is persisted and re-applied on boot (see the effect below).
+  const toggleNostr = useCallback(() => {
+    const next = !isNostrEnabled();
+    localStorage.setItem(STORAGE_KEYS.NOSTR_ENABLED, String(next));
+    setNostrEnabled(next);
+    if (!sphere) return;
+    void (next
+      ? sphere.enableProvider(NOSTR_PROVIDER_ID)
+      : sphere.disableProvider(NOSTR_PROVIDER_ID)
+    ).catch((err) => logger.warn('SphereProvider', `toggleNostr(${next}) failed:`, err));
+  }, [sphere]);
+
+  // Apply a persisted "Nostr off" once the wallet is ready: the SDK always wires the
+  // transport at init, so honour the offline preference by disabling it post-init.
+  useEffect(() => {
+    if (sphere && !nostrEnabled) {
+      void sphere.disableProvider(NOSTR_PROVIDER_ID).catch(() => {});
+    }
+  }, [sphere, nostrEnabled]);
+
   const value: SphereContextValue = {
     sphere,
     providers,
@@ -563,6 +595,8 @@ export function SphereProvider({
     reinitialize: initialize,
     ipfsEnabled,
     toggleIpfs,
+    nostrEnabled,
+    toggleNostr,
   };
 
   return (

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -27,7 +27,7 @@ import type {
   ImportFromFileResult,
 } from './SphereContext';
 import { clearAllSphereData, STORAGE_KEYS } from '../config/storageKeys';
-import { getVaultStore, isValidVaultUrl, getVaultDeviceId } from '../config/vaultStore';
+import { getVaultStore, isValidVaultUrl, getVaultDeviceId, getActiveCustomUrl } from '../config/vaultStore';
 import { migrateApprovedSessions } from '../utils/connected-sites';
 
 // One-time migration from old approved sessions format (idempotent)
@@ -115,11 +115,11 @@ function getTokenApiConfig(network: NetworkType): TokenApiConfig {
   if (setting.mode === 'off') return {};
 
   if (setting.mode === 'custom') {
-    const url = setting.customUrl?.trim();
+    const url = getActiveCustomUrl(setting);
     if (!isValidVaultUrl(url)) {
       console.warn(
-        '[Vault] Custom vault URL is blank or invalid — treating cloud backup as OFF. ' +
-        'Set a valid http(s) URL in Settings → Vault.',
+        '[Vault] Active custom store URL is blank or invalid — treating cloud backup as OFF. ' +
+        'Pick or add a valid server in Settings → Vault.',
       );
       return {};
     }

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -27,6 +27,7 @@ import type {
   ImportFromFileResult,
 } from './SphereContext';
 import { clearAllSphereData, STORAGE_KEYS } from '../config/storageKeys';
+import { getVaultStore, isValidVaultUrl } from '../config/vaultStore';
 import { migrateApprovedSessions } from '../utils/connected-sites';
 
 // One-time migration from old approved sessions format (idempotent)
@@ -67,15 +68,24 @@ function getIpfsConfig() {
 }
 
 /**
- * Token-Vault v2 wiring (opt-in, env-gated). Both the encrypted remote backup
- * (`vault`) and the store-and-forward token delivery channel (`courier`) are
- * OFF by default — with the env vars unset the wallet boots EXACTLY as today
- * (no vault provider, Nostr-only delivery). Flip them on per-build via:
+ * Token-Vault v2 wiring. The encrypted remote backup (`vault`) and the
+ * store-and-forward token delivery channel (`courier`) are driven by the user's
+ * persisted "Cloud backup & sync (Vault)" setting (Settings → Vault), with the
+ * env flags acting only as a fall-back default until the user has chosen.
+ *
+ * The Vault is operator-blind durable backup/sync of the user's OWN tokens; the
+ * local IndexedDB stays the working copy. The user choice is which token-api
+ * SERVER (or none). One server hosts both vault + courier, so a single URL feeds
+ * both. See config/vaultStore.ts for the persisted setting.
+ *
+ * Env fall-back (only when nothing has been saved yet):
  *   VITE_VAULT_ENABLED=true   VITE_VAULT_URL=http://localhost:3000   (optional)
  *   VITE_COURIER_ENABLED=true VITE_COURIER_URL=http://localhost:3000 (optional)
  * When enabled but the URL is unset, the SDK resolves NETWORKS[network].vaultUrl
- * (the per-network token-api default). The two flags are threaded into the
- * Sphere.init / import options on EVERY boot path (create, load, import).
+ * (the per-network token-api default). The resolved config is threaded into the
+ * Sphere.init / import options on EVERY boot path (create, load, import). When
+ * the effective mode is "off", this returns `{}` — a NO-OP, byte-identical to
+ * today (no vault provider, Nostr-only delivery).
  */
 function isVaultEnabled(): boolean {
   return import.meta.env.VITE_VAULT_ENABLED === 'true';
@@ -85,21 +95,50 @@ function isCourierEnabled(): boolean {
   return import.meta.env.VITE_COURIER_ENABLED === 'true';
 }
 
-/**
- * Build the `{ vault?, courier? }` slice of the Sphere init options from the env
- * flags for the given network. Returns `{}` when both are off, so spreading it
- * into init options is a NO-OP on the default (unset) build — byte-identical to
- * today. `url` is omitted unless explicitly set, letting the SDK fall back to
- * `NETWORKS[network].vaultUrl`.
- */
-function getTokenApiConfig(network: NetworkType): {
+type TokenApiConfig = {
   vault?: { enabled: boolean; url?: string };
   courier?: { enabled: boolean; url?: string };
-} {
-  const cfg: {
-    vault?: { enabled: boolean; url?: string };
-    courier?: { enabled: boolean; url?: string };
-  } = {};
+};
+
+/**
+ * Build the `{ vault?, courier? }` slice of the Sphere init options for the given
+ * network, resolving the effective config from the persisted vault-store setting
+ * (overriding the env flags). Falls back to the env flags only when the user has
+ * not chosen yet. Returns `{}` (a no-op) for the "off" mode.
+ */
+function getTokenApiConfig(network: NetworkType): TokenApiConfig {
+  const setting = getVaultStore();
+
+  // No saved choice yet — honour the build-time env flags (legacy behavior).
+  if (!setting) return getTokenApiConfigFromEnv(network);
+
+  if (setting.mode === 'off') return {};
+
+  if (setting.mode === 'custom') {
+    const url = setting.customUrl?.trim();
+    if (!isValidVaultUrl(url)) {
+      console.warn(
+        '[Vault] Custom vault URL is blank or invalid — treating cloud backup as OFF. ' +
+        'Set a valid http(s) URL in Settings → Vault.',
+      );
+      return {};
+    }
+    return { vault: { enabled: true, url }, courier: { enabled: true, url } };
+  }
+
+  // 'default' — Unicity's company token-api. The dev env var (if set) points
+  // this session at the local token-api; otherwise the SDK uses the per-network
+  // default (NETWORKS[network].vaultUrl).
+  const url = import.meta.env.VITE_VAULT_URL || NETWORKS[network]?.vaultUrl;
+  return {
+    vault: { enabled: true, ...(url ? { url } : {}) },
+    courier: { enabled: true, ...(url ? { url } : {}) },
+  };
+}
+
+/** Legacy env-flag resolution, used only before the user has saved a choice. */
+function getTokenApiConfigFromEnv(network: NetworkType): TokenApiConfig {
+  const cfg: TokenApiConfig = {};
   if (isVaultEnabled()) {
     const url = import.meta.env.VITE_VAULT_URL || NETWORKS[network]?.vaultUrl;
     cfg.vault = { enabled: true, ...(url ? { url } : {}) };

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -27,7 +27,7 @@ import type {
   ImportFromFileResult,
 } from './SphereContext';
 import { clearAllSphereData, STORAGE_KEYS } from '../config/storageKeys';
-import { getVaultStore, isValidVaultUrl } from '../config/vaultStore';
+import { getVaultStore, isValidVaultUrl, getVaultDeviceId } from '../config/vaultStore';
 import { migrateApprovedSessions } from '../utils/connected-sites';
 
 // One-time migration from old approved sessions format (idempotent)
@@ -123,7 +123,10 @@ function getTokenApiConfig(network: NetworkType): TokenApiConfig {
       );
       return {};
     }
-    return { vault: { enabled: true, url }, courier: { enabled: true, url } };
+    return {
+      vault: { enabled: true, url, deviceId: getVaultDeviceId() },
+      courier: { enabled: true, url },
+    };
   }
 
   // 'default' — Unicity's company token-api. The dev env var (if set) points
@@ -131,7 +134,7 @@ function getTokenApiConfig(network: NetworkType): TokenApiConfig {
   // default (NETWORKS[network].vaultUrl).
   const url = import.meta.env.VITE_VAULT_URL || NETWORKS[network]?.vaultUrl;
   return {
-    vault: { enabled: true, ...(url ? { url } : {}) },
+    vault: { enabled: true, deviceId: getVaultDeviceId(), ...(url ? { url } : {}) },
     courier: { enabled: true, ...(url ? { url } : {}) },
   };
 }
@@ -141,7 +144,7 @@ function getTokenApiConfigFromEnv(network: NetworkType): TokenApiConfig {
   const cfg: TokenApiConfig = {};
   if (isVaultEnabled()) {
     const url = import.meta.env.VITE_VAULT_URL || NETWORKS[network]?.vaultUrl;
-    cfg.vault = { enabled: true, ...(url ? { url } : {}) };
+    cfg.vault = { enabled: true, deviceId: getVaultDeviceId(), ...(url ? { url } : {}) };
   }
   if (isCourierEnabled()) {
     const url = import.meta.env.VITE_COURIER_URL || NETWORKS[network]?.vaultUrl;
@@ -161,12 +164,24 @@ async function disconnectTransport(providers: BrowserProviders): Promise<void> {
   }
 }
 
-/** Add IPFS storage provider and trigger initial sync (fire-and-forget) */
-function setupIpfsSync(instance: Sphere, providers: BrowserProviders): void {
-  if (providers.ipfsTokenStorage) {
-    instance.addTokenStorageProvider(providers.ipfsTokenStorage)
+/**
+ * Register the IPFS provider (if enabled) and trigger an initial cloud sync.
+ *
+ * The boot sync is what PULLS a peer device's tokens into THIS device: the vault's
+ * sync() returns the full rehydrated remote snapshot as `merged`, which the
+ * PaymentsModule merge folds in. `load()` alone won't do it on a reload (it
+ * short-circuits at the first successful provider once local has data), so we MUST
+ * fire a sync at boot whenever a cloud provider (IPFS or vault) is active — not
+ * only when IPFS happens to be on.
+ */
+function setupIpfsSync(instance: Sphere, providers: BrowserProviders, vaultEnabled = false): void {
+  const ipfsAdd = providers.ipfsTokenStorage
+    ? instance.addTokenStorageProvider(providers.ipfsTokenStorage)
+    : Promise.resolve();
+  if (providers.ipfsTokenStorage || vaultEnabled) {
+    ipfsAdd
       .then(() => instance.sync())
-      .catch(err => logger.warn('SphereProvider', 'IPFS sync failed', err));
+      .catch(err => logger.warn('SphereProvider', 'cloud sync failed', err));
   }
 }
 
@@ -243,15 +258,16 @@ export function SphereProvider({
 
       if (exists) {
         setInitProgress({ step: 'initializing', message: 'Loading wallet...' });
+        const tokenApiConfig = getTokenApiConfig(network);
         const { sphere: instance } = await Sphere.init({
           ...browserProviders,
           network, // ensure the SDK configures TokenRegistry for THIS network (not the testnet default)
           l1: {},
           discoverAddresses: false, // Run separately below for UX
           onProgress: setInitProgress,
-          ...getTokenApiConfig(network), // opt-in vault backup + courier delivery (OFF by default)
+          ...tokenApiConfig, // opt-in vault backup + courier delivery (OFF by default)
         });
-        setupIpfsSync(instance, browserProviders);
+        setupIpfsSync(instance, browserProviders, !!tokenApiConfig.vault?.enabled);
         setInitProgress(null);
         sphereRef.current = instance;
         setSphere(instance);

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -66,6 +66,51 @@ function getIpfsConfig() {
   };
 }
 
+/**
+ * Token-Vault v2 wiring (opt-in, env-gated). Both the encrypted remote backup
+ * (`vault`) and the store-and-forward token delivery channel (`courier`) are
+ * OFF by default — with the env vars unset the wallet boots EXACTLY as today
+ * (no vault provider, Nostr-only delivery). Flip them on per-build via:
+ *   VITE_VAULT_ENABLED=true   VITE_VAULT_URL=http://localhost:3000   (optional)
+ *   VITE_COURIER_ENABLED=true VITE_COURIER_URL=http://localhost:3000 (optional)
+ * When enabled but the URL is unset, the SDK resolves NETWORKS[network].vaultUrl
+ * (the per-network token-api default). The two flags are threaded into the
+ * Sphere.init / import options on EVERY boot path (create, load, import).
+ */
+function isVaultEnabled(): boolean {
+  return import.meta.env.VITE_VAULT_ENABLED === 'true';
+}
+
+function isCourierEnabled(): boolean {
+  return import.meta.env.VITE_COURIER_ENABLED === 'true';
+}
+
+/**
+ * Build the `{ vault?, courier? }` slice of the Sphere init options from the env
+ * flags for the given network. Returns `{}` when both are off, so spreading it
+ * into init options is a NO-OP on the default (unset) build — byte-identical to
+ * today. `url` is omitted unless explicitly set, letting the SDK fall back to
+ * `NETWORKS[network].vaultUrl`.
+ */
+function getTokenApiConfig(network: NetworkType): {
+  vault?: { enabled: boolean; url?: string };
+  courier?: { enabled: boolean; url?: string };
+} {
+  const cfg: {
+    vault?: { enabled: boolean; url?: string };
+    courier?: { enabled: boolean; url?: string };
+  } = {};
+  if (isVaultEnabled()) {
+    const url = import.meta.env.VITE_VAULT_URL || NETWORKS[network]?.vaultUrl;
+    cfg.vault = { enabled: true, ...(url ? { url } : {}) };
+  }
+  if (isCourierEnabled()) {
+    const url = import.meta.env.VITE_COURIER_URL || NETWORKS[network]?.vaultUrl;
+    cfg.courier = { enabled: true, ...(url ? { url } : {}) };
+  }
+  return cfg;
+}
+
 // =============================================================================
 // Shared helpers (pure functions, no React state)
 // =============================================================================
@@ -165,6 +210,7 @@ export function SphereProvider({
           l1: {},
           discoverAddresses: false, // Run separately below for UX
           onProgress: setInitProgress,
+          ...getTokenApiConfig(network), // opt-in vault backup + courier delivery (OFF by default)
         });
         setupIpfsSync(instance, browserProviders);
         setInitProgress(null);
@@ -244,6 +290,7 @@ export function SphereProvider({
           nametag: options?.nametag,
           l1: {},
           onProgress: setInitProgress,
+          ...getTokenApiConfig(network), // opt-in vault backup + courier delivery (OFF by default)
         });
         setInitProgress(null);
 
@@ -309,6 +356,7 @@ export function SphereProvider({
         nametag: options?.nametag,
         l1: {},
         onProgress: setInitProgress,
+        ...getTokenApiConfig(network), // opt-in vault backup + courier delivery (OFF by default)
       });
       setInitProgress(null);
 
@@ -335,6 +383,7 @@ export function SphereProvider({
           nametag: options.nametag,
           l1: {},
           onProgress: setInitProgress,
+          ...getTokenApiConfig(network), // opt-in vault backup + courier delivery (OFF by default)
         });
         setInitProgress(null);
 

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -53,7 +53,10 @@ if (import.meta.env.DEV) {
 
 function isIpfsEnabled(): boolean {
   const stored = localStorage.getItem(STORAGE_KEYS.IPFS_ENABLED);
-  return stored !== 'false'; // enabled by default
+  // OFF by default: the token-api Vault is the primary backup/sync now. IPFS is a
+  // second, flaky token-storage provider (slow/unreliable IPNS resolve+publish) sharing
+  // the same load/sync/merge path — opt-in only. An explicit prior choice is respected.
+  return stored === 'true';
 }
 
 /** The Nostr transport provider id (NostrTransportProvider.id). */

--- a/src/sdk/hooks/core/useVaultSync.ts
+++ b/src/sdk/hooks/core/useVaultSync.ts
@@ -84,24 +84,21 @@ export function useVaultSync(): UseVaultSyncReturn {
       setState((prev) => (prev.status === 'syncing' ? { ...prev, status: 'idle' } : prev));
     };
 
-    const handleSyncError = (data: { error: string }) => {
-      setState((prev) => (prev.status === 'syncing'
-        ? { ...prev, status: 'error', lastError: data.error }
-        : prev));
-    };
-
+    // Vault status is provider-SPECIFIC. We deliberately do NOT subscribe to the GLOBAL
+    // 'sync:error' event: it fires for ANY provider (e.g. IPFS), so honouring it would
+    // mislabel the VAULT as failed when an UNRELATED provider errors — e.g. right after
+    // toggling IPFS off. The vault's OWN failures arrive via the provider-filtered
+    // 'sync:provider' (success:false) handler above.
     sphere.on('sync:started', handleSyncStarted);
     sphere.on('sync:provider', handleSyncProvider);
     sphere.on('sync:remote-update', handleRemoteUpdate);
     sphere.on('sync:completed', handleSyncCompleted);
-    sphere.on('sync:error', handleSyncError);
 
     return () => {
       sphere.off('sync:started', handleSyncStarted);
       sphere.off('sync:provider', handleSyncProvider);
       sphere.off('sync:remote-update', handleRemoteUpdate);
       sphere.off('sync:completed', handleSyncCompleted);
-      sphere.off('sync:error', handleSyncError);
     };
   }, [sphere]);
 

--- a/src/sdk/hooks/core/useVaultSync.ts
+++ b/src/sdk/hooks/core/useVaultSync.ts
@@ -53,6 +53,12 @@ export function useVaultSync(): UseVaultSyncReturn {
       setEnabled(false);
     }
 
+    // A reinitialize (e.g. toggling IPFS) SWAPS the sphere instance and re-runs this
+    // effect. Clear any stale error carried over from the previous instance so the
+    // indicator never hangs red after the wallet has actually recovered — the fresh
+    // instance re-reports its true status via sync:provider.
+    setState((prev) => (prev.status === 'error' ? { ...prev, status: 'idle', lastError: null } : prev));
+
     const handleSyncStarted = () => {
       setState((prev) => ({ ...prev, status: 'syncing', lastError: null }));
     };

--- a/src/sdk/hooks/core/useVaultSync.ts
+++ b/src/sdk/hooks/core/useVaultSync.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSphereContext } from './useSphere';
+
+/**
+ * The vault token-storage provider's id, as registered by the SDK
+ * (`RemoteTokenStorageProvider.id` / `VAULT_PROVIDER_ID`). Used to filter the
+ * per-provider `sync:provider` / `sync:remote-update` events so this hook
+ * reflects the VAULT specifically, not the IPFS provider.
+ */
+const VAULT_PROVIDER_ID = 'remote-token-storage';
+
+export type VaultSyncStatus = 'idle' | 'syncing' | 'error';
+
+export interface VaultSyncState {
+  status: VaultSyncStatus;
+  /** ms timestamp of the last successful vault sync, or null. */
+  lastSynced: number | null;
+  lastError: string | null;
+}
+
+export interface UseVaultSyncReturn extends VaultSyncState {
+  /** Whether the wallet is currently configured to use a cloud vault. */
+  enabled: boolean;
+  triggerSync: () => Promise<void>;
+}
+
+/**
+ * useVaultSync — tracks the cloud Vault backup/sync status by subscribing to the
+ * SDK's storage/sync events. `enabled` is derived from whether a vault provider
+ * is actually wired into the running Sphere instance, so it stays truthful even
+ * if the persisted setting and the live instance disagree (e.g. before reload).
+ */
+export function useVaultSync(): UseVaultSyncReturn {
+  const { sphere } = useSphereContext();
+  const [enabled, setEnabled] = useState(false);
+  const [state, setState] = useState<VaultSyncState>({
+    status: 'idle',
+    lastSynced: null,
+    lastError: null,
+  });
+
+  useEffect(() => {
+    if (!sphere) {
+      setEnabled(false);
+      return;
+    }
+
+    // Is a vault provider actually registered on this instance? The SDK keys the
+    // provider Map by id, and the vault registers under VAULT_PROVIDER_ID.
+    try {
+      setEnabled(sphere.getTokenStorageProviders().has(VAULT_PROVIDER_ID));
+    } catch {
+      setEnabled(false);
+    }
+
+    const handleSyncStarted = () => {
+      setState((prev) => ({ ...prev, status: 'syncing', lastError: null }));
+    };
+
+    // Per-provider result — the authoritative signal for the vault specifically.
+    const handleSyncProvider = (data: {
+      providerId: string;
+      success: boolean;
+      error?: string;
+    }) => {
+      if (data.providerId !== VAULT_PROVIDER_ID) return;
+      setEnabled(true);
+      if (data.success) {
+        setState((prev) => ({ ...prev, status: 'idle', lastSynced: Date.now(), lastError: null }));
+      } else {
+        setState((prev) => ({ ...prev, status: 'error', lastError: data.error ?? 'Sync failed' }));
+      }
+    };
+
+    const handleRemoteUpdate = (data: { providerId: string }) => {
+      if (data.providerId !== VAULT_PROVIDER_ID) return;
+      setEnabled(true);
+      setState((prev) => ({ ...prev, lastSynced: Date.now() }));
+    };
+
+    // Global sync completion clears a transient "syncing" if no provider error
+    // arrived; harmless when the vault is off.
+    const handleSyncCompleted = () => {
+      setState((prev) => (prev.status === 'syncing' ? { ...prev, status: 'idle' } : prev));
+    };
+
+    const handleSyncError = (data: { error: string }) => {
+      setState((prev) => (prev.status === 'syncing'
+        ? { ...prev, status: 'error', lastError: data.error }
+        : prev));
+    };
+
+    sphere.on('sync:started', handleSyncStarted);
+    sphere.on('sync:provider', handleSyncProvider);
+    sphere.on('sync:remote-update', handleRemoteUpdate);
+    sphere.on('sync:completed', handleSyncCompleted);
+    sphere.on('sync:error', handleSyncError);
+
+    return () => {
+      sphere.off('sync:started', handleSyncStarted);
+      sphere.off('sync:provider', handleSyncProvider);
+      sphere.off('sync:remote-update', handleRemoteUpdate);
+      sphere.off('sync:completed', handleSyncCompleted);
+      sphere.off('sync:error', handleSyncError);
+    };
+  }, [sphere]);
+
+  const triggerSync = useCallback(async () => {
+    if (!sphere) return;
+    await sphere.sync();
+  }, [sphere]);
+
+  return { ...state, enabled, triggerSync };
+}

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -9,6 +9,8 @@ export type { UseNametagReturn } from './core/useNametag';
 export { useSphereEvents } from './core/useSphereEvents';
 export { useIpfsSync } from './core/useIpfsSync';
 export type { IpfsSyncStatus, IpfsSyncState, UseIpfsSyncReturn } from './core/useIpfsSync';
+export { useVaultSync } from './core/useVaultSync';
+export type { VaultSyncStatus, VaultSyncState, UseVaultSyncReturn } from './core/useVaultSync';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/tests/unit/config/vaultStore.test.ts
+++ b/tests/unit/config/vaultStore.test.ts
@@ -1,0 +1,105 @@
+/**
+ * vaultStore — multi-store model: legacy migration, active-store resolution,
+ * and normalization on persist. Pure localStorage logic (jsdom).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getVaultStore,
+  setVaultStore,
+  getActiveCustomUrl,
+  isValidVaultUrl,
+  hostLabel,
+  type VaultStoreSetting,
+  type CustomStore,
+} from '../../../src/config/vaultStore';
+import { STORAGE_KEYS } from '../../../src/config/storageKeys';
+
+function seed(raw: unknown): void {
+  localStorage.setItem(STORAGE_KEYS.VAULT_STORE, JSON.stringify(raw));
+}
+
+describe('vaultStore — multi-store', () => {
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+      clear: () => { store = {}; },
+    });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns null when nothing has been saved (so callers fall back to env)', () => {
+    expect(getVaultStore()).toBeNull();
+  });
+
+  it('migrates a legacy { mode:custom, customUrl } into customStores + activeCustomId', () => {
+    seed({ mode: 'custom', customUrl: 'https://my.token-api.example' });
+    const s = getVaultStore()!;
+    expect(s.mode).toBe('custom');
+    expect(s.customStores).toHaveLength(1);
+    expect(s.customStores![0].url).toBe('https://my.token-api.example');
+    expect(s.activeCustomId).toBe(s.customStores![0].id);
+    // The migrated setting resolves to the legacy URL.
+    expect(getActiveCustomUrl(s)).toBe('https://my.token-api.example');
+  });
+
+  it('resolves the ACTIVE store among several customs', () => {
+    const a: CustomStore = { id: 'a', label: 'A', url: 'https://a.example', addedAt: 1 };
+    const b: CustomStore = { id: 'b', label: 'B', url: 'https://b.example', addedAt: 2 };
+    seed({ mode: 'custom', customStores: [a, b], activeCustomId: 'b' });
+    const s = getVaultStore()!;
+    expect(s.customStores).toHaveLength(2);
+    expect(getActiveCustomUrl(s)).toBe('https://b.example');
+  });
+
+  it('falls back to the first store when activeCustomId is stale/missing', () => {
+    seed({
+      mode: 'custom',
+      customStores: [{ id: 'a', label: 'A', url: 'https://a.example', addedAt: 1 }],
+      activeCustomId: 'gone',
+    });
+    const s = getVaultStore()!;
+    expect(s.activeCustomId).toBe('a');
+    expect(getActiveCustomUrl(s)).toBe('https://a.example');
+  });
+
+  it('filters out invalid custom stores', () => {
+    seed({
+      mode: 'custom',
+      customStores: [
+        { id: 'good', label: 'ok', url: 'https://ok.example', addedAt: 1 },
+        { id: 'bad', label: 'nope', url: 'not-a-url', addedAt: 2 },
+        { id: 'nourl', label: 'x', addedAt: 3 },
+      ],
+    });
+    const s = getVaultStore()!;
+    expect(s.customStores).toHaveLength(1);
+    expect(s.customStores![0].id).toBe('good');
+  });
+
+  it('getActiveCustomUrl is undefined for non-custom modes', () => {
+    expect(getActiveCustomUrl({ mode: 'default' })).toBeUndefined();
+    expect(getActiveCustomUrl({ mode: 'off' })).toBeUndefined();
+  });
+
+  it('setVaultStore normalizes — drops the legacy customUrl, keeps the migrated list', () => {
+    const setting: VaultStoreSetting = { mode: 'custom', customUrl: 'https://legacy.example' };
+    setVaultStore(setting);
+    const rawAfter = JSON.parse(localStorage.getItem(STORAGE_KEYS.VAULT_STORE)!);
+    expect(rawAfter.customUrl).toBeUndefined();
+    expect(rawAfter.customStores).toHaveLength(1);
+    expect(rawAfter.customStores[0].url).toBe('https://legacy.example');
+  });
+
+  it('isValidVaultUrl + hostLabel helpers', () => {
+    expect(isValidVaultUrl('https://x.example')).toBe(true);
+    expect(isValidVaultUrl('ftp://x')).toBe(false);
+    expect(isValidVaultUrl('')).toBe(false);
+    expect(hostLabel('https://api.example.com:8080/path')).toBe('api.example.com:8080');
+  });
+});


### PR DESCRIPTION
Wires the token-api Vault (encrypted multi-device token backup/sync) + Courier (store-and-forward delivery) into the wallet via env flags VITE_VAULT_ENABLED/URL + VITE_COURIER_ENABLED/URL, threaded into Sphere.init/create/load/import in SphereProvider.tsx. OFF by default - with the env unset the wallet boots byte-identical to today (no vault, Nostr delivery). Proven end-to-end by the SDK Sphere.init e2e against a real in-process token-api: vault flush -> fresh load restores BALANCE (key=chainPubkey, no DIRECT); courier A.send -> B.receive -> A pollSent GC. NOTE: do NOT merge into the v2 branch until the SDK publishes the vault+courier (this branch links file:../sphere-sdk; package.json must then re-pin the published version). tsc clean against the linked SDK.