### PR TITLE
fix(history): lazy-load spinner spins forever — root the observer at the scroll container

### DIFF
--- a/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
+++ b/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
@@ -87,6 +87,7 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
   // (newest-first) and grow it as the user scrolls near the bottom (lazy loading).
   const PAGE = 40;
   const [visibleCount, setVisibleCount] = useState(PAGE);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const hasMore = visibleCount < history.length;
 
@@ -95,13 +96,16 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
     if (isOpen) setVisibleCount(PAGE);
   }, [isOpen]);
 
-  // Grow the window when the bottom sentinel scrolls into view.
+  // Grow the window when the bottom sentinel scrolls into view. The observer is rooted at the modal's
+  // SCROLL CONTAINER (not the viewport) — the list scrolls inside it, and the framer-motion modal's
+  // transforms break viewport-relative intersection math (the bug where the spinner span forever).
   useEffect(() => {
     const node = sentinelRef.current;
-    if (!node || !hasMore) return;
+    const root = scrollRef.current;
+    if (!node || !root || !hasMore) return;
     const observer = new IntersectionObserver(
       (entries) => { if (entries[0]?.isIntersecting) setVisibleCount((c) => c + PAGE); },
-      { rootMargin: '400px 0px' },
+      { root, rootMargin: '600px 0px' },
     );
     observer.observe(node);
     return () => observer.disconnect();
@@ -142,7 +146,7 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
       <ModalHeader variant="screen" title="Transaction History" icon={Clock} onClose={onClose} />
 
       {/* Content - Scrollable */}
-      <div className="relative flex-1 overflow-y-auto custom-scrollbar p-4 space-y-3 z-10 min-h-0 bg-transparent">
+      <div ref={scrollRef} className="relative flex-1 overflow-y-auto custom-scrollbar p-4 space-y-3 z-10 min-h-0 bg-transparent">
         {isLoading ? (
           <div className="flex items-center justify-center py-20">
             <Loader2 className="w-6 h-6 animate-spin text-orange-500" />


### PR DESCRIPTION
The transaction-history lazy-load sentinel never fired: the spinner spun forever and no further rows loaded.

**Cause:** the `IntersectionObserver` defaulted to the **viewport** root, but the list scrolls inside an inner `overflow-y-auto` container, and the modal is a framer-motion (transformed) overlay — which breaks viewport-relative intersection math, so the sentinel was never reported as intersecting.

**Fix:** root the observer at the **scroll container** (a `ref` on the `overflow-y-auto` div) and widen the prefetch margin. As a bonus this auto-loads when the sentinel is already visible on short content (the container can't scroll yet). `tsc -b` + lint green.