### PR TITLE
Sync base: merge feat/sdk-migration-v2 into the integration branch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Sphere backend (sphere-quest) — marketplace, user installed-apps, auth
 VITE_SPHERE_API_URL=http://localhost:3001
 
+# Developer Portal — "Open developer portal" / "Submit your project" CTAs link here
+VITE_DEV_PORTAL_URL=https://developers.staging.unicity.network/
+
 # Aggregator (state-transition gateway) API key.
 # The testnet2 value below is NOT a secret — safe to keep here and in docs.
 # For mainnet this MUST be a real secret: set it only in the deploy env, never commit it.

--- a/src/components/desktop/DesktopShortcuts.tsx
+++ b/src/components/desktop/DesktopShortcuts.tsx
@@ -16,6 +16,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { getAgentConfig } from '../../config/activities';
+import { DEV_PORTAL_URL } from '../../config/devPortal';
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { useDmUnreadCount } from '../chat/hooks/useDmUnreadCount';
 import { useGroupUnreadCount } from '../chat/hooks/useGroupUnreadCount';
@@ -230,7 +231,7 @@ export function DesktopShortcuts() {
             Explore marketplace
           </Link>
           {' '}&middot;{' '}
-          <a href="https://github.com/unicity-sphere/sphere-apps" target="_blank" rel="noopener noreferrer" className="underline hover:text-neutral-600 dark:hover:text-[rgba(255,255,255,0.6)] transition-colors">
+          <a href={DEV_PORTAL_URL} target="_blank" rel="noopener noreferrer" className="underline hover:text-neutral-600 dark:hover:text-[rgba(255,255,255,0.6)] transition-colors">
             Submit your project
           </a>
         </p>

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -34,7 +34,7 @@ function TransferToast({ data, onClose }: { data: TransferToastData; onClose: ()
           <div className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center">
             <ArrowDownLeft className="w-3 h-3 text-white" />
           </div>
-          <span className="text-xs font-medium text-emerald-400">Incoming Transfer</span>
+          <span className="text-xs font-medium text-emerald-400">{data.title ?? 'Incoming Transfer'}</span>
         </div>
         <button
           onClick={onClose}
@@ -59,9 +59,11 @@ function TransferToast({ data, onClose }: { data: TransferToastData; onClose: ()
           <div className="text-lg font-bold text-white">
             +{data.amount} <span className="text-emerald-400">{data.symbol}</span>
           </div>
-          <div className="text-xs text-neutral-400">
-            from <span className="text-neutral-200 font-medium">{data.sender}</span>
-          </div>
+          {data.sender && (
+            <div className="text-xs text-neutral-400">
+              from <span className="text-neutral-200 font-medium">{data.sender}</span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/ui/toast-utils.ts
+++ b/src/components/ui/toast-utils.ts
@@ -1,7 +1,10 @@
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
 export interface TransferToastData {
-  sender: string;
+  /** Header label; defaults to 'Incoming Transfer' when omitted. */
+  title?: string;
+  /** Omitted for self-mints (top-up), where there is no counterparty. */
+  sender?: string;
   amount: string;
   symbol: string;
   iconUrl?: string | null;
@@ -29,6 +32,23 @@ export function showTransferToast(transfer: TransferToastData, duration = 6000) 
   window.dispatchEvent(
     new CustomEvent<ShowToastDetail>('show-toast', {
       detail: { message, type: 'success', duration, transfer },
+    })
+  );
+}
+
+/** Toast for coins self-minted via top-up — a transfer toast without a sender. */
+export function showMintToast(
+  mint: { amount: string; symbol: string; iconUrl?: string | null },
+  duration = 6000,
+) {
+  window.dispatchEvent(
+    new CustomEvent<ShowToastDetail>('show-toast', {
+      detail: {
+        message: `Received ${mint.amount} ${mint.symbol}`,
+        type: 'success',
+        duration,
+        transfer: { title: 'Top Up', amount: mint.amount, symbol: mint.symbol, iconUrl: mint.iconUrl },
+      },
     })
   );
 }

--- a/src/components/wallet/L3/modals/TopUpModal.tsx
+++ b/src/components/wallet/L3/modals/TopUpModal.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { Sparkles, Receipt, CheckCircle, XCircle, ArrowRight, Loader2 } from 'lucide-react';
 import { useTopUp } from '../../../../sdk';
 import { getErrorMessage } from '../../../../sdk/errors';
-import { showToast } from '../../../ui/toast-utils';
+import { showToast, showMintToast } from '../../../ui/toast-utils';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader } from '../../ui';
 import { SendPaymentRequestModal } from './SendPaymentRequestModal';
@@ -32,6 +32,11 @@ export function TopUpModal({ isOpen, onClose }: TopUpModalProps) {
       // Self-mint test tokens to this wallet (v2; no faucet, no nametag).
       const results = await topUp();
       const failed = results.filter((r) => !r.success);
+
+      // One toast per minted coin — outlives the modal's 1.5s auto-close.
+      for (const r of results) {
+        if (r.success) showMintToast(r);
+      }
 
       if (failed.length === results.length) {
         // All failed — surface the reason(s).

--- a/src/config/devPortal.ts
+++ b/src/config/devPortal.ts
@@ -1,0 +1,8 @@
+/**
+ * Developer Portal URL.
+ *
+ * Env-driven (`VITE_DEV_PORTAL_URL`) so each environment points at its own host
+ * (staging/prod). Falls back to staging when the env var is unset.
+ */
+export const DEV_PORTAL_URL =
+  import.meta.env.VITE_DEV_PORTAL_URL ?? 'https://developers.staging.unicity.network/';

--- a/src/hooks/useMaintenanceStatus.ts
+++ b/src/hooks/useMaintenanceStatus.ts
@@ -1,0 +1,65 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+const API_BASE = import.meta.env.VITE_SPHERE_API_URL ?? 'http://localhost:3001';
+
+export interface MaintenanceStatus {
+  enabled: boolean;
+  message: string | null;
+  updatedAt: string | null;
+}
+
+const NOT_UNDER_MAINTENANCE: MaintenanceStatus = { enabled: false, message: null, updatedAt: null };
+
+/**
+ * Polls the allowlisted `/api/maintenance/status` endpoint. That route is exempt
+ * from the maintenance gate, so it always answers 200 — unlike the marketplace
+ * routes, which answer 503 while `sphere` is under maintenance. Knowing the state
+ * up-front lets us skip the marketplace requests entirely instead of firing them
+ * and letting the browser log the (expected) 503s as red console errors.
+ */
+async function fetchStatus(): Promise<MaintenanceStatus> {
+  try {
+    const res = await fetch(`${API_BASE}/api/maintenance/status`, {
+      headers: { 'x-client': 'sphere' },
+    });
+    if (!res.ok) return NOT_UNDER_MAINTENANCE;
+    return (await res.json()) as MaintenanceStatus;
+  } catch {
+    // Fail-open: a hiccup on the status endpoint must never hide the marketplace.
+    return NOT_UNDER_MAINTENANCE;
+  }
+}
+
+export function useMaintenanceStatus() {
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    // If any API call slips through and gets a 503 maintenance response, it
+    // dispatches `maintenance:forced` — invalidate immediately instead of
+    // waiting up to 30s for the next poll.
+    const handler = (): void => { void qc.invalidateQueries({ queryKey: ['maintenance-status'] }); };
+    window.addEventListener('maintenance:forced', handler);
+    return () => window.removeEventListener('maintenance:forced', handler);
+  }, [qc]);
+
+  return useQuery({
+    queryKey: ['maintenance-status'],
+    queryFn: fetchStatus,
+    refetchInterval: 30_000,
+    staleTime: 0,
+    retry: 1,
+  });
+}
+
+/**
+ * Gate for marketplace queries. True only once we KNOW the API is not under
+ * maintenance for the `sphere` client. While the status is still loading the
+ * gate stays closed so marketplace requests wait for the (fast, allowlisted)
+ * status call rather than racing ahead and triggering 503s. `fetchStatus`
+ * fails open, so a status outage never permanently blocks the marketplace.
+ */
+export function useMarketplaceEnabled(): boolean {
+  const { data, isSuccess } = useMaintenanceStatus();
+  return isSuccess && !data.enabled;
+}

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -11,88 +11,108 @@ import {
   fetchRatingReplies,
   fetchCategories,
 } from '../services/marketplaceApi';
+import { useMarketplaceEnabled } from './useMaintenanceStatus';
+
+// Every query below talks to the sphere-api marketplace/metrics routes, which the
+// maintenance gate answers with 503 while `sphere` is under maintenance. Gating on
+// `useMarketplaceEnabled()` means the requests simply don't fire in that window, so
+// the browser never logs the (expected) 503s as red console errors. The wallet core
+// is unaffected — it talks to the chain/SDK, not sphere-api.
 
 export function useProjects(params?: { type?: 'app' | 'skill'; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'projects', params],
     queryFn: () => fetchProjects(params),
+    enabled: marketplaceEnabled,
     staleTime: 5 * 60_000,
   });
 }
 
 export function useFeaturedProjects(type?: 'app' | 'skill') {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'featured', type],
     queryFn: () => fetchFeaturedProjects(type),
+    enabled: marketplaceEnabled,
     staleTime: 5 * 60_000,
     retry: 1,
   });
 }
 
 export function useProject(slug: string, preview?: boolean) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project', slug, { preview }],
     queryFn: () => fetchProject(slug, preview),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
   });
 }
 
 export function useProjectQuests(slug: string) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project-quests', slug],
     queryFn: () => fetchProjectQuests(slug),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
   });
 }
 
 export function useProjectAchievements(slug: string) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project-achievements', slug],
     queryFn: () => fetchProjectAchievements(slug),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
   });
 }
 
 export function useCategories() {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'categories'],
     queryFn: fetchCategories,
+    enabled: marketplaceEnabled,
     staleTime: 10 * 60_000,
   });
 }
 
 export function useProjectMetrics(projectId: string | undefined) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['metrics', 'project', projectId],
     queryFn: () => fetchProjectMetrics(projectId!),
-    enabled: !!projectId,
+    enabled: marketplaceEnabled && !!projectId,
     staleTime: 60_000,
   });
 }
 
 export function useProjectMetricsBatch(projectIds: string[]) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['metrics', 'projects', projectIds.slice().sort().join(',')],
     queryFn: () => fetchProjectMetricsBatch(projectIds),
-    enabled: projectIds.length > 0,
+    enabled: marketplaceEnabled && projectIds.length > 0,
     staleTime: 60_000,
   });
 }
 
 export function useProjectRatings(slug: string | undefined, page = 1, sort: 'helpful' | 'recent' = 'helpful') {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'ratings', slug, page, sort],
     queryFn: () => fetchProjectRatings(slug!, page, 20, sort),
-    enabled: !!slug,
+    enabled: marketplaceEnabled && !!slug,
     staleTime: 30_000,
   });
 }
 
 export function useRatingReplies(ratingId: string | undefined, enabled = true) {
+  const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'replies', ratingId],
     queryFn: () => fetchRatingReplies(ratingId!),
-    enabled: enabled && !!ratingId,
+    enabled: marketplaceEnabled && enabled && !!ratingId,
     staleTime: 15_000,
   });
 }

--- a/src/pages/DocsPage.tsx
+++ b/src/pages/DocsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Link } from 'react-router-dom';
+import { DEV_PORTAL_URL } from '../config/devPortal';
 
 type Section =
   | 'getting-started'
@@ -1832,9 +1832,9 @@ main();`}
               <a href="https://github.com/unicity-sphere/sphere" target="_blank" rel="noopener noreferrer" className="hover:text-orange-500 transition">
                 GitHub
               </a>
-              <Link to="/developers" className="hover:text-orange-500 transition">
+              <a href={DEV_PORTAL_URL} target="_blank" rel="noopener noreferrer" className="hover:text-orange-500 transition">
                 Developer Portal
-              </Link>
+              </a>
             </div>
             <p className="text-sm text-neutral-500">
               AgentSphere by Unicity Labs

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Search, ArrowRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import { useProjects, useFeaturedProjects, useProjectMetricsBatch } from '../hooks/useMarketplace';
 import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCard';
 import { ProjectCard } from '../components/marketplace/ProjectCard';
 import { CategoryFilter } from '../components/marketplace/CategoryFilter';
 import { MaintenanceScreen } from '../components/MaintenanceScreen';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
+import { DEV_PORTAL_URL } from '../config/devPortal';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -300,13 +300,15 @@ export function ExplorePage() {
             <p className="text-neutral-500 dark:text-white/55 text-sm sm:text-base leading-relaxed max-w-md">
               Register your project, ship quests, and plug into wallets and chat — all from one portal.
             </p>
-            <Link
-              to="/developers"
+            <a
+              href={DEV_PORTAL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
               className="group inline-flex items-center gap-2 self-start sm:self-auto px-6 py-3 rounded-xl bg-orange-500 dark:bg-brand-orange hover:bg-orange-600 dark:hover:bg-brand-orange-dark text-white font-semibold text-sm transition-colors shadow-lg shadow-orange-500/20 shrink-0"
             >
               Open developer portal
               <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5" />
-            </Link>
+            </a>
           </div>
         </div>
       </section>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -7,6 +7,7 @@ import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCa
 import { ProjectCard } from '../components/marketplace/ProjectCard';
 import { CategoryFilter } from '../components/marketplace/CategoryFilter';
 import { MaintenanceScreen } from '../components/MaintenanceScreen';
+import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -101,16 +102,10 @@ function HeroDivider() {
 export function ExplorePage() {
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState<string | null>(null);
-  const [maintenance, setMaintenance] = useState<string | null | undefined>(undefined);
-
-  useEffect(() => {
-    function onForced(e: Event) {
-      const detail = (e as CustomEvent<{ message?: string }>).detail;
-      setMaintenance(detail?.message ?? null);
-    }
-    window.addEventListener('maintenance:forced', onForced);
-    return () => window.removeEventListener('maintenance:forced', onForced);
-  }, []);
+  // Proactive maintenance status — the hook polls the allowlisted status endpoint
+  // and also listens for `maintenance:forced`, so the marketplace queries (gated on
+  // the same status) never fire requests that would 503 during maintenance.
+  const { data: maintenance } = useMaintenanceStatus();
 
   // Data — always filtered for apps only
   const { data: projectsData, isLoading } = useProjects({ type: 'app' });
@@ -155,8 +150,8 @@ export function ExplorePage() {
   const itemLabel = 'projects';
   const searchPlaceholder = 'Search projects...';
 
-  if (maintenance !== undefined) {
-    return <MaintenanceScreen message={maintenance} />;
+  if (maintenance?.enabled) {
+    return <MaintenanceScreen message={maintenance.message} />;
   }
 
   return (

--- a/src/sdk/hooks/payments/useTopUp.ts
+++ b/src/sdk/hooks/payments/useTopUp.ts
@@ -6,6 +6,9 @@ import { TokenRegistry, toSmallestUnit } from '@unicitylabs/sphere-sdk';
 /** Per-coin result of a top-up mint, for partial-success display. */
 export interface TopUpResult {
   symbol: string;
+  /** Human-readable minted amount from the predefined basket (e.g. "100"). */
+  amount: string;
+  iconUrl?: string;
   success: boolean;
   error?: string;
 }
@@ -57,20 +60,23 @@ export function useTopUp(): UseTopUpReturn {
         fungible.filter((d) => d.id && d.symbol).map((d) => [d.symbol as string, d]),
       );
 
+      const registry = TokenRegistry.getInstance();
       return Promise.all(
         Object.entries(AMOUNTS).map(async ([symbol, human]): Promise<TopUpResult> => {
+          const base = { symbol, amount: String(human) };
           const def = bySymbol.get(symbol);
           if (!def) {
-            return { symbol, success: false, error: 'Not in token registry' };
+            return { ...base, success: false, error: 'Not in token registry' };
           }
+          const iconUrl = registry.getIconUrl(def.id) ?? undefined;
           const amount = toSmallestUnit(human, def.decimals ?? 0);
           try {
             const res = await sphere.payments.mintFungibleToken(def.id, amount);
             return res.success
-              ? { symbol, success: true }
-              : { symbol, success: false, error: res.error };
+              ? { ...base, iconUrl, success: true }
+              : { ...base, iconUrl, success: false, error: res.error };
           } catch (e) {
-            return { symbol, success: false, error: e instanceof Error ? e.message : String(e) };
+            return { ...base, iconUrl, success: false, error: e instanceof Error ? e.message : String(e) };
           }
         }),
       );

--- a/tests/unit/components/toast-utils.test.ts
+++ b/tests/unit/components/toast-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  showToast,
+  showTransferToast,
+  showMintToast,
+  type ShowToastDetail,
+} from '../../../src/components/ui/toast-utils';
+
+/** Capture the next `show-toast` CustomEvent dispatched on window. */
+function captureToast(fire: () => void): ShowToastDetail {
+  let detail: ShowToastDetail | undefined;
+  const handler = (e: Event) => {
+    detail = (e as CustomEvent<ShowToastDetail>).detail;
+  };
+  window.addEventListener('show-toast', handler);
+  try {
+    fire();
+  } finally {
+    window.removeEventListener('show-toast', handler);
+  }
+  if (!detail) throw new Error('show-toast event was not dispatched');
+  return detail;
+}
+
+describe('showToast', () => {
+  it('dispatches a plain toast with message and type', () => {
+    const detail = captureToast(() => showToast('hello', 'warning', 1234));
+    expect(detail).toEqual({ message: 'hello', type: 'warning', duration: 1234 });
+  });
+});
+
+describe('showTransferToast', () => {
+  it('dispatches a transfer toast with sender line', () => {
+    const detail = captureToast(() =>
+      showTransferToast({ sender: '@alice', amount: '5', symbol: 'UCT' }),
+    );
+    expect(detail.type).toBe('success');
+    expect(detail.message).toBe('@alice sent you 5 UCT');
+    expect(detail.transfer).toMatchObject({ sender: '@alice', amount: '5', symbol: 'UCT' });
+  });
+});
+
+describe('showMintToast', () => {
+  it('dispatches a senderless transfer toast titled "Top Up"', () => {
+    const detail = captureToast(() =>
+      showMintToast({ amount: '100', symbol: 'UCT', iconUrl: 'https://x/uct.png' }),
+    );
+    expect(detail.type).toBe('success');
+    expect(detail.message).toBe('Received 100 UCT');
+    expect(detail.transfer).toEqual({
+      title: 'Top Up',
+      amount: '100',
+      symbol: 'UCT',
+      iconUrl: 'https://x/uct.png',
+    });
+    expect(detail.transfer?.sender).toBeUndefined();
+  });
+
+  it('works without an icon', () => {
+    const detail = captureToast(() => showMintToast({ amount: '0.5', symbol: 'ETH' }));
+    expect(detail.message).toBe('Received 0.5 ETH');
+    expect(detail.transfer).toEqual({ title: 'Top Up', amount: '0.5', symbol: 'ETH', iconUrl: undefined });
+  });
+});


### PR DESCRIPTION
Brings `feat/wallet-api-integration` up to date with its base `feat/sdk-migration-v2` (7 commits since the last common ancestor).

## What base adds
- marketplace maintenance gate (#353) + `useMaintenanceStatus` hook
- env-driven Developer Portal link (#354/#355) + `config/devPortal.ts`
- **Top Up notification**: `TopUpResult` gains `amount`/`iconUrl` display fields (`useTopUp.ts`, `TopUpModal.tsx`, toast utils + test)

## Merge safety
- **No textual conflicts.** Only `.env.example` overlapped; git auto-merged it — both var sets preserved (base's `VITE_DEV_PORTAL_URL` + ours `VITE_WALLET_API_URL`/`VITE_REQUIRE_WALLET_API`/`VITE_AGGREGATOR_URL`).
- `useTopUp.ts` is **base-only** (our branch never touched it); its new `registry.getIconUrl()` call is present in the pinned **sphere-sdk 0.9.1-dev.9** (verified). Local typecheck clean on the merged tree.
- **Real merge commit** (not squash) so the base remains a proper ancestor — future base-syncs compute the right merge-base. **Merge this PR with a merge commit, not squash.**

## Verification
- CI: lint + unit (incl. base's new `toast-utils.test.ts`) + build.
- e2e two-profile smoke (incl. the F5 reload assertions) run locally against the compose stack — top-up path changed, so this is the regression gate.