### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk to 0.11.3 (+ handle #631 possibly-certified sends)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.1",
+        "@unicitylabs/sphere-sdk": "0.11.2",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.1.tgz",
-      "integrity": "sha512-a9/MGxyorGpNd54N5O3LQrZ6H4g/ZHFH7Lr1oCDC9Klerw3FIoYmphuiOKcv24CrE+k5DjYDNKZOK65R10mUFg==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.2.tgz",
+      "integrity": "sha512-w4cQV7btYjPMN8V1ppLuo+alOaE3nsLsAZgpLYsLyTZHMjm853LBfAgJ4Y7rFyNmUC7CRF6Lr2fUio19GGhEGg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.0",
+        "@unicitylabs/sphere-sdk": "0.11.1",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.0.tgz",
-      "integrity": "sha512-Eu3RnbudJMA5B/QDam8EPCivrSQwMoWeh05IUCqklqfSsmVMUrNIzM6/5SRRBNg+OfrvDnik+UHHuQm1crrhgg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.1.tgz",
+      "integrity": "sha512-a9/MGxyorGpNd54N5O3LQrZ6H4g/ZHFH7Lr1oCDC9Klerw3FIoYmphuiOKcv24CrE+k5DjYDNKZOK65R10mUFg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.2",
+        "@unicitylabs/sphere-sdk": "0.11.3",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.2.tgz",
-      "integrity": "sha512-w4cQV7btYjPMN8V1ppLuo+alOaE3nsLsAZgpLYsLyTZHMjm853LBfAgJ4Y7rFyNmUC7CRF6Lr2fUio19GGhEGg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.3.tgz",
+      "integrity": "sha512-dFzcm78az9HF0X8zs5IFV5IAhH7u1y7eqzo3NHXtR6xQgajnxKl6vDHZoNrfOl6hWoH3FYHOX1TohZZGhNnRLQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.1",
+    "@unicitylabs/sphere-sdk": "0.11.2",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.0",
+    "@unicitylabs/sphere-sdk": "0.11.1",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.2",
+    "@unicitylabs/sphere-sdk": "0.11.3",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/errors.ts
+++ b/src/sdk/errors.ts
@@ -11,6 +11,9 @@ const FRIENDLY_OVERRIDES: Partial<Record<SphereErrorCode, string>> = {
   DECRYPTION_ERROR: 'Wrong password',
   STORAGE_ERROR: 'Storage error',
   MODULE_NOT_AVAILABLE: 'Feature not available',
+  // #631/#633: a possibly-certified send. useTransfer already converts this to a pending
+  // success (so the send path never re-sends); this is a friendly fallback for any other surface.
+  CERTIFICATION_UNCONFIRMED: 'Payment sent — confirming on-chain. No need to resend.',
 };
 
 /**

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSphereContext } from '../core/useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
+import { getErrorCode } from '../../errors';
 import type { TransferResult } from '@unicitylabs/sphere-sdk';
 
 export interface TransferParams {
@@ -25,12 +26,24 @@ export function useTransfer(): UseTransferReturn {
   const mutation = useMutation({
     mutationFn: async (params: TransferParams): Promise<TransferResult> => {
       if (!sphere) throw new Error('Wallet not initialized');
-      return sphere.payments.send({
-        coinId: params.coinId,
-        amount: params.amount,
-        recipient: params.recipient,
-        memo: params.memo,
-      });
+      try {
+        return await sphere.payments.send({
+          coinId: params.coinId,
+          amount: params.amount,
+          recipient: params.recipient,
+          memo: params.memo,
+        });
+      } catch (e) {
+        // #631/#633: a POSSIBLY-CERTIFIED send rejects with ProofUnconfirmedError
+        // (code CERTIFICATION_UNCONFIRMED) — the spend may already be final on-chain and
+        // the SDK keeps the intent OPEN, so resume completes it under the same transferId.
+        // Treat it as a delivery-pending SUCCESS, NEVER a re-sendable failure: re-issuing a
+        // fresh send() would consume a DIFFERENT source and double-pay the recipient.
+        if (getErrorCode(e) === 'CERTIFICATION_UNCONFIRMED') {
+          return { id: '', status: 'pending', tokens: [], tokenTransfers: [], deliveryPending: true };
+        }
+        throw e;
+      }
     },
     onSuccess: () => {
       // Force refetch all payment queries with fresh data.

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -40,6 +40,9 @@ export function useTransfer(): UseTransferReturn {
         // Treat it as a delivery-pending SUCCESS, NEVER a re-sendable failure: re-issuing a
         // fresh send() would consume a DIFFERENT source and double-pay the recipient.
         if (getErrorCode(e) === 'CERTIFICATION_UNCONFIRMED') {
+          // `id` is intentionally empty: ProofUnconfirmedError carries no transferId
+          // (the still-open intent + resume own it), and no send UI reads result.id
+          // on this path — it exists only to render the "pending" state.
           return { id: '', status: 'pending', tokens: [], tokenTransfers: [], deliveryPending: true };
         }
         throw e;

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SphereError } from '@unicitylabs/sphere-sdk';
+import { useTransfer } from '../../../src/sdk/hooks/payments/useTransfer';
+
+// The hook reads the wallet from useSphereContext — swap in a fake with just
+// payments.send. The SDK throws a ProofUnconfirmedError (extends SphereError,
+// code CERTIFICATION_UNCONFIRMED) for a possibly-certified send (#631/#633).
+let fakeSphere: { payments: { send: ReturnType<typeof vi.fn> } } | null = null;
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ sphere: fakeSphere }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const PARAMS = { coinId: 'c', amount: '100', recipient: '@bob' };
+
+beforeEach(() => {
+  fakeSphere = null;
+});
+
+describe('useTransfer — #631/#633 possibly-certified send', () => {
+  it('converts a CERTIFICATION_UNCONFIRMED reject into a delivery-pending SUCCESS (no re-send → no double-pay)', async () => {
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed — the source spend may be on-chain', 'CERTIFICATION_UNCONFIRMED'),
+    );
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    // Resolved (NOT rejected) as a pending success: the send screen shows "Sent —
+    // pending" and never returns to a re-sendable confirm step. send() ran exactly once.
+    expect(res?.deliveryPending).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects a genuine failure so the user is told (and can retry safely)', async () => {
+    const send = vi.fn().mockRejectedValue(new SphereError('not enough balance', 'INSUFFICIENT_BALANCE'));
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper });
+
+    await expect(
+      act(async () => {
+        await result.current.transfer(PARAMS);
+      }),
+    ).rejects.toThrow(/not enough balance/);
+  });
+
+  it('passes a normal success result through unchanged', async () => {
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper });
+
+    let res: unknown;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+    expect(res).toEqual(ok);
+  });
+});

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, useState, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SphereError } from '@unicitylabs/sphere-sdk';
 import { useTransfer } from '../../../src/sdk/hooks/payments/useTransfer';
@@ -13,10 +13,12 @@ vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
   useSphereContext: () => ({ sphere: fakeSphere }),
 }));
 
-function wrapper({ children }: { children: ReactNode }) {
-  const qc = new QueryClient({
-    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
-  });
+function Wrapper({ children }: { children: ReactNode }) {
+  // One stable client per wrapper instance — a fresh QueryClient on each render
+  // would reset mutation state mid-test and flake.
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } }),
+  );
   return createElement(QueryClientProvider, { client: qc }, children);
 }
 
@@ -32,7 +34,7 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
       new SphereError('certification unconfirmed — the source spend may be on-chain', 'CERTIFICATION_UNCONFIRMED'),
     );
     fakeSphere = { payments: { send } };
-    const { result } = renderHook(() => useTransfer(), { wrapper });
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
 
     let res: { deliveryPending?: boolean } | undefined;
     await act(async () => {
@@ -49,7 +51,7 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
   it('still rejects a genuine failure so the user is told (and can retry safely)', async () => {
     const send = vi.fn().mockRejectedValue(new SphereError('not enough balance', 'INSUFFICIENT_BALANCE'));
     fakeSphere = { payments: { send } };
-    const { result } = renderHook(() => useTransfer(), { wrapper });
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
 
     await expect(
       act(async () => {
@@ -62,7 +64,7 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
     const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
     const send = vi.fn().mockResolvedValue(ok);
     fakeSphere = { payments: { send } };
-    const { result } = renderHook(() => useTransfer(), { wrapper });
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
 
     let res: unknown;
     await act(async () => {


### PR DESCRIPTION
Bumps `@unicitylabs/sphere-sdk` `0.11.0` → **`0.11.2`** and adds the app-side handling the new SDK behavior requires.

## What's in the bump

- **0.11.1** — wallet-api client resilience (sphere-sdk #630): idempotent-GET retry + jitter; `429`/`503` honor `Retry-After`; quieter background pumps.
- **0.11.2** — `ProofUnconfirmedError` / same-`transferId` resume safety (sphere-sdk #631): `payments.send` now **rejects with code `CERTIFICATION_UNCONFIRMED`** when a send *may* have certified on-chain but the proof fetch was inconclusive. The SDK keeps the intent **open** and resume completes it under the same `transferId`.

## Why the app needs handling (double-pay guard)

Left unhandled, a `CERTIFICATION_UNCONFIRMED` reject would surface as a **failure** and drop the send screen back to a re-sendable confirm step. Pressing **Send** again consumes a *different* source and **double-pays the recipient** while the original resumes — reachable through the normal UI.

**Fix (central, in `useTransfer`):** convert a `CERTIFICATION_UNCONFIRMED` reject into a **delivery-pending SUCCESS**, reusing the existing `deliveryPending` path (*"Sent — delivery pending… nothing more to do"*). This covers **all three** `useTransfer` consumers at once — `SendModal`, `SendIntentModal` (Connect), `SwapModal` — so none offers a re-send and the global error toast never fires. Adds a friendly fallback message in `sdk/errors.ts` for any other surface.

Semantically safe: a possibly-certified send is "sent, confirming," not "failed" — and even if it didn't certify, resume completes the intended send (never a second on-chain spend, per the SDK's same-`transferId` resume).

## Verification

`tsc -b` + `vite build` clean · `lint` 0 errors · `test:run` **68 pass** (3 new `useTransfer` tests: `CERTIFICATION_UNCONFIRMED` → pending success; a genuine failure still rejects; normal success passes through).
