### PR TITLE
fix(connect): harden intent handling — validate params, implement receive, scope DM auto-approve (A1-A3, #609)

### DIFF
--- a/src/components/connect/ConnectContext.ts
+++ b/src/components/connect/ConnectContext.ts
@@ -54,7 +54,7 @@ export interface ConnectContextValue {
   /** Register an auto-approve handler for an intent action (bypasses modal) */
   registerAutoIntent: (
     action: string,
-    handler: (action: string, params: Record<string, unknown>) => Promise<{ result?: unknown; error?: { code: number; message: string } }>,
+    handler: (action: string, params: Record<string, unknown>) => Promise<{ result?: unknown; error?: { code: number; message: string } } | null>,
   ) => void;
 }
 

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -13,6 +13,9 @@ import { useSphereContext } from '../../sdk';
 /** Intents this wallet actually implements. Anything else is rejected cleanly. */
 const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint']);
 
+/** Default coin when a send/payment_request intent omits coinId. */
+const DEFAULT_COIN = 'UCT';
+
 type IntentError = { code: number; message: string };
 
 /**
@@ -46,7 +49,7 @@ function validateIntent(action: string, params: Record<string, unknown>): Intent
     if (params.amount == null || String(params.amount).trim() === '') {
       return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "amount"' };
     }
-    if (!resolveCoinId((params.coinId as string | undefined) ?? 'UCT')) {
+    if (!resolveCoinId((params.coinId as string | undefined) ?? DEFAULT_COIN)) {
       return { code: ERROR_CODES.INVALID_PARAMS, message: `Unknown coinId: ${String(params.coinId)}` };
     }
     return null;
@@ -103,6 +106,9 @@ export function ConnectIntentHandler() {
 
   // --- Send Intent: reuse the wallet's SendModal ---
   if (action === 'send') {
+    // validateIntent() above guarantees the coinId resolves; narrow defensively.
+    const coinId = resolveCoinId((params.coinId as string | undefined) ?? DEFAULT_COIN);
+    if (!coinId) return null;
     return (
       <SendModal
         isOpen={true}
@@ -116,7 +122,7 @@ export function ConnectIntentHandler() {
         prefill={{
           to: params.to as string,
           amount: params.amount as string,
-          coinId: resolveCoinId((params.coinId as string | undefined) ?? 'UCT') ?? 'UCT',
+          coinId,
           memo: params.memo as string | undefined,
         }}
         asModal
@@ -126,6 +132,9 @@ export function ConnectIntentHandler() {
 
   // --- Payment Request Intent: reuse SendPaymentRequestModal ---
   if (action === 'payment_request') {
+    // validateIntent() above guarantees the coinId resolves; narrow defensively.
+    const coinId = resolveCoinId((params.coinId as string | undefined) ?? DEFAULT_COIN);
+    if (!coinId) return null;
     return (
       <SendPaymentRequestModal
         isOpen={true}
@@ -139,7 +148,7 @@ export function ConnectIntentHandler() {
         prefill={{
           to: params.to as string,
           amount: params.amount as string,
-          coinId: resolveCoinId((params.coinId as string | undefined) ?? 'UCT') ?? 'UCT',
+          coinId,
           message: params.message as string | undefined,
         }}
         asModal

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -13,21 +13,10 @@ import { useSphereContext } from '../../sdk';
 /** Intents this wallet actually implements. Anything else is rejected cleanly. */
 const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint']);
 
-/** Default coin when a send/payment_request intent omits coinId. */
-const DEFAULT_COIN = 'UCT';
-
 type IntentError = { code: number; message: string };
 
-/**
- * Resolve a coin identifier to its canonical 64-hex coinId.
- * Accepts an already-canonical even-length lowercase hex id (returned as-is) or a
- * registry symbol (e.g. "UCT") resolved to its hex id. Returns null if neither.
- */
-function resolveCoinId(input: unknown): string | null {
-  if (typeof input !== 'string' || input.length === 0) return null;
-  if (/^([0-9a-f]{2})+$/.test(input)) return input;
-  return TokenRegistry.getInstance().getDefinitionBySymbol(input)?.id ?? null;
-}
+/** Canonical coinId: even-length lowercase hex (same shape the mint intent requires). */
+const COIN_ID_RE = /^([0-9a-f]{2})+$/;
 
 /**
  * Validate dApp-supplied intent params up front. Returns a structured error to
@@ -49,8 +38,8 @@ function validateIntent(action: string, params: Record<string, unknown>): Intent
     if (params.amount == null || String(params.amount).trim() === '') {
       return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "amount"' };
     }
-    if (!resolveCoinId((params.coinId as string | undefined) ?? DEFAULT_COIN)) {
-      return { code: ERROR_CODES.INVALID_PARAMS, message: `Unknown coinId: ${String(params.coinId)}` };
+    if (typeof params.coinId !== 'string' || !COIN_ID_RE.test(params.coinId)) {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'coinId must be lowercase even-length hex' };
     }
     return null;
   }
@@ -106,9 +95,6 @@ export function ConnectIntentHandler() {
 
   // --- Send Intent: reuse the wallet's SendModal ---
   if (action === 'send') {
-    // validateIntent() above guarantees the coinId resolves; narrow defensively.
-    const coinId = resolveCoinId((params.coinId as string | undefined) ?? DEFAULT_COIN);
-    if (!coinId) return null;
     return (
       <SendModal
         isOpen={true}
@@ -122,7 +108,7 @@ export function ConnectIntentHandler() {
         prefill={{
           to: params.to as string,
           amount: params.amount as string,
-          coinId,
+          coinId: params.coinId as string,
           memo: params.memo as string | undefined,
         }}
         asModal
@@ -132,9 +118,6 @@ export function ConnectIntentHandler() {
 
   // --- Payment Request Intent: reuse SendPaymentRequestModal ---
   if (action === 'payment_request') {
-    // validateIntent() above guarantees the coinId resolves; narrow defensively.
-    const coinId = resolveCoinId((params.coinId as string | undefined) ?? DEFAULT_COIN);
-    if (!coinId) return null;
     return (
       <SendPaymentRequestModal
         isOpen={true}
@@ -148,7 +131,7 @@ export function ConnectIntentHandler() {
         prefill={{
           to: params.to as string,
           amount: params.amount as string,
-          coinId,
+          coinId: params.coinId as string,
           message: params.message as string | undefined,
         }}
         asModal

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { MessageSquare, PenLine, Coins } from 'lucide-react';
+import { MessageSquare, PenLine, Coins, Inbox } from 'lucide-react';
 import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
 import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
 import { BaseModal, ModalHeader, Button } from '../wallet/ui';
@@ -11,7 +11,7 @@ import { getErrorMessage } from '../../sdk/errors';
 import { useSphereContext } from '../../sdk';
 
 /** Intents this wallet actually implements. Anything else is rejected cleanly. */
-const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint']);
+const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint', 'receive']);
 
 type IntentError = { code: number; message: string };
 
@@ -70,6 +70,8 @@ export function ConnectIntentHandler() {
   const [signError, setSignError] = useState<string | null>(null);
   const [mintError, setMintError] = useState<string | null>(null);
   const [isMinting, setIsMinting] = useState(false);
+  const [receiveError, setReceiveError] = useState<string | null>(null);
+  const [isReceiving, setIsReceiving] = useState(false);
 
   // Validate/normalize params up front: reject malformed or unsupported intents
   // cleanly (INVALID_PARAMS / METHOD_NOT_FOUND) instead of opening a modal that
@@ -154,12 +156,19 @@ export function ConnectIntentHandler() {
         // so it's immune to ConnectHost lifecycle issues.
         if (autoApproveDM && sphere) {
           const sphereRef = sphere;
+          const approvedTo = to;
           registerAutoIntent('dm', async (_action, intentParams) => {
+            const nextTo = intentParams.to;
+            const nextMessage = intentParams.message;
+            // Auto-approval is scoped to the recipient the user approved. A DM to
+            // any other recipient falls back to the normal confirmation modal
+            // (return null) instead of being sent silently.
+            if (typeof nextTo !== 'string' || nextTo !== approvedTo) return null;
+            if (typeof nextMessage !== 'string' || nextMessage === '') {
+              return { error: { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "message"' } };
+            }
             try {
-              const result = await sphereRef.communications.sendDM(
-                intentParams.to as string,
-                intentParams.message as string,
-              );
+              const result = await sphereRef.communications.sendDM(nextTo, nextMessage);
               return { result: { sent: true, messageId: result.id, timestamp: result.timestamp } };
             } catch (err) {
               return {
@@ -380,6 +389,54 @@ export function ConnectIntentHandler() {
             </Button>
             <Button variant="primary" fullWidth disabled={isMinting} onClick={handleMint}>
               {isMinting ? 'Minting…' : 'Mint'}
+            </Button>
+          </div>
+        </div>
+      </BaseModal>
+    );
+  }
+
+  // --- Receive Intent: fetch the user's pending incoming transfers ---
+  if (action === 'receive') {
+    const handleReceive = async () => {
+      setReceiveError(null);
+      if (!sphere) {
+        setReceiveError('Wallet not available');
+        return;
+      }
+      setIsReceiving(true);
+      try {
+        const { transfers } = await sphere.payments.receive();
+        resolveIntent({ transfers });
+      } catch (err) {
+        setReceiveError(getErrorMessage(err));
+      } finally {
+        setIsReceiving(false);
+      }
+    };
+
+    return (
+      <BaseModal isOpen={true} onClose={handleClose}>
+        <ModalHeader title="Check for Transfers" icon={Inbox} onClose={handleClose} />
+
+        <div className="px-6 py-5 flex-1 flex flex-col justify-center">
+          <div className="bg-neutral-100 dark:bg-neutral-900 rounded-2xl p-5 mb-5 border border-neutral-200 dark:border-white/10">
+            <div className="text-sm text-neutral-500">
+              This dApp wants to check your wallet for{' '}
+              <span className="text-neutral-900 dark:text-white font-medium">incoming transfers</span>.
+            </div>
+          </div>
+
+          {receiveError && (
+            <div className="text-red-500 text-sm mb-3 text-center">{receiveError}</div>
+          )}
+
+          <div className="flex gap-3">
+            <Button variant="secondary" fullWidth onClick={handleClose} disabled={isReceiving}>
+              Cancel
+            </Button>
+            <Button variant="primary" fullWidth disabled={isReceiving} onClick={handleReceive}>
+              {isReceiving ? 'Checking…' : 'Check'}
             </Button>
           </div>
         </div>

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -3,8 +3,8 @@ import { MessageSquare, PenLine, Coins, Inbox } from 'lucide-react';
 import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
 import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
 import { BaseModal, ModalHeader, Button } from '../wallet/ui';
-import { SendModal } from '../wallet/L3/modals/SendModal';
-import { SendPaymentRequestModal } from '../wallet/L3/modals/SendPaymentRequestModal';
+import { SendIntentModal } from './SendIntentModal';
+import { PaymentRequestIntentModal } from './PaymentRequestIntentModal';
 import { useConnectContext } from './ConnectContext';
 import { useSendDM } from '../../sdk/hooks/comms/useSendDM';
 import { getErrorMessage } from '../../sdk/errors';
@@ -35,8 +35,13 @@ function validateIntent(action: string, params: Record<string, unknown>): Intent
     if (typeof params.to !== 'string' || params.to.trim() === '') {
       return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "to"' };
     }
-    if (params.amount == null || String(params.amount).trim() === '') {
-      return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "amount"' };
+    // amount is in BASE UNITS (smallest indivisible unit) — a positive integer
+    // string, exactly like the `mint` intent. Whole-token/decimal amounts are
+    // rejected: every major wallet carries dApp-requested amounts in base units
+    // (exactness, no float), and the dApp converts at its own UI edge.
+    const amountStr = params.amount == null ? '' : String(params.amount).trim();
+    if (!/^\d+$/.test(amountStr) || BigInt(amountStr) <= 0n) {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'amount must be a positive integer string in base units' };
     }
     if (typeof params.coinId !== 'string' || !COIN_ID_RE.test(params.coinId)) {
       return { code: ERROR_CODES.INVALID_PARAMS, message: 'coinId must be lowercase even-length hex' };
@@ -95,48 +100,30 @@ export function ConnectIntentHandler() {
     rejectIntent(ERROR_CODES.USER_REJECTED, 'User cancelled');
   };
 
-  // --- Send Intent: reuse the wallet's SendModal ---
+  // --- Send Intent: confirm-only (amount fixed, base units, approve/reject) ---
   if (action === 'send') {
     return (
-      <SendModal
-        isOpen={true}
-        onClose={(result) => {
-          if (result?.success) {
-            resolveIntent({ success: true });
-          } else {
-            rejectIntent(ERROR_CODES.USER_REJECTED, 'User cancelled');
-          }
-        }}
-        prefill={{
-          to: params.to as string,
-          amount: params.amount as string,
-          coinId: params.coinId as string,
-          memo: params.memo as string | undefined,
-        }}
-        asModal
+      <SendIntentModal
+        to={params.to as string}
+        amount={String(params.amount)}
+        coinId={params.coinId as string}
+        memo={params.memo as string | undefined}
+        onResolve={() => resolveIntent({ success: true })}
+        onCancel={handleClose}
       />
     );
   }
 
-  // --- Payment Request Intent: reuse SendPaymentRequestModal ---
+  // --- Payment Request Intent: confirm-only (amount fixed, base units) ---
   if (action === 'payment_request') {
     return (
-      <SendPaymentRequestModal
-        isOpen={true}
-        onClose={(result) => {
-          if (result?.success) {
-            resolveIntent({ success: true, requestId: result.requestId });
-          } else {
-            rejectIntent(ERROR_CODES.USER_REJECTED, 'User cancelled');
-          }
-        }}
-        prefill={{
-          to: params.to as string,
-          amount: params.amount as string,
-          coinId: params.coinId as string,
-          message: params.message as string | undefined,
-        }}
-        asModal
+      <PaymentRequestIntentModal
+        to={params.to as string}
+        amount={String(params.amount)}
+        coinId={params.coinId as string}
+        message={params.message as string | undefined}
+        onResolve={(requestId) => resolveIntent({ success: true, requestId })}
+        onCancel={handleClose}
       />
     );
   }

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { MessageSquare, PenLine, Coins } from 'lucide-react';
 import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
 import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
@@ -10,6 +10,65 @@ import { useSendDM } from '../../sdk/hooks/comms/useSendDM';
 import { getErrorMessage } from '../../sdk/errors';
 import { useSphereContext } from '../../sdk';
 
+/** Intents this wallet actually implements. Anything else is rejected cleanly. */
+const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint']);
+
+type IntentError = { code: number; message: string };
+
+/**
+ * Resolve a coin identifier to its canonical 64-hex coinId.
+ * Accepts an already-canonical even-length lowercase hex id (returned as-is) or a
+ * registry symbol (e.g. "UCT") resolved to its hex id. Returns null if neither.
+ */
+function resolveCoinId(input: unknown): string | null {
+  if (typeof input !== 'string' || input.length === 0) return null;
+  if (/^([0-9a-f]{2})+$/.test(input)) return input;
+  return TokenRegistry.getInstance().getDefinitionBySymbol(input)?.id ?? null;
+}
+
+/**
+ * Validate dApp-supplied intent params up front. Returns a structured error to
+ * reject with (INVALID_PARAMS / METHOD_NOT_FOUND), or null when the intent is
+ * supported and well-formed. `mint` does its own engine-specific validation in
+ * its handler, so it is only checked for support here.
+ */
+function validateIntent(action: string, params: Record<string, unknown>): IntentError | null {
+  if (!SUPPORTED_INTENTS.has(action)) {
+    return {
+      code: ERROR_CODES.METHOD_NOT_FOUND,
+      message: `Intent "${action}" is not supported by this wallet`,
+    };
+  }
+  if (action === 'send' || action === 'payment_request') {
+    if (typeof params.to !== 'string' || params.to.trim() === '') {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "to"' };
+    }
+    if (params.amount == null || String(params.amount).trim() === '') {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "amount"' };
+    }
+    if (!resolveCoinId((params.coinId as string | undefined) ?? 'UCT')) {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: `Unknown coinId: ${String(params.coinId)}` };
+    }
+    return null;
+  }
+  if (action === 'dm') {
+    if (typeof params.to !== 'string' || params.to.trim() === '') {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "to"' };
+    }
+    if (typeof params.message !== 'string' || params.message === '') {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "message"' };
+    }
+    return null;
+  }
+  if (action === 'sign_message') {
+    if (typeof params.message !== 'string' || params.message === '') {
+      return { code: ERROR_CODES.INVALID_PARAMS, message: 'Missing or invalid "message"' };
+    }
+    return null;
+  }
+  return null;
+}
+
 export function ConnectIntentHandler() {
   const { pendingIntent, resolveIntent, rejectIntent, registerAutoIntent } = useConnectContext();
   const { sphere } = useSphereContext();
@@ -20,9 +79,23 @@ export function ConnectIntentHandler() {
   const [mintError, setMintError] = useState<string | null>(null);
   const [isMinting, setIsMinting] = useState(false);
 
+  // Validate/normalize params up front: reject malformed or unsupported intents
+  // cleanly (INVALID_PARAMS / METHOD_NOT_FOUND) instead of opening a modal that
+  // silently hangs (unresolved coinId) or crashes (missing sign_message body).
+  // Runs once per pending intent.
+  useEffect(() => {
+    if (!pendingIntent) return;
+    const error = validateIntent(pendingIntent.action, pendingIntent.params);
+    if (error) rejectIntent(error.code, error.message);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingIntent]);
+
   if (!pendingIntent) return null;
 
   const { action, params } = pendingIntent;
+
+  // Malformed / unsupported intents are rejected by the effect above — render nothing.
+  if (validateIntent(action, params)) return null;
 
   const handleClose = () => {
     rejectIntent(ERROR_CODES.USER_REJECTED, 'User cancelled');
@@ -43,7 +116,7 @@ export function ConnectIntentHandler() {
         prefill={{
           to: params.to as string,
           amount: params.amount as string,
-          coinId: (params.coinId as string) ?? 'UCT',
+          coinId: resolveCoinId((params.coinId as string | undefined) ?? 'UCT') ?? 'UCT',
           memo: params.memo as string | undefined,
         }}
         asModal
@@ -66,7 +139,7 @@ export function ConnectIntentHandler() {
         prefill={{
           to: params.to as string,
           amount: params.amount as string,
-          coinId: (params.coinId as string) ?? 'UCT',
+          coinId: resolveCoinId((params.coinId as string | undefined) ?? 'UCT') ?? 'UCT',
           message: params.message as string | undefined,
         }}
         asModal
@@ -322,18 +395,7 @@ export function ConnectIntentHandler() {
     );
   }
 
-  // --- Unknown Intent ---
-  return (
-    <BaseModal isOpen={true} onClose={handleClose}>
-      <ModalHeader title="Unknown Request" onClose={handleClose} />
-      <div className="px-6 py-5 text-center">
-        <p className="text-neutral-500 mb-4">
-          Unsupported intent: <code className="text-neutral-700 dark:text-neutral-300">{action}</code>
-        </p>
-        <Button variant="secondary" onClick={handleClose}>
-          Dismiss
-        </Button>
-      </div>
-    </BaseModal>
-  );
+  // Unsupported intents are rejected up front by the validation effect
+  // (METHOD_NOT_FOUND), so there is nothing to render here.
+  return null;
 }

--- a/src/components/connect/ConnectProvider.tsx
+++ b/src/components/connect/ConnectProvider.tsx
@@ -21,7 +21,7 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
   const connectHostRef = useRef<ConnectHost | null>(null);
   const [, forceUpdate] = useState(0);
 
-  type AutoHandler = (action: string, params: Record<string, unknown>) => Promise<{ result?: unknown; error?: { code: number; message: string } }>;
+  type AutoHandler = (action: string, params: Record<string, unknown>) => Promise<{ result?: unknown; error?: { code: number; message: string } } | null>;
   // Auto-approve handlers scoped to a specific ConnectHost instance
   const autoIntentHandlersRef = useRef<Map<string, { host: ConnectHost; handler: AutoHandler }>>(new Map());
 
@@ -61,7 +61,10 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
       const entry = autoIntentHandlersRef.current.get(action);
       if (entry && entry.host === connectHostRef.current) {
         try {
-          return await entry.handler(action, params);
+          const handled = await entry.handler(action, params);
+          // A null result means the handler declined (e.g. a DM to a recipient
+          // other than the one the user approved) — fall through to the modal.
+          if (handled) return handled;
         } catch (err) {
           return { error: { code: ERROR_CODES.INTERNAL_ERROR, message: err instanceof Error ? err.message : 'Auto-approve handler failed' } };
         }

--- a/src/components/connect/IntentConfirmModal.tsx
+++ b/src/components/connect/IntentConfirmModal.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { BaseModal, ModalHeader, Button } from '../wallet/ui';
+
+interface IntentConfirmModalProps {
+  /** Modal title shown in the header. */
+  title: string;
+  /** Header icon. */
+  icon: LucideIcon;
+  /** Body content (the amount/recipient card). */
+  children: ReactNode;
+  /** Inline error shown above the action buttons. */
+  error?: string | null;
+  /** Disables the confirm button (e.g. insufficient balance). */
+  confirmDisabled?: boolean;
+  /** True while the underlying action is running. */
+  busy: boolean;
+  /** Confirm button label when idle. */
+  confirmLabel: string;
+  /** Confirm button label while busy. */
+  busyLabel: string;
+  /** Approve — runs the action. */
+  onConfirm: () => void;
+  /** Reject / cancel the dApp request. */
+  onCancel: () => void;
+}
+
+/**
+ * Confirm-only shell for value-bearing Connect intents (`send`,
+ * `payment_request`). Mirrors the `mint` intent's modal: the dApp-supplied
+ * amount is FIXED and shown for review only (approve/reject) — there is no
+ * amount input here. This matches how every major wallet treats a
+ * dApp-requested transfer (MetaMask, Phantom, WalletConnect): the amount
+ * travels in base units and the wallet only formats it for display.
+ */
+export function IntentConfirmModal({
+  title,
+  icon,
+  children,
+  error,
+  confirmDisabled,
+  busy,
+  confirmLabel,
+  busyLabel,
+  onConfirm,
+  onCancel,
+}: IntentConfirmModalProps) {
+  return (
+    <BaseModal isOpen={true} onClose={onCancel}>
+      <ModalHeader title={title} icon={icon} onClose={onCancel} />
+
+      <div className="px-6 py-5 flex-1 flex flex-col justify-center">
+        {children}
+
+        {error && <div className="text-red-500 text-sm mb-3 text-center">{error}</div>}
+
+        <div className="flex gap-3">
+          <Button variant="secondary" fullWidth onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="primary" fullWidth disabled={busy || confirmDisabled} onClick={onConfirm}>
+            {busy ? busyLabel : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/connect/PaymentRequestIntentModal.tsx
+++ b/src/components/connect/PaymentRequestIntentModal.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { Receipt } from 'lucide-react';
+import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
+import { useSphereContext } from '../../sdk';
+import { getErrorMessage } from '../../sdk/errors';
+import { IntentConfirmModal } from './IntentConfirmModal';
+
+interface PaymentRequestIntentModalProps {
+  /** Who should pay: Unicity ID (@tag) or DIRECT:// address, as supplied by the dApp. */
+  to: string;
+  /** Requested amount in BASE UNITS (smallest indivisible unit) — integer string. */
+  amount: string;
+  /** Token coinId (lowercase even-length hex). */
+  coinId: string;
+  message?: string;
+  /** Called after the request is sent (resolves the intent). */
+  onResolve: (requestId?: string) => void;
+  /** Called when the user cancels (rejects the intent). */
+  onCancel: () => void;
+}
+
+/**
+ * Confirm-only modal for the Connect `payment_request` intent. The dApp
+ * specifies who to bill, the coin and the amount (in base units); the user
+ * approves or rejects — the amount is NOT editable here. The base-unit amount is
+ * passed to the SDK verbatim; `formatAmount` renders a human-readable figure for
+ * review only. Coin metadata comes from the registry (a request needs no balance).
+ */
+export function PaymentRequestIntentModal({
+  to,
+  amount,
+  coinId,
+  message,
+  onResolve,
+  onCancel,
+}: PaymentRequestIntentModalProps) {
+  const { sphere } = useSphereContext();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const registry = TokenRegistry.getInstance();
+  const def = registry.getDefinition(coinId);
+  const decimals = def?.decimals ?? 0;
+  const symbol = def?.symbol ?? '';
+  const iconUrl = (def ? registry.getIconUrl(coinId) : null) ?? undefined;
+
+  const displayAmount = formatAmount(amount, { decimals, symbol, maxFractionDigits: 8 });
+
+  const handleSend = async () => {
+    setError(null);
+    if (!sphere) {
+      setError('Wallet not available');
+      return;
+    }
+    setBusy(true);
+    try {
+      const recipient = to.startsWith('DIRECT://') ? to : `@${to.replace(/^@/, '')}`;
+      const result = await sphere.payments.sendPaymentRequest(recipient, {
+        amount,
+        coinId,
+        ...(message ? { message } : {}),
+      });
+      if (!result.success) throw new Error(result.error || 'Failed to send payment request');
+      onResolve(result.requestId || undefined);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <IntentConfirmModal
+      title="Payment Request"
+      icon={Receipt}
+      busy={busy}
+      confirmLabel="Send Request"
+      busyLabel="Sending…"
+      error={error}
+      onConfirm={handleSend}
+      onCancel={onCancel}
+    >
+      <div className="bg-neutral-100 dark:bg-neutral-900 rounded-2xl p-5 mb-5 border border-neutral-200 dark:border-white/10">
+        <div className="text-sm text-neutral-500 mb-4">
+          This dApp wants to send a payment request on your behalf.
+        </div>
+
+        <div className="flex items-center gap-3 mb-3">
+          {iconUrl && <img src={iconUrl} alt="" className="w-9 h-9 rounded-full shrink-0" />}
+          <span className="text-2xl font-semibold text-neutral-900 dark:text-white break-all">
+            {displayAmount}
+          </span>
+        </div>
+
+        <div className="text-[11px] text-neutral-400 break-all mb-1">
+          <span className="text-neutral-500 dark:text-neutral-400">Requested from:</span>{' '}
+          <span className="font-mono">{to}</span>
+        </div>
+
+        {!def && (
+          <div className="mt-1 text-amber-600 dark:text-amber-500 text-xs break-all">
+            Unrecognized coin ({coinId}) — verify before approving
+          </div>
+        )}
+
+        {message && (
+          <div className="text-sm text-neutral-500 dark:text-white/45 italic mt-2">&ldquo;{message}&rdquo;</div>
+        )}
+      </div>
+    </IntentConfirmModal>
+  );
+}

--- a/src/components/connect/SendIntentModal.tsx
+++ b/src/components/connect/SendIntentModal.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { Send } from 'lucide-react';
+import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
+import { useAssets, useTransfer } from '../../sdk';
+import { getErrorMessage } from '../../sdk/errors';
+import { IntentConfirmModal } from './IntentConfirmModal';
+
+interface SendIntentModalProps {
+  /** Recipient: Unicity ID (@tag) or DIRECT:// address, as supplied by the dApp. */
+  to: string;
+  /** Amount in BASE UNITS (smallest indivisible unit) — integer string. */
+  amount: string;
+  /** Token coinId (lowercase even-length hex). */
+  coinId: string;
+  memo?: string;
+  /** Called after the transfer succeeds (resolves the intent). */
+  onResolve: () => void;
+  /** Called when the user cancels (rejects the intent). */
+  onCancel: () => void;
+}
+
+/**
+ * Confirm-only modal for the Connect `send` intent. The dApp specifies the
+ * recipient, coin and amount (in base units); the user approves or rejects — the
+ * amount is NOT editable here (a different amount = a different dApp request).
+ * The base-unit amount is handed to the SDK verbatim; `formatAmount` is used only
+ * to render a human-readable figure for review.
+ */
+export function SendIntentModal({ to, amount, coinId, memo, onResolve, onCancel }: SendIntentModalProps) {
+  const { assets } = useAssets();
+  const { transfer } = useTransfer();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Prefer the held asset (gives balance); fall back to the registry for
+  // metadata when the coin isn't held, so we can still display it sensibly.
+  const asset = assets.find((a) => a.coinId === coinId);
+  const registry = TokenRegistry.getInstance();
+  const def = registry.getDefinition(coinId);
+  const decimals = asset?.decimals ?? def?.decimals ?? 0;
+  const symbol = asset?.symbol ?? def?.symbol ?? '';
+  const iconUrl = asset?.iconUrl ?? (def ? registry.getIconUrl(coinId) : null) ?? undefined;
+
+  // `amount` is validated as a positive integer (base units) before this renders.
+  const amountBig = BigInt(amount);
+  const held = asset ? BigInt(asset.totalAmount) : 0n;
+  const insufficient = amountBig > held;
+
+  const displayAmount = formatAmount(amount, { decimals, symbol, maxFractionDigits: 8 });
+
+  const handleSend = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const recipient = to.startsWith('DIRECT://') ? to : to.replace(/^@/, '');
+      await transfer({ coinId, amount, recipient, ...(memo ? { memo } : {}) });
+      onResolve();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <IntentConfirmModal
+      title="Send Tokens"
+      icon={Send}
+      busy={busy}
+      confirmLabel="Send"
+      busyLabel="Sending…"
+      confirmDisabled={insufficient}
+      error={error}
+      onConfirm={handleSend}
+      onCancel={onCancel}
+    >
+      <div className="bg-neutral-100 dark:bg-neutral-900 rounded-2xl p-5 mb-5 border border-neutral-200 dark:border-white/10">
+        <div className="text-sm text-neutral-500 mb-4">
+          This dApp is asking to send tokens from your wallet.
+        </div>
+
+        <div className="flex items-center gap-3 mb-3">
+          {iconUrl && <img src={iconUrl} alt="" className="w-9 h-9 rounded-full shrink-0" />}
+          <span className="text-2xl font-semibold text-neutral-900 dark:text-white break-all">
+            {displayAmount}
+          </span>
+        </div>
+
+        <div className="text-[11px] text-neutral-400 break-all mb-1">
+          <span className="text-neutral-500 dark:text-neutral-400">To:</span>{' '}
+          <span className="font-mono">{to}</span>
+        </div>
+
+        {memo && (
+          <div className="text-sm text-neutral-500 dark:text-white/45 italic mt-2">&ldquo;{memo}&rdquo;</div>
+        )}
+
+        {insufficient && (
+          <div className="mt-3 text-amber-600 dark:text-amber-500 text-xs break-all">
+            {asset
+              ? `Insufficient balance — you have ${formatAmount(asset.totalAmount, { decimals, symbol, maxFractionDigits: 8 })}`
+              : "You don't hold this token"}
+          </div>
+        )}
+      </div>
+    </IntentConfirmModal>
+  );
+}


### PR DESCRIPTION
## What

Hardens the wallet's Connect intent handling so dApp intents are validated and handled correctly instead of silently hanging, crashing, granting-then-rejecting, or over-permitting.

Part of #609 — tracks **A1 / A2 / A3**.

## A1 — param validation & clean rejection (`ConnectIntentHandler.tsx`)

- Centralized `validateIntent()` + a one-shot effect that rejects the pending intent before any modal renders.
- **W3** — `sign_message` no longer crashes the render when `message` is missing (was `undefined.match()` in the render body); missing/invalid `message` → `INVALID_PARAMS`.
- **W4 / W5** — `send` / `payment_request` now **require a canonical 64-hex `coinId`** (same check as `mint`); missing/non-hex → `INVALID_PARAMS`. The old default symbol `'UCT'` never matched the 64-hex `Asset.coinId`, causing a silent hang — removed (no symbol resolution, no symbol default).
- **W6** — `dm` validates `to`/`message` → `INVALID_PARAMS`.
- **W1 (UX)** — unsupported intents (`create_invoice` … `set_auto_return`) reject immediately with `METHOD_NOT_FOUND` ("not supported by this wallet") instead of granting then `USER_REJECTED`, matching the gate decision that invoicing is experimental and not enabled (#609).

## A2 — implement `receive` (`ConnectIntentHandler.tsx`)

- The `receive` intent now fetches pending incoming transfers via `sphere.payments.receive()` behind a confirmation modal, and resolves with `{ transfers }` (previously rejected as unsupported).

## A3 — scope DM auto-approve to the approved recipient (`ConnectIntentHandler.tsx`, `ConnectProvider.tsx`, `ConnectContext.ts`)

- After the user enables "send DMs without confirmation", the auto-approve is now scoped to **the recipient they approved**. A DM to any other recipient falls back to the normal confirmation modal (the auto-handler returns `null`) instead of being sent silently; the message param is validated.
- Adds a `null` ("declined → show modal") return to the auto-intent handler contract.

## Behavior change

`send` / `payment_request` now require a canonical 64-hex `coinId` (consistent with `mint`). Omitting it or passing a symbol like `'UCT'` returns `INVALID_PARAMS` instead of the previous silent hang. The dApp-facing docs (#609 track B1) will be updated to state `coinId` is the 64-hex id.

## Not in this PR (tracked separately)

- W8 (approval-modal `setState` during render) → A4 (separate PR).
- Invoicing stays disabled by decision (#609).
- Residual: a valid-but-not-held `coinId` still opens the send modal on the asset-selection step (the user can cancel → `USER_REJECTED`).

## Verification

- `tsc -b` → clean (exit 0).
- `eslint .` → 0 errors (only 3 pre-existing warnings in an unrelated file `ExplorePage.tsx`).
