### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk 0.11.3 -> 0.11.4 + surface split:checkpoint-stuck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.3",
+        "@unicitylabs/sphere-sdk": "0.11.4",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.3.tgz",
-      "integrity": "sha512-dFzcm78az9HF0X8zs5IFV5IAhH7u1y7eqzo3NHXtR6xQgajnxKl6vDHZoNrfOl6hWoH3FYHOX1TohZZGhNnRLQ==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.4.tgz",
+      "integrity": "sha512-MigL1aEaQKY+O14Z+jRDoNsvuHZgZUy+GJQeDKq3r2uGOGB3bN/moEdhNcpxwvQmlaPauJakyGoZXW4zV8yo7Q==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.3",
+    "@unicitylabs/sphere-sdk": "0.11.4",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -177,6 +177,20 @@ export function useSphereEvents(): void {
       );
     };
 
+    // sphere-sdk#501 / E.4: a certified split is STUCK on a keep-open checkpoint
+    // error (a lost/withheld burn checkpoint, or a trust-base rotation). The
+    // intent stays OPEN and the funds are safe — it retries on the next resume —
+    // but the E.4 contract requires a LOUD signal (not a silent retry) so the
+    // holder can act (or reach support) rather than assume the split completed.
+    const handleSplitCheckpointStuck = (data: { transferId: string; code: string; error: string }) => {
+      showToast(
+        `A split payment is stuck settling (${data.code}) — your funds are safe and it will retry on ` +
+          `reconnect. If it persists, contact support with reference ${data.transferId.slice(0, 8)}.`,
+        'error',
+        15000,
+      );
+    };
+
     sphere.on('transfer:incoming', handleIncomingTransfer);
     sphere.on('transfer:confirmed', handleTransferConfirmed);
     // sphere-sdk 0.10.6 (#621/#622): a send whose recipient delivery is deferred (full mailbox / 429,
@@ -195,6 +209,7 @@ export function useSphereEvents(): void {
     sphere.on('composing:started', handleComposingStarted);
     sphere.on('payment_request:incoming', handlePaymentRequestIncoming);
     sphere.on('storage:degraded', handleStorageDegraded);
+    sphere.on('split:checkpoint-stuck', handleSplitCheckpointStuck);
 
     return () => {
       if (invalidateTimerRef.current) {
@@ -215,6 +230,7 @@ export function useSphereEvents(): void {
       sphere.off('composing:started', handleComposingStarted);
       sphere.off('payment_request:incoming', handlePaymentRequestIncoming);
       sphere.off('storage:degraded', handleStorageDegraded);
+      sphere.off('split:checkpoint-stuck', handleSplitCheckpointStuck);
     };
   }, [sphere, queryClient]);
 }


### PR DESCRIPTION
## Why

0.11.4 carries the **sphere-sdk#501** split-resume money-safety fix (a certified split now recovers
its outputs from a durable burn checkpoint instead of stranding) plus the **#634** change-output fix.
Both wire themselves inside the SDK's PaymentsModule when the wallet-api provider is present — **no
consumer code change is required for the fix itself.**

The deployed staging backend (`wallet-api.staging.unicity.network`, auto-deployed from main) already
runs the matching intent-progress endpoints + schema (verified via a live E.4 round-trip), so the
client bump is deploy-safe.

## What

- Bump the pin `0.11.3 -> 0.11.4` (lockfile refreshed).
- Surface the new `split:checkpoint-stuck` event in `useSphereEvents`: a certified split kept OPEN on
  an unrecoverable-for-now checkpoint error (lost checkpoint / trust-base rotation). Funds are safe
  and it retries on resume, but the E.4 contract asks for a *loud* signal rather than a silent retry
  — so we raise a persistent toast that reassures the holder their funds are safe and gives a support
  reference. Mirrors the existing `storage:degraded` handler.

## Verification

- `tsc -b` clean and the full `npm run build` green against 0.11.4; `eslint` clean on the touched file.
- The `split:checkpoint-stuck` `sphere.on(...)` typechecks against the SDK's event map (confirms the
  event shipped in 0.11.4).