### PR TITLE
chore: bump sphere-sdk to 0.9.1-dev.16 (memo nametag fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
+        "@unicitylabs/sphere-sdk": "0.9.1-dev.16",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2756,9 +2756,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.9.1-dev.15",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.15.tgz",
-      "integrity": "sha512-eWRefN7z6q6MHEoXdX+mRmmjyCaqLZ6Vj/QEst8wP+t80i7LEn3C69d+Yt9pkZXg0E/r6vgOHBmuxyL7t+jWtA==",
+      "version": "0.9.1-dev.16",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.9.1-dev.16.tgz",
+      "integrity": "sha512-8AzwaQTZes2vdfP+P2W16X0qofCeZvt+LhsChB4qPi42CEp68UlkLpshzzEQXmuVbE6BP826NVa/IEeIoV52Yw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.9.1-dev.15",
+    "@unicitylabs/sphere-sdk": "0.9.1-dev.16",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Bumps `@unicitylabs/sphere-sdk` from `0.9.1-dev.15` to `0.9.1-dev.16`.

Picks up sphere-sdk #577 / #576: outgoing payment-request/delivery memos now embed the requester's canonical nametag instead of dropping it (the payer previously rendered a raw pubkey). The SDK change is backward-compatible (added an optional `getCurrentNametag` deps field + an internal fix; no public API changed), so **no app-code change is required**.

Verification (node:22 container):
- `npm install` updated the lockfile; it resolves `@unicitylabs/sphere-sdk@0.9.1-dev.16`.
- `npm run build` (`tsc -b && vite build`) passed — typecheck + bundle green.
- `npm run test:run` (vitest) — 65 tests passed across 7 files.

Refs #375 — **this PR targets `feat/wallet-api-integration` (a non-default base), so squash-merge will NOT auto-close #375; close it manually after merge.**