### PR TITLE
fix(ci): per-operation gh-pages concurrency so a cleanup can't cancel a deploy (#369)

### DIFF
--- a/.github/workflows/deploy-pages-branch.yml
+++ b/.github/workflows/deploy-pages-branch.yml
@@ -9,9 +9,36 @@ on:
 permissions:
   contents: write  # Needed to push to gh-pages branch
 
+# Per-operation concurrency (sphere#369). Deploys are keyed per-branch
+# (`deploy-<branch>`) and delete-cleanups per-deleted-ref (`cleanup-<type>-<ref>`)
+# in DISJOINT namespaces, so a branch-deletion cleanup can never share a group
+# with — and therefore can never cancel — any branch's deploy.
+#
+# The old global `gh-pages-deploy` group (with cancel-in-progress: false) put
+# the push-deploy and the delete-cleanup in the SAME group. On a squash-merge
+# that also deletes the PR branch, both runs become pending together; GitHub
+# keeps only the newest pending run per group and cancels the older one, so the
+# just-merged deploy was silently cancelled and staging kept the old bundle.
+# Note `github.ref` is NOT a fix on its own: on a `delete` event it resolves to
+# the default branch (`main`), so it would still collide a deploy of `main` with
+# any cleanup. The event-aware prefixed key below is collision-free regardless
+# of which branch is the default. (ref_type is folded into the cleanup key so a
+# branch and a same-named tag deleted together don't share a cleanup group.)
+#
+# Trade-off vs. the old design: the global group serialized ALL gh-pages pushes,
+# so they never raced. These per-op groups let pushes of DIFFERENT refs overlap,
+# and peaceiris pushes non-force with no retry (verified against the action
+# source). So two near-simultaneous deploys (two branches whose ~2-min builds
+# finish together) — or the run's two sequential pushes, build-and-deploy then
+# deploy-redirect, when a foreign push interleaves — can fail with a re-runnable
+# non-fast-forward error (re-run the workflow). That is never a folder-restore
+# and never a silent no-ship: a loud, recoverable failure replacing #369's
+# invisible one. (A deploy-vs-cleanup overlap is rarer still: a deploy pushes
+# only after its build, by which point a seconds-fast cleanup has already landed
+# and the deploy fast-forwards cleanly.)
 concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
+  group: pages-${{ github.event_name == 'delete' && format('cleanup-{0}-{1}', github.event.ref_type, github.event.ref) || format('deploy-{0}', github.ref_name) }}
+  cancel-in-progress: true
 
 jobs:
   # Cleanup job - runs when a branch is deleted


### PR DESCRIPTION
## Problem (Closes #369)

`deploy-pages-branch.yml` used a single global concurrency group
(`gh-pages-deploy`, `cancel-in-progress: false`) shared by the **push-deploy**
and the **delete-cleanup**. A squash-merge that also deletes the PR branch fires
both a `push` (integration branch) and a `delete` (PR branch) near-simultaneously
→ both runs land in the same group as *pending*. GitHub keeps only the newest
pending run per group and **cancels the older** → the just-merged deploy was
silently cancelled and staging kept serving the previous bundle. Non-deterministic:
dev.11 won the race, dev.12 lost it.

## Fix

Key the group **per operation** so deploys and cleanups are in disjoint
namespaces:

| event | group |
|---|---|
| push / dispatch | `pages-deploy-<branch>` |
| delete | `pages-cleanup-<ref_type>-<ref>` |

A cleanup can no longer share a group with — and therefore can't cancel — any
deploy. `cancel-in-progress: true` lets a newer same-branch deploy supersede an
older one (the newest commit is always what we want shipped).

`github.ref` alone wouldn't fix it: on a `delete` event it resolves to the
**default branch (`main`)**, so it would still collide a deploy of `main` with
any cleanup. The prefixed, event-aware key is collision-free regardless of the
default branch.

## Verification

Reviewed adversarially. GHA concurrency semantics confirmed against GitHub docs
("any existing pending job or workflow in the same concurrency group will be
canceled"); peaceiris push behaviour confirmed against the action source
(non-force, no retry). Walked every group string literally for: squash-merge,
deploy-of-`main` + concurrent cleanup, two rapid same-branch merges,
`workflow_dispatch`, and tag-delete — all disjoint / correct. The expression is a
valid GHA `A && format() || format()` ternary (both branches always truthy).
CI on this PR: `build-and-deploy`, `deploy-redirect`, and `build` all green;
`cleanup` correctly skipped.

## Residual (documented in the workflow comment)

The old global group serialized *all* gh-pages pushes. Per-op groups let pushes
of different refs overlap; since peaceiris pushes non-force with no retry, a race
now fails with a **re-runnable non-fast-forward error** (remedy: re-run the
workflow) instead of #369's silent no-ship — never a folder-restore, never a
silent loss. A loud, recoverable failure replacing an invisible one. (If push-race
flakiness is ever observed, the follow-up is a single-flight on the push step — not
a revert to the global group, which would reintroduce #369.)
