### PR TITLE
Bump sphere-sdk to dev.12 (payment-request memo fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.12",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.11",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.11.tgz",
-      "integrity": "sha512-z0Y1Ld69RmhJfsH0nDHOS5AUg8rzQuMBytK67eBTALxOOe4FQXqdO5GOwVn0DuI1eLLENauDvtPS+qx0LCCm8w==",
+      "version": "0.9.1-dev.12",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.12.tgz",
+      "integrity": "sha512-tSRpJHQUsNhIl4lGTY/DdMkblTxSXmWln7xjuvy0CzddlhwfxB/GlkqXNFz4c17GYeDtbgZtfN4OaU+tzGTSOA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.11",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.12",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Closes #367. dev.12 ships sphere-sdk#554 — payment-request message+nametag recipient-ECDH (payer-readable). Pages redeploy brings it to staging.