### PR TITLE
Bump sphere-sdk to dev.10 (recipient memo + sender nametag fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.9",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.9.tgz",
-      "integrity": "sha512-LHKBDpFOP+ZxkprNyWmmOyaqAZuX6tx0oyBfOLIZVythLISYsyWtvdziuc+jzybygzBTE4yucigNX2wjbzbS7A==",
+      "version": "0.9.1-dev.10",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.10.tgz",
+      "integrity": "sha512-vL1TjXcA4PavY/eDNNhqaWQrlq8wJve7yCjxwRwKXIp5Qp8CqhzZT4C/0eQBDcXnIv3cc3UGUaXcJW+xpSaUQw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.9",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Closes the issue above. dev.10 ships sphere-sdk#547 — receiver-side memo + sender-nametag fix on the wallet-api delivery path (recipient-ECDH delivery envelope). One-line pin bump; typecheck clean locally; CI verifies. Pages redeploy on merge gets both fixes onto staging (forward-only — new transfers show `@nametag` + memo to the recipient).