### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk 0.10.4 → 0.10.5 (crypto.randomUUID hardening)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.10.4",
+        "@unicitylabs/sphere-sdk": "0.10.5",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.4.tgz",
-      "integrity": "sha512-HK8n3namZakMa2j6Bjyf36k0SmpKaDipHicRSM+aUTf0I0sQgHU5TAcTYMvFJ2dKmuahjy8roBlqwZigh6hiEQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.5.tgz",
+      "integrity": "sha512-yYWiWEtq8VPvrniFHe55g2npLdkT1fjf919GmbqoH5uEW1vtBwoDIMP21WrpUUCKwZj0kDA8KPxJFAIUimHv1g==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.10.4",
+    "@unicitylabs/sphere-sdk": "0.10.5",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Closes #389

Bumps `@unicitylabs/sphere-sdk` to **0.10.5**, which routes bare `crypto.randomUUID()` calls through a browser-safe helper (native `crypto.randomUUID` → `crypto.getRandomValues` fallback) — sphere-sdk#619 / unicity-sphere/sphere-sdk#620.

**User impact:** prevents `crypto.randomUUID is not a function` on the spend/transfer path on sub-15.4 in-app/WebView browsers and non-HTTPS/insecure-context origins. (Secondary hardening; the user-reported Swap/Top Up `AbortSignal.timeout` crash was already fixed in 0.10.4 / #387.)

Exact pin (program convention). Verified locally:
- `npm run build` (tsc -b && vite build) — clean
- `npm run lint` — 0 errors (3 pre-existing warnings)
- `npm run test:run` — 65 passed