### PR TITLE
Bump sphere-sdk to dev.11 (history reload fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.10",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.10.tgz",
-      "integrity": "sha512-vL1TjXcA4PavY/eDNNhqaWQrlq8wJve7yCjxwRwKXIp5Qp8CqhzZT4C/0eQBDcXnIv3cc3UGUaXcJW+xpSaUQw==",
+      "version": "0.9.1-dev.11",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.11.tgz",
+      "integrity": "sha512-z0Y1Ld69RmhJfsH0nDHOS5AUg8rzQuMBytK67eBTALxOOe4FQXqdO5GOwVn0DuI1eLLENauDvtPS+qx0LCCm8w==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.10",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Closes #364. dev.11 ships sphere-sdk#550 — transaction history hydrates from GET /v1/history on reload (the history twin of the inventory reload fix). One-line pin bump; CI verifies; Pages redeploy restores history on staging.