### PR TITLE
fix(connect): seed approval permissions in an effect, not during render (A4, #609)

### DIFF
--- a/src/components/connect/ConnectionApprovalModal.tsx
+++ b/src/components/connect/ConnectionApprovalModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Plug, Shield } from 'lucide-react';
 import { PERMISSION_SCOPES } from '@unicitylabs/sphere-sdk/connect';
 import type { PermissionScope } from '@unicitylabs/sphere-sdk/connect';
@@ -24,17 +24,21 @@ export function ConnectionApprovalModal() {
   const { pendingApproval, approveConnection, denyConnection } = useConnectContext();
   const [selected, setSelected] = useState<Set<PermissionScope>>(new Set());
 
+  // Initialize the selected permissions whenever a new approval arrives.
+  // identity:read is always granted. (Effect — not setState during render.)
+  useEffect(() => {
+    if (!pendingApproval) {
+      setSelected(new Set());
+      return;
+    }
+    const initial = new Set(pendingApproval.permissions);
+    initial.add(PERMISSION_SCOPES.IDENTITY_READ as PermissionScope);
+    setSelected(initial);
+  }, [pendingApproval]);
+
   if (!pendingApproval) return null;
 
   const { dapp, permissions } = pendingApproval;
-
-  // Initialize selected permissions on first render
-  if (selected.size === 0 && permissions.length > 0) {
-    const initial = new Set(permissions);
-    // identity:read is always granted
-    initial.add(PERMISSION_SCOPES.IDENTITY_READ as PermissionScope);
-    setSelected(initial);
-  }
 
   const togglePermission = (perm: PermissionScope) => {
     if (perm === PERMISSION_SCOPES.IDENTITY_READ) return; // always granted


### PR DESCRIPTION
## What

Fixes a React anti-pattern in the Connect approval modal: it initialized its `selected` permission set by calling `setSelected(...)` **during render** (`if (selected.size === 0 && permissions.length > 0) setSelected(...)`).

Part of #609 — track **A4** (finding W8).

## Change (`src/components/connect/ConnectionApprovalModal.tsx`)

- Move the permission-set initialization into a `useEffect` keyed on `pendingApproval` (and reset to empty when there is no pending approval). `identity:read` is still always added.

This removes the setState-during-render call (which can trigger an extra render and is fragile if `permissions` ever changes for the same approval). Behavior is otherwise unchanged: when an approval arrives, all requested scopes plus `identity:read` start selected.

## Verification

- `tsc -b` → clean (exit 0).
- `eslint` on the file → clean (exit 0).
