### PR TITLE
feat(subscription): quota gate — proactive pre-send block + reactive 429/401 upgrade routing (Phase 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.3",
+        "@unicitylabs/sphere-sdk": "0.11.4",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.3.tgz",
-      "integrity": "sha512-dFzcm78az9HF0X8zs5IFV5IAhH7u1y7eqzo3NHXtR6xQgajnxKl6vDHZoNrfOl6hWoH3FYHOX1TohZZGhNnRLQ==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.4.tgz",
+      "integrity": "sha512-MigL1aEaQKY+O14Z+jRDoNsvuHZgZUy+GJQeDKq3r2uGOGB3bN/moEdhNcpxwvQmlaPauJakyGoZXW4zV8yo7Q==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.3",
+    "@unicitylabs/sphere-sdk": "0.11.4",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/components/connect/SendIntentModal.tsx
+++ b/src/components/connect/SendIntentModal.tsx
@@ -3,6 +3,8 @@ import { Send } from 'lucide-react';
 import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
 import { useAssets, useTransfer } from '../../sdk';
 import { getErrorMessage } from '../../sdk/errors';
+import { QuotaBlockedError } from '../../sdk/quotaGate';
+import { useUpgrade } from '../upgrade';
 import { IntentConfirmModal } from './IntentConfirmModal';
 
 interface SendIntentModalProps {
@@ -32,6 +34,7 @@ interface SendIntentModalProps {
 export function SendIntentModal({ to, amount, coinId, memo, onResolve, onReject, onCancel }: SendIntentModalProps) {
   const { assets } = useAssets();
   const { transfer } = useTransfer();
+  const { openUpgrade } = useUpgrade();
   const [busy, setBusy] = useState(false);
 
   // Prefer the held asset (gives balance); fall back to the registry for
@@ -57,6 +60,23 @@ export function SendIntentModal({ to, amount, coinId, memo, onResolve, onReject,
       await transfer({ coinId, amount, recipient, ...(memo ? { memo } : {}) });
       onResolve();
     } catch (err) {
+      // Proactive quota block (useTransfer's mutationFn, Task 3) does NOT open
+      // the Upgrade modal itself — that only happens on the reactive
+      // CERTIFICATION_UNCONFIRMED 429/401 branch (Task 4). This modal unmounts
+      // as soon as onReject resolves the intent, so — unlike SendModal, which
+      // stays on its confirm step and lets the user click an Upgrade button —
+      // there's no lingering UI here to host that CTA. Open it directly so the
+      // dApp user still gets an upgrade path, mirroring SendModal's intent
+      // without double-opening (the hook never opens it on this path).
+      if (err instanceof QuotaBlockedError) {
+        openUpgrade(err.reason === 'expired' ? 'expired' : 'quota');
+        onReject(
+          err.reason === 'expired'
+            ? 'Wallet subscription expired'
+            : 'Wallet subscription quota exceeded'
+        );
+        return;
+      }
       // Tell the dApp it failed instead of leaving the request hanging; the
       // wallet's global query handler also surfaces a toast.
       onReject(getErrorMessage(err));

--- a/src/components/upgrade/PlanDowngradeWatcher.tsx
+++ b/src/components/upgrade/PlanDowngradeWatcher.tsx
@@ -1,0 +1,34 @@
+/**
+ * Watches the live utilization snapshot and, when a previously-paid key comes
+ * back as free (the gateway lazily demotes lapsed paid subscriptions — the
+ * user gets no error, just silently lower limits), opens the Upgrade modal
+ * once with the 'expired' banner. Renders nothing.
+ *
+ * Fires at most once per downgrade event: `rememberPlan` runs after the check,
+ * so the next snapshot compares 'free' → 'free' and stays quiet.
+ */
+import { useEffect } from 'react';
+import { useUtilization } from '../../sdk/hooks/subscription';
+import { getStoredSubscriptionKey } from '../../config/storageKeys';
+import { SUBSCRIPTION_ENABLED } from '../../config/subscription';
+import { getLastKnownPlan, rememberPlan, isPaidToFreeDowngrade } from '../../sdk/subscription/planMemory';
+import type { UpgradeReason } from './UpgradeContext';
+
+export function PlanDowngradeWatcher({ openUpgrade }: { openUpgrade: (r?: UpgradeReason) => void }) {
+  const util = useUtilization();
+  const plan = util.data?.plan;
+  const activeUntil = util.data?.activeUntil ?? null;
+
+  useEffect(() => {
+    if (!SUBSCRIPTION_ENABLED || !plan) return;
+    const apiKey = getStoredSubscriptionKey();
+    if (!apiKey) return;
+
+    if (isPaidToFreeDowngrade(getLastKnownPlan(apiKey), plan.name, activeUntil)) {
+      openUpgrade('expired');
+    }
+    rememberPlan(apiKey, plan.name);
+  }, [plan, activeUntil, openUpgrade]);
+
+  return null;
+}

--- a/src/components/upgrade/UpgradeContext.ts
+++ b/src/components/upgrade/UpgradeContext.ts
@@ -1,7 +1,9 @@
 import { createContext, useContext } from 'react';
 
+export type UpgradeReason = 'quota' | 'expired' | 'settings';
+
 export interface UpgradeContextValue {
-  openUpgrade: (reason?: string) => void;
+  openUpgrade: (reason?: UpgradeReason) => void;
 }
 
 export const UpgradeContext = createContext<UpgradeContextValue | null>(null);

--- a/src/components/upgrade/UpgradeModal.tsx
+++ b/src/components/upgrade/UpgradeModal.tsx
@@ -14,13 +14,42 @@ import { showToast } from '../ui/toast-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { SPHERE_KEYS } from '../../sdk/queryKeys';
 import { useSphereContext } from '../../sdk/hooks';
+import type { UpgradeReason } from './UpgradeContext';
 
 type Step = 'plans' | 'email' | 'awaiting' | 'claim' | 'success' | 'error';
 
 interface UpgradeModalProps {
   isOpen: boolean;
-  reason?: string;
+  reason?: UpgradeReason;
   onClose: () => void;
+}
+
+/**
+ * Banner shown above the plans grid, keyed off why the upgrade modal was
+ * opened. Extracted from UpgradeModal's render body so it can be unit-tested
+ * without mounting the full modal (which pulls in usePlans/useUtilization/
+ * useCheckout/useSphereContext). 'settings' and undefined render nothing.
+ */
+export function UpgradeReasonBanner({ reason }: { reason?: UpgradeReason }) {
+  if (reason === 'quota') {
+    return (
+      <div className="mx-auto mb-6 flex max-w-xl items-start gap-2 rounded-2xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-sm">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+        <span>You've hit your plan's limit. Upgrade for more, or wait for your quota to refill.</span>
+      </div>
+    );
+  }
+
+  if (reason === 'expired') {
+    return (
+      <div className="mx-auto mb-6 flex max-w-xl items-start gap-2 rounded-2xl border border-amber-500/20 bg-amber-500/10 p-3 text-sm">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+        <span>Your plan has expired — renew to restore your limits.</span>
+      </div>
+    );
+  }
+
+  return null;
 }
 
 export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
@@ -155,12 +184,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                   </p>
                 </div>
 
-                {reason === 'quota' && (
-                  <div className="mx-auto mb-6 flex max-w-xl items-start gap-2 rounded-2xl border border-yellow-500/20 bg-yellow-500/10 p-3 text-sm">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
-                    <span>You've hit your plan's limit. Upgrade for more, or wait for your quota to refill.</span>
-                  </div>
-                )}
+                <UpgradeReasonBanner reason={reason} />
 
                 {plans.isLoading && (
                   <div className="py-20 text-center text-neutral-400">

--- a/src/components/upgrade/UpgradeProvider.tsx
+++ b/src/components/upgrade/UpgradeProvider.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { UpgradeContext, type UpgradeReason } from './UpgradeContext';
 import { UpgradeModal } from './UpgradeModal';
+import { PlanDowngradeWatcher } from './PlanDowngradeWatcher';
 
 export function UpgradeProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -16,6 +17,7 @@ export function UpgradeProvider({ children }: { children: ReactNode }) {
   return (
     <UpgradeContext.Provider value={value}>
       {children}
+      <PlanDowngradeWatcher openUpgrade={openUpgrade} />
       <UpgradeModal isOpen={isOpen} reason={reason} onClose={() => setIsOpen(false)} />
     </UpgradeContext.Provider>
   );

--- a/src/components/upgrade/UpgradeProvider.tsx
+++ b/src/components/upgrade/UpgradeProvider.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
-import { UpgradeContext } from './UpgradeContext';
+import { UpgradeContext, type UpgradeReason } from './UpgradeContext';
 import { UpgradeModal } from './UpgradeModal';
 
 export function UpgradeProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [reason, setReason] = useState<string | undefined>();
+  const [reason, setReason] = useState<UpgradeReason | undefined>();
 
-  const openUpgrade = useCallback((r?: string) => {
+  const openUpgrade = useCallback((r?: UpgradeReason) => {
     setReason(r);
     setIsOpen(true);
   }, []);

--- a/src/components/upgrade/index.ts
+++ b/src/components/upgrade/index.ts
@@ -1,2 +1,2 @@
 export { UpgradeProvider } from './UpgradeProvider';
-export { useUpgrade } from './UpgradeContext';
+export { useUpgrade, type UpgradeReason } from './UpgradeContext';

--- a/src/components/wallet/L3/modals/SendModal.tsx
+++ b/src/components/wallet/L3/modals/SendModal.tsx
@@ -1,13 +1,17 @@
 import { useState, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowRight, Loader2, User, CheckCircle, Coins, Hash, Copy, Check, Clock } from 'lucide-react';
+import { ArrowRight, Loader2, User, CheckCircle, Coins, Hash, Copy, Check, Clock, Sparkles } from 'lucide-react';
 import type { Asset } from '@unicitylabs/sphere-sdk';
 import { parseTokenAmount, safeParseTokenAmount } from '@unicitylabs/sphere-sdk';
 import { useAssets, useTransfer, formatAmount } from '../../../../sdk';
 import { getErrorMessage } from '../../../../sdk/errors';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
+import { useUtilization } from '../../../../sdk/hooks/subscription';
+import { QuotaBlockedError, SEND_OPS_HEADROOM } from '../../../../sdk/quotaGate';
+import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
+import { useUpgrade } from '../../../upgrade';
 import { WalletScreen } from '../../ui/WalletScreen';
-import { ModalHeader, Button } from '../../ui';
+import { ModalHeader, Button, AlertMessage } from '../../ui';
 
 type Step = 'asset' | 'details' | 'confirm' | 'processing' | 'success';
 
@@ -20,6 +24,8 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
   const { assets: sdkAssets } = useAssets();
   const { transfer, isLoading: isTransferring } = useTransfer();
   const { sphere } = useSphereContext();
+  const { openUpgrade } = useUpgrade();
+  const utilization = useUtilization();
 
   const assets = sdkAssets;
 
@@ -37,6 +43,10 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
   const [recipient, setRecipient] = useState('');
   const [isCheckingRecipient, setIsCheckingRecipient] = useState(false);
   const [recipientError, setRecipientError] = useState<string | null>(null);
+  // Set instead of recipientError when handleSend's transfer rejects with
+  // QuotaBlockedError (Task 2) — renders a dedicated warning + Upgrade CTA
+  // in the confirm step rather than the generic error paragraph.
+  const [quotaBlocked, setQuotaBlocked] = useState<'expired' | 'exhausted' | null>(null);
 
   const [resolvedAddress, setResolvedAddress] = useState<string | null>(null);
 
@@ -70,6 +80,7 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
     setAmountInput('');
     setMemoInput('');
     setRecipientError(null);
+    setQuotaBlocked(null);
     setDeliveryPending(false);
   };
 
@@ -145,6 +156,7 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
 
     setStep('processing');
     setRecipientError(null);
+    setQuotaBlocked(null);
 
     try {
       const amount = parseTokenAmount(amountInput, selectedAsset.decimals).toString();
@@ -158,7 +170,11 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
       setDeliveryPending(result.deliveryPending ?? false);
       setStep('success');
     } catch (e: unknown) {
-      setRecipientError(getErrorMessage(e));
+      if (e instanceof QuotaBlockedError) {
+        setQuotaBlocked(e.reason);
+      } else {
+        setRecipientError(getErrorMessage(e));
+      }
       setStep('confirm');
     }
   };
@@ -389,9 +405,39 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
                     </div>
                   </div>
                 </div>
+
+                {/* Passive low-quota heads-up (spec §2 'warn' verdict) — informational only, never blocks the send */}
+                {SUBSCRIPTION_ENABLED && typeof utilization.data?.utilization.availablePerMinute === 'number' && utilization.data.utilization.availablePerMinute < SEND_OPS_HEADROOM && (
+                  <div className="p-3 bg-amber-500/10 border border-amber-500/20 rounded-xl flex items-start gap-3">
+                    <Clock className="w-5 h-5 text-amber-500 dark:text-amber-400 mt-0.5" />
+                    <div className="text-xs text-neutral-500 dark:text-white/45">
+                      Only {utilization.data.utilization.availablePerMinute} commitments left this minute — large sends may be throttled.
+                    </div>
+                  </div>
+                )}
               </div>
 
-              {recipientError && <p className="text-red-500 text-sm mb-4 text-center">{recipientError}</p>}
+              {quotaBlocked && (
+                <div className="mb-4">
+                  <AlertMessage variant="warning">
+                    {quotaBlocked === 'expired'
+                      ? "Your plan has expired — renew to keep sending."
+                      : "Your plan's limit is used up — upgrade or wait for the quota to refill."}
+                  </AlertMessage>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    icon={Sparkles}
+                    fullWidth
+                    className="mt-2"
+                    onClick={() => openUpgrade(quotaBlocked === 'expired' ? 'expired' : 'quota')}
+                  >
+                    Upgrade
+                  </Button>
+                </div>
+              )}
+
+              {recipientError && !quotaBlocked && <p className="text-red-500 text-sm mb-4 text-center">{recipientError}</p>}
 
               <div className="flex gap-3">
                 <button

--- a/src/components/wallet/L3/modals/SendModal.tsx
+++ b/src/components/wallet/L3/modals/SendModal.tsx
@@ -115,6 +115,9 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
 
     setIsCheckingRecipient(true);
     setRecipientError(null);
+    // Re-entering confirm via details is a fresh attempt — a quota block from
+    // a previous send must not survive it (same lifecycle as recipientError).
+    setQuotaBlocked(null);
 
     try {
       if (recipientMode === 'direct') {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,16 +18,22 @@ createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <SphereProvider network="testnet2">
         <ServicesProvider>
-          <ConnectProvider>
-            <UpgradeProvider>
+          {/* UpgradeProvider MUST wrap ConnectProvider: ConnectProvider renders
+              ConnectIntentHandler (and its modals, e.g. SendIntentModal →
+              useTransfer → useUpgrade) as a SIBLING of children, so anything
+              those modals consume has to be mounted above ConnectProvider.
+              UpgradeModal itself only needs SphereProvider + react-query,
+              which are both still ancestors here. */}
+          <UpgradeProvider>
+            <ConnectProvider>
               <ThemeInitializer>
                 <BrowserRouter basename={import.meta.env.BASE_URL}>
                   <App />
                 </BrowserRouter>
                 <ToastContainer />
               </ThemeInitializer>
-            </UpgradeProvider>
-          </ConnectProvider>
+            </ConnectProvider>
+          </UpgradeProvider>
         </ServicesProvider>
       </SphereProvider>
     </QueryClientProvider>

--- a/src/sdk/errors.ts
+++ b/src/sdk/errors.ts
@@ -56,4 +56,55 @@ export function getErrorCode(err: unknown): SphereErrorCode | null {
   return isSphereError(err) ? err.code : null;
 }
 
+// --- Gateway (SGW) 429/401 classification ---------------------------------
+//
+// duck-type; JsonRpcNetworkError is NOT exported by sphere-sdk root or
+// subpaths (only deep-importable from @unicitylabs/state-transition-sdk/lib/...
+// — avoid that coupling per architecture rules). See spec §5 "Duck-typed
+// cause detection" risk: a state-transition-sdk bump could rename these
+// fields and silently break detection; the gatewayErrors.test.ts contract
+// canary pins this shape so such a break fails loudly in CI.
+function isJsonRpcNetworkErrorShape(
+  value: unknown
+): value is { name: 'JsonRpcNetworkError'; status: number } {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { name?: unknown; status?: unknown };
+  return candidate.name === 'JsonRpcNetworkError' && typeof candidate.status === 'number';
+}
+
+/**
+ * Resolve the underlying gateway HTTP status (429/401/403/...) from either:
+ *  (a) a SphereError('CERTIFICATION_UNCONFIRMED') whose `cause` duck-types
+ *      JsonRpcNetworkError (the reactive path — the submit already left,
+ *      per #631/#633 this is annotated on top of the existing pending-success
+ *      conversion, never turned into a clean failure); or
+ *  (b) a raw error that itself duck-types JsonRpcNetworkError (the
+ *      pre-first-submit throw, before useTransfer's wrap applies — also
+ *      covers callers that bypass useTransfer entirely, e.g. SwapModal's
+ *      mint or ConnectIntentHandler's mint/receive, per spec §3.6).
+ * Returns null for anything else. Never matches on message text.
+ */
+export function getGatewayHttpStatus(err: unknown): number | null {
+  if (isSphereError(err) && err.code === 'CERTIFICATION_UNCONFIRMED') {
+    return isJsonRpcNetworkErrorShape(err.cause) ? err.cause.status : null;
+  }
+  return isJsonRpcNetworkErrorShape(err) ? err.status : null;
+}
+
+/** True when the gateway rejected the request for quota (SGW rate limit, HTTP 429). */
+export function isQuotaRateLimit(err: unknown): boolean {
+  return getGatewayHttpStatus(err) === 429;
+}
+
+/**
+ * True when the gateway rejected the request as unauthenticated/forbidden
+ * (HTTP 401 or 403). The proxy 401 is byte-identical for missing/invalid/
+ * revoked/expired subscription keys — callers must disambiguate further
+ * (see spec §1 "401 branch") via `/api/utilization`.
+ */
+export function isGatewayAuthError(err: unknown): boolean {
+  const status = getGatewayHttpStatus(err);
+  return status === 401 || status === 403;
+}
+
 export { isSphereError };

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -177,6 +177,20 @@ export function useSphereEvents(): void {
       );
     };
 
+    // sphere-sdk#501 / E.4: a certified split is STUCK on a keep-open checkpoint
+    // error (a lost/withheld burn checkpoint, or a trust-base rotation). The
+    // intent stays OPEN and the funds are safe — it retries on the next resume —
+    // but the E.4 contract requires a LOUD signal (not a silent retry) so the
+    // holder can act (or reach support) rather than assume the split completed.
+    const handleSplitCheckpointStuck = (data: { transferId: string; code: string; error: string }) => {
+      showToast(
+        `A split payment is stuck settling (${data.code}) — your funds are safe and it will retry on ` +
+          `reconnect. If it persists, contact support with reference ${data.transferId.slice(0, 8)}.`,
+        'error',
+        15000,
+      );
+    };
+
     sphere.on('transfer:incoming', handleIncomingTransfer);
     sphere.on('transfer:confirmed', handleTransferConfirmed);
     // sphere-sdk 0.10.6 (#621/#622): a send whose recipient delivery is deferred (full mailbox / 429,
@@ -195,6 +209,7 @@ export function useSphereEvents(): void {
     sphere.on('composing:started', handleComposingStarted);
     sphere.on('payment_request:incoming', handlePaymentRequestIncoming);
     sphere.on('storage:degraded', handleStorageDegraded);
+    sphere.on('split:checkpoint-stuck', handleSplitCheckpointStuck);
 
     return () => {
       if (invalidateTimerRef.current) {
@@ -215,6 +230,7 @@ export function useSphereEvents(): void {
       sphere.off('composing:started', handleComposingStarted);
       sphere.off('payment_request:incoming', handlePaymentRequestIncoming);
       sphere.off('storage:degraded', handleStorageDegraded);
+      sphere.off('split:checkpoint-stuck', handleSplitCheckpointStuck);
     };
   }, [sphere, queryClient]);
 }

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -63,10 +63,13 @@ export interface UseTransferReturn {
 export function useTransfer(): UseTransferReturn {
   const { sphere } = useSphereContext();
   const queryClient = useQueryClient();
-  // Rules of hooks: must be called unconditionally at the top level. Safe
-  // everywhere useTransfer is used — UpgradeProvider is mounted above the
-  // whole app tree (main.tsx), so every consumer (SendModal, SendIntentModal,
-  // SwapModal) is already under it.
+  // Rules of hooks: must be called unconditionally at the top level. This
+  // requires UpgradeProvider to stay mounted ABOVE ConnectProvider in
+  // main.tsx: ConnectProvider renders ConnectIntentHandler (and thus
+  // SendIntentModal → useTransfer) as a SIBLING of its children, so only
+  // providers above ConnectProvider are ancestors of the Connect intent
+  // modals. Reordering main.tsx would make this throw on the dApp
+  // send-intent path.
   const { openUpgrade } = useUpgrade();
 
   const mutation = useMutation({
@@ -109,13 +112,25 @@ export function useTransfer(): UseTransferReturn {
           // synthetic pending result below is returned in ALL cases,
           // regardless of the branch taken here; #631/#633 keep-open
           // semantics are never altered by this block.
+          // INVARIANT: nothing in this annotation block may throw past it —
+          // a possibly-certified spend MUST reach the synthetic pending
+          // return below, or the UI would misreport a finalized-on-chain
+          // spend as a re-sendable failure (double-pay risk). Even the
+          // "synchronous" parts can throw (e.g. getStoredSubscriptionKey →
+          // localStorage.getItem raises SecurityError in storage-blocked
+          // iframes), so the whole block is fail-open.
           if (SUBSCRIPTION_ENABLED) {
-            if (isQuotaRateLimit(e)) {
-              openUpgrade('quota');
-            } else if (isGatewayAuthError(e)) {
-              // Fire-and-forget: the ~/api/utilization round trip must never
-              // delay the pending result below.
-              disambiguateGatewayAuthError(openUpgrade);
+            try {
+              if (isQuotaRateLimit(e)) {
+                openUpgrade('quota');
+              } else if (isGatewayAuthError(e)) {
+                // Fire-and-forget: the /api/utilization round trip must never
+                // delay the pending result below.
+                disambiguateGatewayAuthError(openUpgrade);
+              }
+            } catch {
+              // Swallow everything: annotation is best-effort, money-safety
+              // (the pending return) always wins.
             }
           }
           // `id` is intentionally empty: ProofUnconfirmedError carries no transferId

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -4,7 +4,7 @@ import { SPHERE_KEYS } from '../../queryKeys';
 import { getErrorCode, isQuotaRateLimit, isGatewayAuthError } from '../../errors';
 import { checkSendQuota, QuotaBlockedError } from '../../quotaGate';
 import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
-import { useUpgrade } from '../../../components/upgrade';
+import { useUpgrade, type UpgradeReason } from '../../../components/upgrade';
 import { getUtilization } from '../../../services/subscriptionApi';
 import { getStoredSubscriptionKey } from '../../../config/storageKeys';
 import { showToast } from '../../../components/ui/toast-utils';
@@ -18,7 +18,7 @@ import type { TransferResult } from '@unicitylabs/sphere-sdk';
  * call. Never awaited by the caller — the synthetic pending result must
  * return immediately regardless of how long this takes or how it resolves.
  */
-function disambiguateGatewayAuthError(openUpgrade: (reason?: string) => void): void {
+function disambiguateGatewayAuthError(openUpgrade: (reason?: UpgradeReason) => void): void {
   const apiKey = getStoredSubscriptionKey();
   if (!apiKey) return;
 

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -1,10 +1,49 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSphereContext } from '../core/useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
-import { getErrorCode } from '../../errors';
+import { getErrorCode, isQuotaRateLimit, isGatewayAuthError } from '../../errors';
 import { checkSendQuota, QuotaBlockedError } from '../../quotaGate';
 import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
+import { useUpgrade } from '../../../components/upgrade';
+import { getUtilization } from '../../../services/subscriptionApi';
+import { getStoredSubscriptionKey } from '../../../config/storageKeys';
+import { showToast } from '../../../components/ui/toast-utils';
 import type { TransferResult } from '@unicitylabs/sphere-sdk';
+
+/**
+ * Fire-and-forget disambiguation for a 401/403 submit rejection (spec §1
+ * "401 branch"). The proxy 401 is byte-identical for missing/invalid/revoked/
+ * expired keys, so the only way to tell "expired" (renew CTA) apart from
+ * "invalid/revoked" (re-provision signal) is a follow-up `/api/utilization`
+ * call. Never awaited by the caller — the synthetic pending result must
+ * return immediately regardless of how long this takes or how it resolves.
+ */
+function disambiguateGatewayAuthError(openUpgrade: (reason?: string) => void): void {
+  const apiKey = getStoredSubscriptionKey();
+  if (!apiKey) return;
+
+  const warnKeyRejected = (): void => {
+    console.warn('subscription key rejected by gateway; re-provisioning runs at next load');
+    showToast(
+      'Subscription key was rejected — open Settings → Subscription to re-activate',
+      'error',
+      6000,
+    );
+  };
+
+  getUtilization(apiKey)
+    .then((info) => {
+      if (info.status === 'expired') {
+        openUpgrade('expired');
+      } else {
+        // 401 with a non-expired status back from /api/utilization means the
+        // key itself is invalid/revoked (the proxy can't distinguish these
+        // cases up front) — same re-provision signal as an outright reject.
+        warnKeyRejected();
+      }
+    })
+    .catch(warnKeyRejected);
+}
 
 export interface TransferParams {
   coinId: string;
@@ -24,6 +63,11 @@ export interface UseTransferReturn {
 export function useTransfer(): UseTransferReturn {
   const { sphere } = useSphereContext();
   const queryClient = useQueryClient();
+  // Rules of hooks: must be called unconditionally at the top level. Safe
+  // everywhere useTransfer is used — UpgradeProvider is mounted above the
+  // whole app tree (main.tsx), so every consumer (SendModal, SendIntentModal,
+  // SwapModal) is already under it.
+  const { openUpgrade } = useUpgrade();
 
   const mutation = useMutation({
     mutationFn: async (params: TransferParams): Promise<TransferResult> => {
@@ -61,6 +105,19 @@ export function useTransfer(): UseTransferReturn {
         // Treat it as a delivery-pending SUCCESS, NEVER a re-sendable failure: re-issuing a
         // fresh send() would consume a DIFFERENT source and double-pay the recipient.
         if (getErrorCode(e) === 'CERTIFICATION_UNCONFIRMED') {
+          // Reactive 429/401 annotation (spec §1). Purely additive — the
+          // synthetic pending result below is returned in ALL cases,
+          // regardless of the branch taken here; #631/#633 keep-open
+          // semantics are never altered by this block.
+          if (SUBSCRIPTION_ENABLED) {
+            if (isQuotaRateLimit(e)) {
+              openUpgrade('quota');
+            } else if (isGatewayAuthError(e)) {
+              // Fire-and-forget: the ~/api/utilization round trip must never
+              // delay the pending result below.
+              disambiguateGatewayAuthError(openUpgrade);
+            }
+          }
           // `id` is intentionally empty: ProofUnconfirmedError carries no transferId
           // (the still-open intent + resume own it), and no send UI reads result.id
           // on this path — it exists only to render the "pending" state.

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSphereContext } from '../core/useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { getErrorCode } from '../../errors';
+import { checkSendQuota, QuotaBlockedError } from '../../quotaGate';
+import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
 import type { TransferResult } from '@unicitylabs/sphere-sdk';
 
 export interface TransferParams {
@@ -26,6 +28,25 @@ export function useTransfer(): UseTransferReturn {
   const mutation = useMutation({
     mutationFn: async (params: TransferParams): Promise<TransferResult> => {
       if (!sphere) throw new Error('Wallet not initialized');
+
+      // Proactive quota gate (spec §2): a hard block must land BEFORE the
+      // first submit leaves — after that, #631/#633 keep-open semantics own
+      // the outcome. checkSendQuota() never throws by design; the try/catch
+      // here is a second, defensive layer so a gate malfunction can never
+      // break a send (fail-open at the call site too).
+      if (SUBSCRIPTION_ENABLED) {
+        try {
+          const gate = await checkSendQuota();
+          if (gate.verdict === 'block' && gate.info) {
+            throw new QuotaBlockedError(gate.info);
+          }
+          // 'warn' is UI-only (Task 6's SendModal banner) — no hook effect.
+        } catch (err) {
+          if (err instanceof QuotaBlockedError) throw err;
+          // Swallow anything else (defensive fail-open) and proceed to send.
+        }
+      }
+
       try {
         return await sphere.payments.send({
           coinId: params.coinId,

--- a/src/sdk/quotaGate.ts
+++ b/src/sdk/quotaGate.ts
@@ -1,0 +1,116 @@
+/**
+ * Pre-send quota gate (spec §2, proactive path). A single choke point
+ * (`useTransfer.ts` mutationFn, Task 3) calls `checkSendQuota()` right before
+ * `sphere.payments.send` to decide whether the send should proceed, warn, or
+ * be blocked — WITHOUT throwing itself. The caller owns the decision: it may
+ * construct/throw `QuotaBlockedError` on a `'block'` verdict, show a
+ * non-blocking banner on `'warn'`, or do nothing on `'allow'`.
+ *
+ * Every failure path (flag off, mock mode, no stored key, fetch error,
+ * timeout) resolves to `{verdict:'allow'}` — this module must never block
+ * money on a metering-endpoint problem (spec §2 "Fail-open").
+ */
+import { getUtilization, type UtilizationInfo } from '../services/subscriptionApi';
+import { getStoredSubscriptionKey } from '../config/storageKeys';
+import { SUBSCRIPTION_ENABLED, SUBSCRIPTION_MOCK } from '../config/subscription';
+
+/**
+ * Warn threshold, in remaining per-minute ops. Covers a ≤5-token combination
+ * strategy plus a split's 3 submits (1 burn + 2 output mints — see
+ * `PaymentsModule.ts:1832-1835`). This is a heuristic, not an exact quote:
+ * `SplitPlan`/`SpendPlanner` internals are unexported from sphere-sdk, so the
+ * wallet cannot compute the precise op count before sending (spec §2/§3.1).
+ * A greedy strategy combined with a split can still exceed this headroom.
+ */
+export const SEND_OPS_HEADROOM = 8;
+
+/** Default imperative-fetch timeout before the gate fails open (spec §2). */
+const DEFAULT_TIMEOUT_MS = 2500;
+
+export type QuotaBlockReason = 'expired' | 'exhausted';
+
+/**
+ * Derives the block reason from a `UtilizationInfo` snapshot. `'expired'`
+ * wins when both could apply (an expired plan naturally reads as 0 available
+ * too); everything else that reaches this function is an exhausted quota.
+ * Exported so callers that already have a `'block'` verdict + info can reuse
+ * the exact same derivation `QuotaBlockedError` uses internally.
+ */
+export function blockReason(info: UtilizationInfo): QuotaBlockReason {
+  return info.status === 'expired' ? 'expired' : 'exhausted';
+}
+
+/**
+ * Typed error for callers that want to throw on a `'block'` verdict.
+ * `checkSendQuota` itself never throws this — it only returns the verdict;
+ * the caller (Task 3's `useTransfer` mutationFn) decides to construct and
+ * throw it.
+ */
+export class QuotaBlockedError extends Error {
+  readonly reason: QuotaBlockReason;
+  readonly info: UtilizationInfo;
+
+  constructor(info: UtilizationInfo) {
+    const reason = blockReason(info);
+    super(
+      reason === 'expired'
+        ? 'Your subscription plan has expired. Renew to keep sending.'
+        : 'Send quota exhausted for now. Try again shortly or upgrade your plan.'
+    );
+    this.name = 'QuotaBlockedError';
+    this.reason = reason;
+    this.info = info;
+  }
+}
+
+export interface QuotaVerdict {
+  verdict: 'allow' | 'warn' | 'block';
+  info?: UtilizationInfo;
+}
+
+/**
+ * Imperative (non-react-query) pre-send quota check. See module docstring
+ * for the fail-open contract and spec §2 for the full policy table.
+ */
+export async function checkSendQuota(opts?: { timeoutMs?: number }): Promise<QuotaVerdict> {
+  if (!SUBSCRIPTION_ENABLED || SUBSCRIPTION_MOCK) return { verdict: 'allow' };
+
+  const apiKey = getStoredSubscriptionKey();
+  if (!apiKey) return { verdict: 'allow' };
+
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // jsdom lacks a reliable AbortSignal.timeout; a plain Promise.race timer is
+  // simpler and sufficient here since we only need to stop waiting, not abort
+  // the in-flight fetch.
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs);
+  });
+
+  try {
+    const outcome = await Promise.race([getUtilization(apiKey), timeout]);
+    if (outcome === 'timeout') return { verdict: 'allow' };
+    const info = outcome;
+
+    // Plan-less keys (no plan ever provisioned/attached) fail open — the env
+    // fallback or the gateway itself decides; we must not block money on a
+    // key that was never meant to carry a plan (spec §2 note).
+    if (info.status === 'inactive') return { verdict: 'allow', info };
+
+    if (info.status === 'expired') return { verdict: 'block', info };
+
+    if (info.utilization.availablePerMinute === 0 || info.utilization.availablePerDay === 0) {
+      return { verdict: 'block', info };
+    }
+
+    if (info.utilization.availablePerMinute < SEND_OPS_HEADROOM) {
+      return { verdict: 'warn', info };
+    }
+
+    return { verdict: 'allow', info };
+  } catch {
+    return { verdict: 'allow' };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/sdk/quotaGate.ts
+++ b/src/sdk/quotaGate.ts
@@ -97,7 +97,11 @@ export async function checkSendQuota(opts?: { timeoutMs?: number }): Promise<Quo
     // key that was never meant to carry a plan (spec §2 note).
     if (info.status === 'inactive') return { verdict: 'allow', info };
 
-    if (info.status === 'expired') return { verdict: 'block', info };
+    // 'expired' is NOT a block: since gateway commit f7b9aa7 a lapsed paid key
+    // is lazily demoted to the free tier on its next use — the send this gate
+    // protects would SUCCEED (under free limits). 'expired' only survives in a
+    // ≤60s key-cache window, so blocking here would fail-closed on a send the
+    // gateway accepts. The numeric zero-quota checks below still apply.
 
     if (info.utilization.availablePerMinute === 0 || info.utilization.availablePerDay === 0) {
       return { verdict: 'block', info };

--- a/src/sdk/subscription/planMemory.ts
+++ b/src/sdk/subscription/planMemory.ts
@@ -1,0 +1,38 @@
+/**
+ * Remembers the last plan name observed for a subscription key so the wallet
+ * can detect the gateway's silent paid→free demotion (a lapsed paid key is
+ * lazily demoted to the free tier on its next use — no 401, no 'expired'
+ * state survives past the ~60s key cache) and prompt the user once to renew.
+ *
+ * Slot carries the `sphere_` prefix so `clearAllSphereData()` wipes it with
+ * everything else on wallet deletion.
+ */
+import { STORAGE_KEYS } from '../../config/storageKeys';
+
+const SLOT_PREFIX = `${STORAGE_KEYS.SUBSCRIPTION_API_KEY}.last_plan.`;
+
+export function getLastKnownPlan(apiKey: string): string | null {
+  return localStorage.getItem(SLOT_PREFIX + apiKey);
+}
+
+export function rememberPlan(apiKey: string, planName: string): void {
+  localStorage.setItem(SLOT_PREFIX + apiKey, planName);
+}
+
+/**
+ * True exactly when a key we previously saw on a PAID plan now reports the
+ * free plan with no expiry — the shape the gateway's lazy demotion produces.
+ * First observation (no remembered plan) is never a downgrade.
+ */
+export function isPaidToFreeDowngrade(
+  lastPlan: string | null,
+  currentPlan: string,
+  activeUntil: string | null,
+): boolean {
+  return (
+    lastPlan !== null &&
+    lastPlan.toLowerCase() !== 'free' &&
+    currentPlan.toLowerCase() === 'free' &&
+    activeUntil === null
+  );
+}

--- a/tests/unit/components/upgradeReason.test.tsx
+++ b/tests/unit/components/upgradeReason.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UpgradeReasonBanner } from '@/components/upgrade/UpgradeModal';
+
+describe('UpgradeReasonBanner', () => {
+  it('renders the quota banner for reason "quota"', () => {
+    render(<UpgradeReasonBanner reason="quota" />);
+    expect(screen.queryByText(/hit your plan's limit/i)).not.toBeNull();
+    expect(screen.queryByText(/plan has expired/i)).toBeNull();
+  });
+
+  it('renders the expired banner for reason "expired"', () => {
+    render(<UpgradeReasonBanner reason="expired" />);
+    expect(
+      screen.queryByText(/your plan has expired — renew to restore your limits\./i),
+    ).not.toBeNull();
+    expect(screen.queryByText(/hit your plan's limit/i)).toBeNull();
+  });
+
+  it('renders no banner for reason "settings"', () => {
+    const { container } = render(<UpgradeReasonBanner reason="settings" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders no banner when reason is undefined', () => {
+    const { container } = render(<UpgradeReasonBanner reason={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { createElement, useState, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SphereError } from '@unicitylabs/sphere-sdk';
@@ -26,8 +26,37 @@ vi.mock('../../../src/config/subscription', async (orig) => ({
   SUBSCRIPTION_ENABLED: true,
 }));
 
+// Task 4: reactive 429/401 annotation. Mock the upgrade barrel (simpler than
+// wrapping renderHook in a real UpgradeProvider) and the disambiguation
+// dependencies (getUtilization, getStoredSubscriptionKey, showToast).
+vi.mock('../../../src/components/upgrade', () => ({
+  useUpgrade: vi.fn(),
+}));
+vi.mock('../../../src/services/subscriptionApi', async (orig) => ({
+  ...(await orig<typeof import('../../../src/services/subscriptionApi')>()),
+  getUtilization: vi.fn(),
+}));
+vi.mock('../../../src/config/storageKeys', async (orig) => ({
+  ...(await orig<typeof import('../../../src/config/storageKeys')>()),
+  getStoredSubscriptionKey: vi.fn(),
+}));
+vi.mock('../../../src/components/ui/toast-utils', () => ({
+  showToast: vi.fn(),
+}));
+
 import { checkSendQuota, QuotaBlockedError } from '../../../src/sdk/quotaGate';
 import * as subscriptionConfig from '../../../src/config/subscription';
+import { useUpgrade } from '../../../src/components/upgrade';
+import { getUtilization } from '../../../src/services/subscriptionApi';
+import { getStoredSubscriptionKey } from '../../../src/config/storageKeys';
+import { showToast } from '../../../src/components/ui/toast-utils';
+
+// Fabricate the duck-typed transport error shape that JsonRpcNetworkError
+// (state-transition-sdk, never exported from sphere-sdk) satisfies today —
+// mirrors tests/unit/sdk/gatewayErrors.test.ts.
+function jsonRpcNetworkError(status: number, name = 'JsonRpcNetworkError') {
+  return { name, status, message: 'transport error' };
+}
 
 function utilization(overrides: { status?: UtilizationInfo['status']; availablePerMinute?: number } = {}): UtilizationInfo {
   return {
@@ -58,10 +87,18 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 const PARAMS = { coinId: 'c', amount: '100', recipient: '@bob' };
 
+let openUpgradeMock: ReturnType<typeof vi.fn>;
+
 beforeEach(() => {
   fakeSphere = null;
   vi.mocked(checkSendQuota).mockReset().mockResolvedValue({ verdict: 'allow' });
   (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
+
+  openUpgradeMock = vi.fn();
+  vi.mocked(useUpgrade).mockReset().mockReturnValue({ openUpgrade: openUpgradeMock });
+  vi.mocked(getUtilization).mockReset();
+  vi.mocked(getStoredSubscriptionKey).mockReset().mockReturnValue('sk_test');
+  vi.mocked(showToast).mockReset();
 });
 
 describe('useTransfer — #631/#633 possibly-certified send', () => {
@@ -186,5 +223,104 @@ describe('useTransfer — proactive quota gate (Task 3)', () => {
     expect(res).toEqual(ok);
     expect(checkSendQuota).not.toHaveBeenCalled();
     expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useTransfer — reactive 429/401 annotation (Task 4)', () => {
+  it('opens the upgrade modal with reason "quota" on a 429 cause (still delivery-pending)', async () => {
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED', jsonRpcNetworkError(429)),
+    );
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    expect(res?.deliveryPending).toBe(true);
+    expect(openUpgradeMock).toHaveBeenCalledWith('quota');
+  });
+
+  it('disambiguates a 401 cause via getUtilization: expired status → openUpgrade("expired")', async () => {
+    vi.mocked(getUtilization).mockResolvedValue(utilization({ status: 'expired' }));
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED', jsonRpcNetworkError(401)),
+    );
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    // Synthetic pending result returns immediately — disambiguation is fire-and-forget.
+    expect(res?.deliveryPending).toBe(true);
+    await waitFor(() => expect(openUpgradeMock).toHaveBeenCalledWith('expired'));
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('disambiguates a 401 cause via getUtilization: rejection → warns + toasts, no upgrade modal', async () => {
+    vi.mocked(getUtilization).mockRejectedValue(new Error('unauthorized'));
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED', jsonRpcNetworkError(401)),
+    );
+    fakeSphere = { payments: { send } };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    expect(res?.deliveryPending).toBe(true);
+    await waitFor(() => expect(showToast).toHaveBeenCalled());
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringMatching(/subscription key was rejected/i),
+      'error',
+      6000,
+    );
+    expect(openUpgradeMock).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not open the upgrade modal for a plain CERTIFICATION_UNCONFIRMED (no cause)', async () => {
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed — the source spend may be on-chain', 'CERTIFICATION_UNCONFIRMED'),
+    );
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    expect(res?.deliveryPending).toBe(true);
+    expect(openUpgradeMock).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+    expect(getUtilization).not.toHaveBeenCalled();
+  });
+
+  it('never annotates when SUBSCRIPTION_ENABLED is false, even on a 429 cause', async () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED', jsonRpcNetworkError(429)),
+    );
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    expect(res?.deliveryPending).toBe(true);
+    expect(openUpgradeMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react';
 import { createElement, useState, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SphereError } from '@unicitylabs/sphere-sdk';
+import type { UtilizationInfo } from '../../../src/services/subscriptionApi';
 import { useTransfer } from '../../../src/sdk/hooks/payments/useTransfer';
 
 // The hook reads the wallet from useSphereContext — swap in a fake with just
@@ -12,6 +13,39 @@ let fakeSphere: { payments: { send: ReturnType<typeof vi.fn> } } | null = null;
 vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
   useSphereContext: () => ({ sphere: fakeSphere }),
 }));
+
+// Task 3: proactive quota gate. Mock checkSendQuota (keep the real
+// QuotaBlockedError class so `instanceof` in useTransfer still works) and
+// make SUBSCRIPTION_ENABLED independently toggleable per test.
+vi.mock('../../../src/sdk/quotaGate', async (orig) => ({
+  ...(await orig<typeof import('../../../src/sdk/quotaGate')>()),
+  checkSendQuota: vi.fn(),
+}));
+vi.mock('../../../src/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('../../../src/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: true,
+}));
+
+import { checkSendQuota, QuotaBlockedError } from '../../../src/sdk/quotaGate';
+import * as subscriptionConfig from '../../../src/config/subscription';
+
+function utilization(overrides: { status?: UtilizationInfo['status']; availablePerMinute?: number } = {}): UtilizationInfo {
+  return {
+    status: overrides.status ?? 'active',
+    plan: { name: 'free', requestsPerMinute: 60, requestsPerDay: 1000 },
+    activeUntil: null,
+    utilization: {
+      consumedPerMinute: 0,
+      maxPerMinute: 60,
+      availablePerMinute: overrides.availablePerMinute ?? 60,
+      utilizationPercentPerMinute: 0,
+      consumedPerDay: 0,
+      maxPerDay: 1000,
+      availablePerDay: 1000,
+      utilizationPercentPerDay: 0,
+    },
+  };
+}
 
 function Wrapper({ children }: { children: ReactNode }) {
   // One stable client per wrapper instance — a fresh QueryClient on each render
@@ -26,6 +60,8 @@ const PARAMS = { coinId: 'c', amount: '100', recipient: '@bob' };
 
 beforeEach(() => {
   fakeSphere = null;
+  vi.mocked(checkSendQuota).mockReset().mockResolvedValue({ verdict: 'allow' });
+  (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
 });
 
 describe('useTransfer — #631/#633 possibly-certified send', () => {
@@ -71,5 +107,84 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
       res = await result.current.transfer(PARAMS);
     });
     expect(res).toEqual(ok);
+  });
+});
+
+describe('useTransfer — proactive quota gate (Task 3)', () => {
+  it('rejects with QuotaBlockedError and never calls send on a "block" verdict', async () => {
+    const info = utilization({ status: 'expired' });
+    vi.mocked(checkSendQuota).mockResolvedValue({ verdict: 'block', info });
+    const send = vi.fn().mockResolvedValue({ id: 't1', status: 'completed', tokens: [], tokenTransfers: [] });
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    await expect(
+      act(async () => {
+        await result.current.transfer(PARAMS);
+      }),
+    ).rejects.toThrow(QuotaBlockedError);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to send on an "allow" verdict', async () => {
+    vi.mocked(checkSendQuota).mockResolvedValue({ verdict: 'allow' });
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: unknown;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+    expect(res).toEqual(ok);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('proceeds to send on a "warn" verdict (UI-only, no hook effect)', async () => {
+    const info = utilization({ availablePerMinute: 3 });
+    vi.mocked(checkSendQuota).mockResolvedValue({ verdict: 'warn', info });
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: unknown;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+    expect(res).toEqual(ok);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('still calls send when checkSendQuota throws unexpectedly (defensive fail-open)', async () => {
+    vi.mocked(checkSendQuota).mockRejectedValue(new Error('boom'));
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: unknown;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+    expect(res).toEqual(ok);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('never calls checkSendQuota when SUBSCRIPTION_ENABLED is false', async () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: unknown;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+    expect(res).toEqual(ok);
+    expect(checkSendQuota).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -307,6 +307,33 @@ describe('useTransfer — reactive 429/401 annotation (Task 4)', () => {
     expect(getUtilization).not.toHaveBeenCalled();
   });
 
+  it('still resolves delivery-pending when the annotation itself throws synchronously (401 + storage-blocked iframe)', async () => {
+    // Money-safety invariant: disambiguateGatewayAuthError's FIRST statement
+    // is getStoredSubscriptionKey() → localStorage.getItem, which throws a
+    // SecurityError in storage-blocked iframes. That throw must never escape
+    // ahead of the synthetic pending return — a possibly-certified spend
+    // surfacing as a hard failure invites a re-send (double-pay).
+    vi.mocked(getStoredSubscriptionKey).mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED', jsonRpcNetworkError(401)),
+    );
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    // Resolved as pending, NOT rejected — annotation failure is swallowed.
+    expect(res?.deliveryPending).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(openUpgradeMock).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
   it('never annotates when SUBSCRIPTION_ENABLED is false, even on a 429 cause', async () => {
     (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
     const send = vi.fn().mockRejectedValue(

--- a/tests/unit/sdk/gatewayErrors.test.ts
+++ b/tests/unit/sdk/gatewayErrors.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { SphereError } from '@unicitylabs/sphere-sdk';
+import { getGatewayHttpStatus, isQuotaRateLimit, isGatewayAuthError } from '@/sdk/errors';
+
+// Fabricate the duck-typed transport error shape that JsonRpcNetworkError
+// (state-transition-sdk, never exported from sphere-sdk) satisfies today.
+function jsonRpcNetworkError(status: number, name = 'JsonRpcNetworkError') {
+  return { name, status, message: 'transport error' };
+}
+
+describe('getGatewayHttpStatus', () => {
+  it('reads status off a CERTIFICATION_UNCONFIRMED cause duck-typing JsonRpcNetworkError (429)', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(429)
+    );
+    expect(getGatewayHttpStatus(err)).toBe(429);
+  });
+
+  it('reads status off a CERTIFICATION_UNCONFIRMED cause duck-typing JsonRpcNetworkError (401)', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(401)
+    );
+    expect(getGatewayHttpStatus(err)).toBe(401);
+  });
+
+  it('reads status off a CERTIFICATION_UNCONFIRMED cause duck-typing JsonRpcNetworkError (403)', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(403)
+    );
+    expect(getGatewayHttpStatus(err)).toBe(403);
+  });
+
+  it('returns null when the cause has the wrong name', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      { name: 'SleepError', status: 429 }
+    );
+    expect(getGatewayHttpStatus(err)).toBeNull();
+  });
+
+  it('returns null when cause is missing entirely', () => {
+    const err = new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED');
+    expect(getGatewayHttpStatus(err)).toBeNull();
+  });
+
+  it('returns null for a SphereError with a different code, even with a valid-shaped cause', () => {
+    const err = new SphereError('transfer failed', 'TRANSFER_FAILED', jsonRpcNetworkError(429));
+    expect(getGatewayHttpStatus(err)).toBeNull();
+  });
+
+  it('reads status off a raw error duck-typing JsonRpcNetworkError (pre-first-submit throw)', () => {
+    const raw = jsonRpcNetworkError(429);
+    expect(getGatewayHttpStatus(raw)).toBe(429);
+  });
+
+  it('returns null for a plain Error', () => {
+    expect(getGatewayHttpStatus(new Error('boom'))).toBeNull();
+  });
+
+  it('returns null for a string', () => {
+    expect(getGatewayHttpStatus('nope')).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(getGatewayHttpStatus(null)).toBeNull();
+    expect(getGatewayHttpStatus(undefined)).toBeNull();
+  });
+
+  // Contract canary — see spec §5 "Duck-typed cause detection depends on
+  // JsonRpcNetworkError's name/status fields (state-transition-sdk pinned
+  // 2.0.0-rc.68bc1e5) ... A state-transition-sdk bump could silently break
+  // detection; add a unit test that fails loudly if the shape changes."
+  // This test pins the exact duck-shape our classifier trusts. If a
+  // state-transition-sdk upgrade renames `name`/`status` on its transport
+  // error, this is the test that should go red first, before it's discovered
+  // in production as a gate that silently stops firing.
+  it('CONTRACT CANARY: duck-shape is exactly {name: string, status: number}', () => {
+    const shape = jsonRpcNetworkError(429);
+    expect(shape).toHaveProperty('name', 'JsonRpcNetworkError');
+    expect(shape).toHaveProperty('status', 429);
+    expect(typeof shape.status).toBe('number');
+    expect(getGatewayHttpStatus(shape)).toBe(429);
+  });
+});
+
+describe('isQuotaRateLimit', () => {
+  it('is true for a 429 cause', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(429)
+    );
+    expect(isQuotaRateLimit(err)).toBe(true);
+  });
+
+  it('is false for a 401 cause', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(401)
+    );
+    expect(isQuotaRateLimit(err)).toBe(false);
+  });
+
+  it('is false when there is no gateway status', () => {
+    expect(isQuotaRateLimit(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('isGatewayAuthError', () => {
+  it('is true for a 401 cause', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(401)
+    );
+    expect(isGatewayAuthError(err)).toBe(true);
+  });
+
+  it('is true for a 403 cause', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(403)
+    );
+    expect(isGatewayAuthError(err)).toBe(true);
+  });
+
+  it('is false for a 429 cause', () => {
+    const err = new SphereError(
+      'certification unconfirmed',
+      'CERTIFICATION_UNCONFIRMED',
+      jsonRpcNetworkError(429)
+    );
+    expect(isGatewayAuthError(err)).toBe(false);
+  });
+
+  it('is false when there is no gateway status', () => {
+    expect(isGatewayAuthError('nope')).toBe(false);
+  });
+});

--- a/tests/unit/sdk/planMemory.test.ts
+++ b/tests/unit/sdk/planMemory.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getLastKnownPlan, rememberPlan, isPaidToFreeDowngrade } from '@/sdk/subscription/planMemory';
+
+describe('planMemory', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips the last known plan per key', () => {
+    expect(getLastKnownPlan('sk_a')).toBeNull();
+    rememberPlan('sk_a', 'standard');
+    rememberPlan('sk_b', 'free');
+    expect(getLastKnownPlan('sk_a')).toBe('standard');
+    expect(getLastKnownPlan('sk_b')).toBe('free');
+  });
+
+  it('uses a sphere_-prefixed slot (wiped by clearAllSphereData)', () => {
+    rememberPlan('sk_a', 'basic');
+    const keys = Object.keys(localStorage);
+    expect(keys.some((k) => k.startsWith('sphere_') && k.includes('sk_a'))).toBe(true);
+  });
+});
+
+describe('isPaidToFreeDowngrade', () => {
+  it('detects paid → free with cleared expiry (the gateway demotion shape)', () => {
+    expect(isPaidToFreeDowngrade('standard', 'free', null)).toBe(true);
+    expect(isPaidToFreeDowngrade('Premium', 'FREE', null)).toBe(true); // case-insensitive
+  });
+
+  it('never fires on first observation (nothing remembered)', () => {
+    expect(isPaidToFreeDowngrade(null, 'free', null)).toBe(false);
+  });
+
+  it('never fires for free → free or paid → paid', () => {
+    expect(isPaidToFreeDowngrade('free', 'free', null)).toBe(false);
+    expect(isPaidToFreeDowngrade('basic', 'standard', '2026-08-01T00:00:00Z')).toBe(false);
+  });
+
+  it('never fires when the free plan still carries an expiry (not the demotion shape)', () => {
+    expect(isPaidToFreeDowngrade('basic', 'free', '2026-08-01T00:00:00Z')).toBe(false);
+  });
+});

--- a/tests/unit/sdk/quotaGate.test.ts
+++ b/tests/unit/sdk/quotaGate.test.ts
@@ -89,8 +89,17 @@ describe('checkSendQuota', () => {
     expect(result).toEqual({ verdict: 'allow' });
   });
 
-  it('blocks with reason "expired" when status is expired', async () => {
+  it('does NOT block on transient "expired" status (gateway lazily demotes lapsed keys to free — the send would succeed)', async () => {
+    // Per gateway docs, a not-yet-demoted expired key reports consumed*=0 and
+    // max*=plan limits, so the numeric checks below see available quota.
     const info = utilization({ status: 'expired' });
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'allow', info });
+  });
+
+  it('still blocks an expired-status snapshot when the quota numbers are exhausted', async () => {
+    const info = utilization({ status: 'expired', availablePerMinute: 0 });
     vi.mocked(getUtilization).mockResolvedValue(info);
     const result = await checkSendQuota();
     expect(result).toEqual({ verdict: 'block', info });

--- a/tests/unit/sdk/quotaGate.test.ts
+++ b/tests/unit/sdk/quotaGate.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UtilizationInfo } from '@/services/subscriptionApi';
+
+vi.mock('@/services/subscriptionApi', () => ({
+  getUtilization: vi.fn(),
+}));
+vi.mock('@/config/storageKeys', async (orig) => ({
+  ...(await orig<typeof import('@/config/storageKeys')>()),
+  getStoredSubscriptionKey: vi.fn(),
+}));
+vi.mock('@/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('@/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: true,
+  SUBSCRIPTION_MOCK: false,
+}));
+
+import { checkSendQuota, QuotaBlockedError, SEND_OPS_HEADROOM } from '@/sdk/quotaGate';
+import { getUtilization } from '@/services/subscriptionApi';
+import { getStoredSubscriptionKey } from '@/config/storageKeys';
+import * as subscriptionConfig from '@/config/subscription';
+
+function utilization(overrides: {
+  status?: UtilizationInfo['status'];
+  availablePerMinute?: number;
+  availablePerDay?: number;
+}): UtilizationInfo {
+  return {
+    status: overrides.status ?? 'active',
+    plan: { name: 'free', requestsPerMinute: 60, requestsPerDay: 1000 },
+    activeUntil: null,
+    utilization: {
+      consumedPerMinute: 0,
+      maxPerMinute: 60,
+      availablePerMinute: overrides.availablePerMinute ?? 60,
+      utilizationPercentPerMinute: 0,
+      consumedPerDay: 0,
+      maxPerDay: 1000,
+      availablePerDay: overrides.availablePerDay ?? 1000,
+      utilizationPercentPerDay: 0,
+    },
+  };
+}
+
+describe('checkSendQuota', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getStoredSubscriptionKey).mockReturnValue('key_abc');
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
+    (subscriptionConfig as { SUBSCRIPTION_MOCK: boolean }).SUBSCRIPTION_MOCK = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fails open when the flag is off', async () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'allow' });
+    expect(getUtilization).not.toHaveBeenCalled();
+  });
+
+  it('fails open in mock mode', async () => {
+    (subscriptionConfig as { SUBSCRIPTION_MOCK: boolean }).SUBSCRIPTION_MOCK = true;
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'allow' });
+    expect(getUtilization).not.toHaveBeenCalled();
+  });
+
+  it('fails open when there is no stored key', async () => {
+    vi.mocked(getStoredSubscriptionKey).mockReturnValue(null);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'allow' });
+    expect(getUtilization).not.toHaveBeenCalled();
+  });
+
+  it('fails open when getUtilization throws', async () => {
+    vi.mocked(getUtilization).mockRejectedValue(new Error('network error'));
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'allow' });
+  });
+
+  it('fails open on timeout', async () => {
+    vi.useFakeTimers();
+    vi.mocked(getUtilization).mockReturnValue(new Promise<UtilizationInfo>(() => {})); // never resolves
+    const pending = checkSendQuota({ timeoutMs: 100 });
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await pending;
+    expect(result).toEqual({ verdict: 'allow' });
+  });
+
+  it('blocks with reason "expired" when status is expired', async () => {
+    const info = utilization({ status: 'expired' });
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'block', info });
+  });
+
+  it('blocks with reason "exhausted" when availablePerMinute is 0', async () => {
+    const info = utilization({ availablePerMinute: 0 });
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'block', info });
+  });
+
+  it('blocks with reason "exhausted" when availablePerDay is 0', async () => {
+    const info = utilization({ availablePerDay: 0 });
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'block', info });
+  });
+
+  it('warns when availablePerMinute is under the headroom constant', async () => {
+    const info = utilization({ availablePerMinute: 5 });
+    expect(5).toBeLessThan(SEND_OPS_HEADROOM);
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'warn', info });
+  });
+
+  it('allows with info when healthy', async () => {
+    const info = utilization({ availablePerMinute: 60, availablePerDay: 1000 });
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result).toEqual({ verdict: 'allow', info });
+  });
+
+  it('allows plan-less (inactive) keys without blocking', async () => {
+    const info = utilization({ status: 'inactive', availablePerMinute: 0, availablePerDay: 0 });
+    vi.mocked(getUtilization).mockResolvedValue(info);
+    const result = await checkSendQuota();
+    expect(result.verdict).toBe('allow');
+  });
+});
+
+describe('QuotaBlockedError', () => {
+  it('carries reason "expired" and the triggering info', () => {
+    const info = utilization({ status: 'expired' });
+    const err = new QuotaBlockedError(info);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.reason).toBe('expired');
+    expect(err.info).toBe(info);
+  });
+
+  it('carries reason "exhausted" for a non-expired, quota-depleted info', () => {
+    const info = utilization({ availablePerMinute: 0 });
+    const err = new QuotaBlockedError(info);
+    expect(err.reason).toBe('exhausted');
+    expect(err.info).toBe(info);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 of the subscription migration: when a send would exceed (or already hit) the SGW quota, the wallet now explains WHY and routes to the Upgrade modal — instead of a silent \"delivery pending\" or a generic error. Stacked on #402.

### Proactive gate (the real fix)
- **`checkSendQuota()`** (`src/sdk/quotaGate.ts`): imperative `GET /api/utilization` check (2.5s timeout) at the top of `useTransfer.mutationFn`, before any spend. Policy: **block** on `status='expired'` or zero remaining (minute/day); **warn** below `SEND_OPS_HEADROOM=8`; **fail-open** on no key / mock / flag off / fetch error / timeout — metering failure never blocks money.
- `QuotaBlockedError` surfaces in SendModal as a warning with reason-specific copy + **Upgrade** button; SendIntentModal rejects the dApp intent with a quota-specific message (same `TRANSFER_FAILED` contract) and opens the Upgrade modal.

### Reactive annotation (money-safety preserved)
- A rate-limited submit surfaces as `CERTIFICATION_UNCONFIRMED` (#631) — the synthetic pending result is **untouchable** and still returned on every path. New: the wallet reads the HTTP status off the error's cause (`getGatewayHttpStatus`, duck-typed, no deep SDK imports): **429 → `openUpgrade('quota')`**; **401/403 → disambiguation** via utilization (expired → `openUpgrade('expired')`, invalid/revoked → toast pointing at Settings re-activation). The whole annotation is throw-proof (swallow-all guard) with a RED-verified regression test.

### Also
- Typed `UpgradeReason = 'quota' | 'expired' | 'settings'` + expired-plan banner in UpgradeModal.
- **Fix from final review:** `UpgradeProvider` now mounts above `ConnectProvider` — `ConnectIntentHandler` renders its modals as a sibling of children, so the previous order crashed the app on any dApp send intent.
- Merged main: sphere-sdk **0.11.4** (split-checkpoint resume) + `split:checkpoint-stuck` surfacing.

### Verification
- `tsc -b` zero errors; **177/177 tests** (incl. new gate/classifier/regression suites); lint clean; build ok.
- **Live SGW check**: free plan shrunk to 2 rpm → 3rd `certification_request` got 429; `/api/utilization` showed `availablePerMinute: 0` (the gate's block threshold). Plan restored.
- Final whole-branch review: READY TO MERGE after 2 findings fixed (provider order, throw window).

### Known limitations (accepted; spec'd as SDK follow-ups)
- No precise commitment-count estimation wallet-side (SDK doesn't export the split planner) — follow-up: `sphere.payments.estimateSend()`.
- Reactive trigger fires after the ~60s per-op timeout (SDK doesn't fail fast on 429 mid-send) — follow-up: typed `RATE_LIMITED` pre-first-submit.
- No automated test renders the real main.tsx provider composition — manual dApp send-intent smoke recommended post-merge.