### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk 0.10.3 → 0.10.4 (old-browser AbortSignal.timeout fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.10.3",
+        "@unicitylabs/sphere-sdk": "0.10.4",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.3.tgz",
-      "integrity": "sha512-+ZD4KCJXsCEs5KLLncK1MVx/upm8aBLRAkc7VXX4QylzcDYbMx6gxwN5GhVkjoJEOeoL3c52wwtiYsEdNX0leg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.4.tgz",
+      "integrity": "sha512-HK8n3namZakMa2j6Bjyf36k0SmpKaDipHicRSM+aUTf0I0sQgHU5TAcTYMvFJ2dKmuahjy8roBlqwZigh6hiEQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.10.3",
+    "@unicitylabs/sphere-sdk": "0.10.4",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Closes #386

Bumps `@unicitylabs/sphere-sdk` to **0.10.4**, which guards `AbortSignal.timeout` behind a feature-detect + `AbortController`/`setTimeout` fallback (sphere-sdk#617 / unicity-sphere/sphere-sdk#618).

**User impact:** **Swap** and **Top Up** no longer crash with `AbortSignal.timeout is not a function` on iOS 15.x, older Android WebViews, and in-app/embedded browsers. Both flows route through the SDK's send engine, which called the unguarded API.

Exact pin (program convention). Verified locally:
- `npm run build` (tsc -b && vite build) — clean
- `npm run lint` — 0 errors (3 pre-existing warnings)
- `npm run test:run` — 65 passed