### PR TITLE
chore(deps): bump sphere-sdk 0.10.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.10.6",
+        "@unicitylabs/sphere-sdk": "0.10.7",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.6.tgz",
-      "integrity": "sha512-kCT+2D4eGIfEkO5C8Aljwq9L+5+3mnKufaSP7UkYKLuSx15dlICIG2rLMhjc/no+P5tyVimdwQ1kgdpYiB0StA==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.7.tgz",
+      "integrity": "sha512-4ry1MUNWMHpawn11FrvvwpU8U94RxxW997syU92BSrUx8Cfx2c8S+VkGUnZJJht4694/tGQI1zagnaMdDTm+xA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.10.6",
+    "@unicitylabs/sphere-sdk": "0.10.7",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Bumps `@unicitylabs/sphere-sdk` 0.10.6 → 0.10.7 (internal/resilience — e.g. the wallet-api client GET-retry on transient connection drops; no consumer API change). `tsc -b` + `npm run build` green.