### PR TITLE
Bump sphere-sdk to 0.9.1-dev.14 (serialized-build release, #548)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.14",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.13",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.13.tgz",
-      "integrity": "sha512-ijFOa6LS8pLU76SpObNP1inwmJiKezCyBpUtGSj/gg42hgoL3vNvN4rbcUg5S2qXnDFa27LUG4vJCA+6gxrrLw==",
+      "version": "0.9.1-dev.14",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.14.tgz",
+      "integrity": "sha512-gZ0nGBZVuVIum/8I9b1T4cFmW/w27GQYqnM4LbgOPDrdF7F17BjfN0+EEGtmpvKIvMS5CFJTNxj3gjf1vk/pBg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.14",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Bumps the frontend pin to `@unicitylabs/sphere-sdk@0.9.1-dev.14` (lockfile updated; deps identical to dev.13, registry integrity verified).

dev.14 is the first release built by the new **serialized tsup build** (sphere-sdk#548 — fixes the ~50% flaky missing `token-engine/index.d.ts`). The dev.14 publish passed the packaging gate on the **first** dispatch. The published artifacts are output-equivalent to dev.13, so this is a housekeeping bump that keeps the pin current and ships the reliably-built SDK to staging on merge (the Pages deploy redeploys).

Closes #371