### PR TITLE
chore(deps): bump sphere-sdk 0.10.6 + wire transfer:delivery_pending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.10.5",
+        "@unicitylabs/sphere-sdk": "0.10.6",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.5.tgz",
-      "integrity": "sha512-yYWiWEtq8VPvrniFHe55g2npLdkT1fjf919GmbqoH5uEW1vtBwoDIMP21WrpUUCKwZj0kDA8KPxJFAIUimHv1g==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.6.tgz",
+      "integrity": "sha512-kCT+2D4eGIfEkO5C8Aljwq9L+5+3mnKufaSP7UkYKLuSx15dlICIG2rLMhjc/no+P5tyVimdwQ1kgdpYiB0StA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.10.5",
+    "@unicitylabs/sphere-sdk": "0.10.6",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -179,6 +179,11 @@ export function useSphereEvents(): void {
 
     sphere.on('transfer:incoming', handleIncomingTransfer);
     sphere.on('transfer:confirmed', handleTransferConfirmed);
+    // sphere-sdk 0.10.6 (#621/#622): a send whose recipient delivery is deferred (full mailbox / 429,
+    // or a transient outage) resolves and emits transfer:delivery_pending INSTEAD of transfer:confirmed
+    // — the spend is final on-chain. Refresh on it too so balances/inventory/history don't go stale
+    // until the next sync.
+    sphere.on('transfer:delivery_pending', handleTransferConfirmed);
     sphere.on('history:updated', handleHistoryUpdated);
     sphere.on('nametag:registered', handleNametagChange);
     sphere.on('nametag:recovered', handleNametagChange);
@@ -198,6 +203,7 @@ export function useSphereEvents(): void {
       }
       sphere.off('transfer:incoming', handleIncomingTransfer);
       sphere.off('transfer:confirmed', handleTransferConfirmed);
+      sphere.off('transfer:delivery_pending', handleTransferConfirmed);
       sphere.off('history:updated', handleHistoryUpdated);
       sphere.off('nametag:registered', handleNametagChange);
       sphere.off('nametag:recovered', handleNametagChange);


### PR DESCRIPTION
Bumps `@unicitylabs/sphere-sdk` to **0.10.6** (covenant delivery fix #621/#622 + incoming-claim batching #623/#624) and makes the one consumer change that bump needs.

## Why the one code change

0.10.6's covenant fix makes `send()` **resolve** (not throw) when the recipient's delivery is deferred (full mailbox / `429`, or a transient outage) — the spend is final on-chain, so failing the sender was the bug. A pure win: the send UI no longer shows a scary error for a send that actually succeeded.

Such a send emits the **new `transfer:delivery_pending`** event *instead of* `transfer:confirmed`. `useSphereEvents` maps `transfer:confirmed → invalidatePayments`, so without wiring the new event, balances/inventory/history would go stale after a deferred send until the next sync. This PR wires `transfer:delivery_pending` to the same handler.

## What's NOT needed
- The app doesn't consume `inventory:conflict`, so the SDK's self-healing coin selection (P3, still in-flight in sphere-sdk #626 — not in 0.10.6) surfaces nothing new here.
- Batching (#624) is internal to the SDK pump — no app surface.

## Verification
`tsc -b` (typecheck) and `npm run build` both green against 0.10.6.

## Optional follow-up (not required)
Surface the new states in the UI — "sent — delivery pending" (`transfer:delivery_pending` / `delivery:deferred`) and spent-elsewhere vs delivery-pending in the activity panel. Tracked as P4 in sphere-sdk #625.