### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.10.7",
+        "@unicitylabs/sphere-sdk": "0.11.0",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/@unicitylabs/nostr-js-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.5.0.tgz",
-      "integrity": "sha512-v6qaZBkyuZzvfjyO/x+czqftYdAqxjyfBXipsB0QJIdqePBiWHR2aRs28zzJIhCMk1vP9HXzxGnpjRqlcnzroA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/nostr-js-sdk/-/nostr-js-sdk-0.6.0.tgz",
+      "integrity": "sha512-l6WcCmFok9nxI1WkYsjIVu67svouA2QyB5Vb+GTNugWrbw7hUgJMA1Elj8qu3u0qojvSINL/L9eWTmXVWRzZUw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^1.0.0",
@@ -2790,15 +2790,15 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.10.7.tgz",
-      "integrity": "sha512-4ry1MUNWMHpawn11FrvvwpU8U94RxxW997syU92BSrUx8Cfx2c8S+VkGUnZJJht4694/tGQI1zagnaMdDTm+xA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.0.tgz",
+      "integrity": "sha512-Eu3RnbudJMA5B/QDam8EPCivrSQwMoWeh05IUCqklqfSsmVMUrNIzM6/5SRRBNg+OfrvDnik+UHHuQm1crrhgg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
-        "@unicitylabs/nostr-js-sdk": "^0.5.0",
+        "@unicitylabs/nostr-js-sdk": "^0.6.0",
         "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
@@ -5375,9 +5375,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.6.tgz",
-      "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.7.tgz",
+      "integrity": "sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.10.7",
+    "@unicitylabs/sphere-sdk": "0.11.0",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Bumps `@unicitylabs/sphere-sdk` `0.10.7` → `0.11.0`.

0.11.0 adopts the **nostr-js-sdk 0.6.0 UNIP-01 client**: nametag resolution now prefers the relay-vetted single-owner binding (and ignores self-asserted `created_at`), and binding events carry the NIP-32 `["L","unicity:nametag"]` marker. The relay-side enforcement (UNIP-01) is already merged and deployed.

No app code changes required — the SDK API is unchanged.

## Verification
- `npm run build` (`tsc -b && vite build`): ✅
- `npm run lint`: ✅ 0 errors (3 pre-existing ExplorePage warnings, unrelated)
- `npm run test:run`: ✅ 65/65 pass