### PR TITLE
Connect: SDK 0.10.1 + surface gate rejection reason in the wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.10.0",
+        "@unicitylabs/sphere-sdk": "0.10.1",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -1317,18 +1317,18 @@
       "optional": true
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.19.tgz",
-      "integrity": "sha512-hYNeHQpUSwLPopWCgDf6OklOvVwJPS/vYZOiBG3VXPIzx5AkONBOfdkgVwB4YsIBH2V6z+TMgMH0yXUZsMurPA==",
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.20.tgz",
+      "integrity": "sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.2.3",
+        "@libp2p/interface": "^3.2.4",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
-        "protons-runtime": "^6.0.1",
-        "uint8arraylist": "^2.4.8",
+        "protons-runtime": "^7.0.0",
+        "uint8arraylist": "^3.0.2",
         "uint8arrays": "^6.1.1"
       }
     },
@@ -1340,9 +1340,9 @@
       "optional": true
     },
     "node_modules/@libp2p/interface": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.3.tgz",
-      "integrity": "sha512-OKZFrY+x8IYl4Fr/YWjh4s6+uks5zQBIAdg2cl+zaRUpPORfk1ELI4r+eB+fUlXR9mHDsQylSSzmAqi0drDfiA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.4.tgz",
+      "integrity": "sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
@@ -1351,7 +1351,7 @@
         "main-event": "^1.0.1",
         "multiformats": "^14.0.0",
         "progress-events": "^1.1.0",
-        "uint8arraylist": "^2.4.8"
+        "uint8arraylist": "^3.0.2"
       }
     },
     "node_modules/@libp2p/interface/node_modules/multiformats": {
@@ -1362,17 +1362,39 @@
       "optional": true
     },
     "node_modules/@libp2p/logger": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.8.tgz",
-      "integrity": "sha512-oPTkWJhYvhk8fjInH1ySyUDC/LLuqHsVqpNprtImd/64lnRHInV0EbwpRYwjdPNXAxYXDU/eQJzyqMWUNnN4+A==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.9.tgz",
+      "integrity": "sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.2.3",
+        "@libp2p/interface": "^3.2.4",
         "@multiformats/multiaddr": "^13.0.3",
-        "interface-datastore": "^9.0.1",
+        "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
         "weald": "^1.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-datastore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-10.0.1.tgz",
+      "integrity": "sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2",
+        "interface-store": "^8.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/interface-store": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+      "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-error": "^1.0.2"
       }
     },
     "node_modules/@libp2p/logger/node_modules/multiformats": {
@@ -1383,14 +1405,14 @@
       "optional": true
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.10.tgz",
-      "integrity": "sha512-FgXeraxl932zim/K+vipCkscjLNMsyNVBh1NpGcJ+y8DQi/jgFXV4YZ0M2JuWM20GTcVCqDT5P10A0DJHRjecg==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.11.tgz",
+      "integrity": "sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/crypto": "^5.1.19",
-        "@libp2p/interface": "^3.2.3",
+        "@libp2p/crypto": "^5.1.20",
+        "@libp2p/interface": "^3.2.4",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
@@ -1448,12 +1470,12 @@
       "optional": true
     },
     "node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2728,6 +2750,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@unicitylabs/nostr-js-sdk/node_modules/@noble/curves": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
@@ -2756,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.0.tgz",
-      "integrity": "sha512-MOo4Rd72udmitb7xtfmhXEx/IhqDre8BrjIFfFde2oi4XeFF2kmTF+CBI/bRJI9zkuqlLZ8w6mL3l7GkwMB2kg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.1.tgz",
+      "integrity": "sha512-Kq3xSPkZ8wW32ikaB0CMV5ae34SAv1bseZDF8pNgNEBFb42Oc8SzjUjpSFSxA+XxQXnlePy9BYyeoieB8yBNhw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
@@ -2804,18 +2838,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@unicitylabs/sphere-sdk/node_modules/@noble/ciphers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
-      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
@@ -3054,6 +3076,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -4975,6 +5004,39 @@
         "uint8arrays": "^5.1.0"
       }
     },
+    "node_modules/ipns/node_modules/protons-runtime": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
+      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/ipns/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
     "node_modules/ipns/node_modules/uint8arrays": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
@@ -6320,36 +6382,15 @@
       "license": "MIT"
     },
     "node_modules/protons-runtime": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-6.0.2.tgz",
-      "integrity": "sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-7.0.0.tgz",
+      "integrity": "sha512-r/e72006xoVND4Uvf1aIs4OQOkJaASBU3ip4DzOWAktoKAkTiOYqKoS3TYMBm8HnnYU8+h0uEzr5gIRwk/pmTg==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "uint8-varint": "^2.0.4",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/protons-runtime/node_modules/uint8-varint": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
-      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/protons-runtime/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "uint8-varint": "^3.0.0",
+        "uint8arraylist": "^3.0.0",
+        "uint8arrays": "^6.0.0"
       }
     },
     "node_modules/public-encrypt": {
@@ -7289,7 +7330,7 @@
         "uint8arrays": "^6.1.0"
       }
     },
-    "node_modules/uint8-varint/node_modules/uint8arraylist": {
+    "node_modules/uint8arraylist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
       "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
@@ -7297,26 +7338,6 @@
       "optional": true,
       "dependencies": {
         "uint8arrays": "^6.0.0"
-      }
-    },
-    "node_modules/uint8arraylist": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
-      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/uint8arraylist/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
       }
     },
     "node_modules/uint8arrays": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.10.0",
+    "@unicitylabs/sphere-sdk": "0.10.1",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/pages/ConnectPage.tsx
+++ b/src/pages/ConnectPage.tsx
@@ -13,6 +13,19 @@ import {
   revokeApprovedOrigin,
 } from '../utils/connected-sites';
 
+type RejectionInfo = { dappName: string; code: number; message: string; data: Record<string, unknown> | undefined };
+
+function describeRejection(data: Record<string, unknown> | undefined): string {
+  const reason = data?.reason as string | undefined;
+  if (reason === 'protocol_incompatible') {
+    return 'was built for an older version of Sphere. Its developer needs to update it before it can connect.';
+  }
+  if (reason === 'network_incompatible') {
+    return 'is built for a different Unicity network than your wallet, so it cannot connect here.';
+  }
+  return 'is not compatible with this wallet.';
+}
+
 export function ConnectPage() {
   const [searchParams] = useSearchParams();
   const origin = searchParams.get('origin');
@@ -23,6 +36,7 @@ export function ConnectPage() {
   const [status, setStatus] = useState<'waiting' | 'ready' | 'error'>('waiting');
   const [errorMsg, setErrorMsg] = useState('');
   const [connectedDapp, setConnectedDapp] = useState<string | null>(null);
+  const [rejection, setRejection] = useState<RejectionInfo | null>(null);
 
   // Stable refs so the effect doesn't re-run when these change
   const sphereRef = useRef(sphere);
@@ -117,6 +131,17 @@ export function ConnectPage() {
         }
         return result;
       },
+      onConnectionRejected: (dapp, error, silent) => {
+        // The compatibility gate refused the connection (protocol/network mismatch).
+        // Surface the reason to the user — but stay quiet for background (silent) auto-connect attempts.
+        if (silent) return;
+        setRejection({
+          dappName: dapp?.name ?? 'An app',
+          code: error.code,
+          message: error.message,
+          data: (error.data as Record<string, unknown> | undefined) ?? undefined,
+        });
+      },
       onDisconnect: () => {
         revokeApprovedOrigin(origin);
         setConnectedDapp(null);
@@ -178,6 +203,29 @@ export function ConnectPage() {
       <div className="flex-1 min-h-0 p-3">
         <WalletPanel />
       </div>
+
+      {rejection && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 shadow-xl p-5">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="w-10 h-10 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center shrink-0">
+                <span className="text-amber-600 dark:text-amber-400 text-xl">⚠</span>
+              </div>
+              <h2 className="text-base font-semibold text-gray-900 dark:text-neutral-100">Unable to connect</h2>
+            </div>
+            <p className="text-sm text-gray-700 dark:text-neutral-300">
+              <span className="font-medium">{rejection.dappName}</span> {describeRejection(rejection.data)}
+            </p>
+            <p className="mt-2 text-xs text-gray-400 dark:text-neutral-500">Error code {rejection.code}</p>
+            <button
+              onClick={() => setRejection(null)}
+              className="mt-4 w-full rounded-xl bg-gray-900 dark:bg-neutral-100 text-white dark:text-neutral-900 text-sm font-medium py-2.5 hover:opacity-90 transition"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Bumps @unicitylabs/sphere-sdk to 0.10.1 (Connect compatibility gate) and wires `ConnectHostConfig.onConnectionRejected` in ConnectPage to show a plain-language 'Unable to connect' modal when the gate refuses a dApp (outdated app / wrong network). Technical detail stays in the console log for developers. Refs unicity-sphere/sphere-sdk#596, #597.