### PR TITLE
Cross-session UI sync: dev.15 pin + drop resolved payment requests + wake-socket liveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.13",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.13.tgz",
-      "integrity": "sha512-ijFOa6LS8pLU76SpObNP1inwmJiKezCyBpUtGSj/gg42hgoL3vNvN4rbcUg5S2qXnDFa27LUG4vJCA+6gxrrLw==",
+      "version": "0.9.1-dev.15",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.15.tgz",
+      "integrity": "sha512-eWRefN7z6q6MHEoXdX+mRmmjyCaqLZ6Vj/QEst8wP+t80i7LEn3C69d+Yt9pkZXg0E/r6vgOHBmuxyL7t+jWtA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.13",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/components/layout/WalletApiSessionIndicator.tsx
+++ b/src/components/layout/WalletApiSessionIndicator.tsx
@@ -1,34 +1,64 @@
-import { CloudOff } from 'lucide-react';
-import { useSphereContext, useWalletApiSession } from '../../sdk/hooks';
+import { CloudOff, RadioTower } from 'lucide-react';
+import { useSphereContext, useWalletApiSession, useRealtimeStatus } from '../../sdk/hooks';
 import { HeaderTooltip } from './HeaderTooltip';
 
 /**
- * Header badge for the wallet-api session state (#351 / sphere-sdk#515 F3).
+ * Header badge for the wallet-api session state (#351 / sphere-sdk#515 F3) and
+ * the realtime wake-socket liveness (`realtime:status`).
  *
- * Renders ONLY when the wallet-api composition is active and the session is
- * 'offline' — i.e. the SDK could not sign in to the backend, so server
- * custody (inventory + mailbox) is not reachable even though the app booted.
- * The 2026-06-12 incident class: this state must be visible, never log-only.
+ * Two distinct, ordered states (sign-in is the hard failure, takes priority):
+ *  - session 'offline' — the SDK could not sign in, so server custody
+ *    (inventory + mailbox) is unreachable even though the app booted. The
+ *    2026-06-12 incident class: must be visible, never log-only.
+ *  - signed-in but the wake socket is 'reconnecting'/'closed' — cross-session
+ *    updates won't arrive in realtime (they fall back to the slower poll
+ *    backstop). A window can be signed-in while its wake socket is dead, so
+ *    this liveness is surfaced separately from sign-in.
  */
 export function WalletApiSessionIndicator() {
   const { walletApiEnabled } = useSphereContext();
   const { status, lastError } = useWalletApiSession();
+  const { status: realtimeStatus } = useRealtimeStatus();
 
-  if (!walletApiEnabled || status !== 'offline') return null;
+  if (!walletApiEnabled) return null;
 
-  return (
-    <HeaderTooltip
-      label={lastError ?? 'wallet-api sign-in failed — assets are unavailable'}
-    >
-      <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-red-500/10">
-        <span className="relative">
-          <CloudOff className="w-4 h-4 sm:w-5 sm:h-5 text-red-400 dark:text-red-500" />
-          <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
-        </span>
-        <span className="text-xs font-medium text-red-400 dark:text-red-500">
-          Wallet API offline
-        </span>
-      </div>
-    </HeaderTooltip>
-  );
+  if (status === 'offline') {
+    return (
+      <HeaderTooltip
+        label={lastError ?? 'wallet-api sign-in failed — assets are unavailable'}
+      >
+        <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-red-500/10">
+          <span className="relative">
+            <CloudOff className="w-4 h-4 sm:w-5 sm:h-5 text-red-400 dark:text-red-500" />
+            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />
+          </span>
+          <span className="text-xs font-medium text-red-400 dark:text-red-500">
+            Wallet API offline
+          </span>
+        </div>
+      </HeaderTooltip>
+    );
+  }
+
+  // Wake-socket degraded while signed-in: realtime updates are delayed (the
+  // poll backstop still keeps state correct), so this is a milder warning.
+  if (realtimeStatus === 'reconnecting' || realtimeStatus === 'closed') {
+    return (
+      <HeaderTooltip
+        label="Realtime updates paused — reconnecting. Changes from other windows may be delayed."
+      >
+        <div className="relative flex items-center gap-1.5 px-2 py-1.5 sm:px-2.5 sm:py-2 rounded-lg sm:rounded-xl bg-amber-500/10">
+          <span className="relative">
+            <RadioTower className="w-4 h-4 sm:w-5 sm:h-5 text-amber-500 dark:text-amber-400" />
+            <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-amber-500" />
+          </span>
+          <span className="text-xs font-medium text-amber-500 dark:text-amber-400">
+            Reconnecting
+          </span>
+        </div>
+      </HeaderTooltip>
+    );
+  }
+
+  return null;
 }

--- a/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
+++ b/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
@@ -87,10 +87,22 @@ export const useIncomingPaymentRequests = () => {
         // mounted (e.g. the wallet-api sign-in backfill) are not re-emitted.
         refresh();
 
+        // The SDK list is the source of truth: on incoming AND on resolution
+        // (paid / rejected / expired), the SDK advances the request's status in
+        // its own list, then emits. Re-reading drops a request resolved
+        // elsewhere (another window — or this wallet's other session) out of
+        // the actionable (PENDING) state, so its Pay/Decline buttons disappear:
+        // the UI half of the cross-session-sync fix.
         const handler = () => refresh();
         sphere.on('payment_request:incoming', handler);
+        sphere.on('payment_request:paid', handler);
+        sphere.on('payment_request:rejected', handler);
+        sphere.on('payment_request:expired', handler);
         return () => {
             sphere.off('payment_request:incoming', handler);
+            sphere.off('payment_request:paid', handler);
+            sphere.off('payment_request:rejected', handler);
+            sphere.off('payment_request:expired', handler);
         };
     }, [sphere, refresh]);
 

--- a/src/sdk/hooks/core/useRealtimeStatus.ts
+++ b/src/sdk/hooks/core/useRealtimeStatus.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { useSphereContext } from './useSphere';
+
+/**
+ * Wake-socket liveness (sphere-sdk `realtime:status`): the true state of the
+ * §9 realtime wake channel — DISTINCT from the wallet-api sign-in session
+ * (`walletapi:session`). A window can be signed-in while its wake socket is
+ * dead, so cross-session updates would only land via the slower poll backstop.
+ */
+export type RealtimeStatus = 'connecting' | 'connected' | 'reconnecting' | 'closed' | null;
+
+export interface UseRealtimeStatusReturn {
+  /** null until the first `realtime:status` event arrives (no SDK getter). */
+  status: RealtimeStatus;
+}
+
+/**
+ * Mirrors the SDK `realtime:status` event into React so the Header can reflect
+ * real wake-socket health (connected vs reconnecting/closed) rather than just
+ * sign-in state. The wake is only a nudge — this is a liveness indicator, never
+ * a correctness gate (the poll backstop carries correctness while reconnecting).
+ */
+export function useRealtimeStatus(): UseRealtimeStatusReturn {
+  const { sphere } = useSphereContext();
+  const [status, setStatus] = useState<RealtimeStatus>(null);
+
+  useEffect(() => {
+    if (!sphere) {
+      setStatus(null);
+      return;
+    }
+
+    // No SDK getter for the current wake-socket state — seed from the event.
+    // The socket emits 'connecting'/'connected' on (re)establish, so the
+    // indicator converges within one wake-channel lifecycle.
+    const handleStatus = (data: { status: Exclude<RealtimeStatus, null> }) => {
+      setStatus(data.status);
+    };
+
+    sphere.on('realtime:status', handleStatus);
+    return () => {
+      sphere.off('realtime:status', handleStatus);
+    };
+  }, [sphere]);
+
+  return { status };
+}

--- a/src/sdk/hooks/index.ts
+++ b/src/sdk/hooks/index.ts
@@ -11,6 +11,8 @@ export { useIpfsSync } from './core/useIpfsSync';
 export type { IpfsSyncStatus, IpfsSyncState, UseIpfsSyncReturn } from './core/useIpfsSync';
 export { useWalletApiSession } from './core/useWalletApiSession';
 export type { WalletApiSessionStatus, UseWalletApiSessionReturn } from './core/useWalletApiSession';
+export { useRealtimeStatus } from './core/useRealtimeStatus';
+export type { RealtimeStatus, UseRealtimeStatusReturn } from './core/useRealtimeStatus';
 
 // Payments (L3)
 export { useTokens } from './payments/useTokens';

--- a/src/sdk/hooks/payments/useAssets.ts
+++ b/src/sdk/hooks/payments/useAssets.ts
@@ -23,7 +23,7 @@ export interface UseAssetsReturn {
 }
 
 export function useAssets(): UseAssetsReturn {
-  const { sphere } = useSphereContext();
+  const { sphere, walletApiEnabled } = useSphereContext();
   const registryReady = useRegistryReady();
   const queryClient = useQueryClient();
 
@@ -35,6 +35,10 @@ export function useAssets(): UseAssetsReturn {
     },
     enabled: !!sphere,
     staleTime: 30_000,
+    // wallet-api mode: refetch on focus so a tab backgrounded with a dead wake
+    // socket refreshes on return (realtime invalidation is the primary path;
+    // TanStack dedupes). Local-only mode keeps the global default (no server).
+    refetchOnWindowFocus: walletApiEnabled,
   });
 
   // If the token registry finishes loading AFTER the first getAssets() call,

--- a/src/sdk/hooks/payments/useBalance.ts
+++ b/src/sdk/hooks/payments/useBalance.ts
@@ -18,7 +18,7 @@ export interface UseBalanceReturn {
  * @param coinId - Coin ID to get balance for, or undefined for total portfolio value in USD
  */
 export function useBalance(coinId?: string): UseBalanceReturn {
-  const { sphere } = useSphereContext();
+  const { sphere, walletApiEnabled } = useSphereContext();
 
   const query = useQuery({
     queryKey: coinId
@@ -40,6 +40,11 @@ export function useBalance(coinId?: string): UseBalanceReturn {
     },
     enabled: !!sphere,
     staleTime: 30_000,
+    // wallet-api mode: realtime inventory wakes drive invalidation, but a tab
+    // backgrounded with a dead wake socket can miss them — refetch on focus as
+    // a cheap backstop (TanStack dedupes against the realtime path). Local-only
+    // mode keeps the global refetchOnWindowFocus:false (no server to re-poll).
+    refetchOnWindowFocus: walletApiEnabled,
   });
 
   const asset = (coinId && query.data && typeof query.data !== 'number') ? query.data as Asset : null;

--- a/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
+++ b/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
@@ -81,6 +81,15 @@ function makeFakeSphere(initial: FakeSdkRequest[] = []) {
       requests.unshift(r);
       listeners.get("payment_request:incoming")?.forEach((fn) => fn({ ...r }));
     },
+    // Simulate a resolution driven elsewhere (another window / this wallet's
+    // other session): the SDK advances the status in its own list, THEN emits
+    // the matching event. Mirrors sphere-sdk's paid/rejected/expired surface.
+    _resolveRemote: (id: string, status: "paid" | "rejected" | "expired") => {
+      const r = find(id);
+      if (r) r.status = status;
+      const evt = `payment_request:${status}`;
+      listeners.get(evt)?.forEach((fn) => fn(r ? { ...r } : { id, status }));
+    },
   };
   return sphere;
 }
@@ -122,6 +131,30 @@ describe("useIncomingPaymentRequests", () => {
     await waitFor(() => expect(result.current.requests).toHaveLength(1));
     expect(result.current.pendingCount).toBe(1);
   });
+
+  it.each([
+    ["paid", PaymentRequestStatus.PAID],
+    ["rejected", PaymentRequestStatus.REJECTED],
+    ["expired", PaymentRequestStatus.EXPIRED],
+  ] as const)(
+    "drops a request from the actionable view on payment_request:%s (cross-session)",
+    async (sdkStatus, uiStatus) => {
+      fakeSphere = makeFakeSphere([makeRequest("a")]);
+      const { result } = renderHook(() => useIncomingPaymentRequests());
+      expect(result.current.pendingCount).toBe(1);
+      expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+
+      // Another window (or this wallet's other session) resolves the request.
+      act(() => {
+        fakeSphere!._resolveRemote("a", sdkStatus);
+      });
+
+      // The request leaves the actionable (PENDING) state — its Pay/Decline
+      // buttons disappear — and the status reflects the resolution.
+      await waitFor(() => expect(result.current.requests[0].status).toBe(uiStatus));
+      expect(result.current.pendingCount).toBe(0);
+    },
+  );
 
   it("pays through payments.payPaymentRequest (no raw transfer + paid flip)", async () => {
     fakeSphere = makeFakeSphere([makeRequest("a")]);


### PR DESCRIPTION
Closes #373. Step 6 (frontend) of the cross-session-sync fix — the backend + SDK steps (1-5) are merged and published as `@unicitylabs/sphere-sdk@0.9.1-dev.15`.

## Changes

### 1. Pin bump -> `0.9.1-dev.15`
Surgical bump (the auto-install churned unrelated `@tailwindcss/oxide-wasm32-wasi` bundled deps and added a `^`, so it was reset). The diff touches the `@unicitylabs/sphere-sdk` entry ONLY — version + `resolved` + `integrity`, exact-pin style preserved. `npm ci` reinstalls clean (integrity matches), no lockfile churn.

> Note: the base branch `feat/wallet-api-integration` was at **dev.13** (the dev.14 bump lives only on the unmerged `chore/bump-sphere-sdk-dev.14` branch), so this is dev.13 -> dev.15. The dep tree is identical across dev.13->dev.15.

dev.15's `SphereEventType` now includes `payment_request:expired` and `realtime:status`.

### 2. Drop resolved requests from the actionable view
`src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts` previously subscribed only to `payment_request:incoming`. It now ALSO subscribes to `payment_request:paid` / `:rejected` / `:expired`, re-reading `sphere.payments.getPaymentRequests()` (the SDK list is the source of truth) on each — same pattern as the existing `:incoming` handler. A request resolved in another window (or this wallet's other session) advances out of PENDING, so its Pay/Decline buttons disappear. This is the UI half of "window B keeps showing a request A already paid."

### 3. Surface wake-socket liveness
New `src/sdk/hooks/core/useRealtimeStatus.ts` mirrors the `realtime:status` event (`connecting | connected | reconnecting | closed`). `WalletApiSessionIndicator` now shows a milder amber "Reconnecting" badge when signed-in but the wake socket is `reconnecting`/`closed` — distinct from the existing red sign-in offline badge. A window can be signed-in while its wake socket is dead; that's now visible. (No SDK getter exists for the current wake status, so the hook seeds from the event.)

### 4. Defense-in-depth (inventory)
`useBalance`/`useAssets` enable `refetchOnWindowFocus` in wallet-api mode only (gated on `walletApiEnabled`), so a tab backgrounded with a dead wake socket refreshes on return. Realtime invalidation (`sync:remote-update` -> `invalidatePayments`) stays the primary path; TanStack dedupes, and local-only mode keeps the global `refetchOnWindowFocus:false`.

## Local test results (node:22 container, real Docker)
- `npm ci` — clean, dev.15 installed, no lockfile churn.
- `npm run build` (`tsc -b` + vite) — green. TypeScript compiles clean against the dev.15 event types.
- `npm run lint` — 0 errors (3 pre-existing warnings in `ExplorePage.tsx`, untouched).
- `npm run test:run` — 65/65 pass.
- New test (3 parameterized cases): a remotely-resolved request drops out of the actionable view. **Verified meaningful** — the cases FAIL on base behavior (Expected PAID/REJECTED/EXPIRED, got PENDING) and pass with the subscription.

## Playwright two-profile smoke — SKIPPED (not faked)
`tests/e2e/two-profile-smoke.spec.ts` is LOCAL-ONLY / not-CI: it requires the full wallet-api dev stack (postgres + redis + minio + mock aggregator + wallet-api) running on loopback AND a real Chromium with public Nostr relay access. The bare `node:22` container has no browser and no backend stack up. Standing up the entire stack + browsers is a milestone-boundary operation beyond this wiring PR; skipped rather than faked. The new unit test covers the resolution-drop behavior deterministically.