### PR TITLE
feat(subscription): wallet-level key via index-0 identity, per-address opt-out

### DIFF
--- a/src/components/subscription/AddressKeyPromptModal.tsx
+++ b/src/components/subscription/AddressKeyPromptModal.tsx
@@ -11,6 +11,7 @@ import { KeyRound } from 'lucide-react';
 import { BaseModal } from '../wallet/ui/BaseModal';
 import { Button } from '../wallet/ui';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
+import { useUtilization } from '../../sdk/hooks/subscription';
 import { setAddressPreference } from '../../sdk/subscription/keyVault';
 import { useUpgrade } from '../upgrade';
 
@@ -19,6 +20,12 @@ const KEY_RE = /^sk_[0-9a-f]{32}$/;
 export function AddressKeyPromptModal() {
   const { sphere, network, applySubscriptionKey } = useSphereContext();
   const { openUpgrade } = useUpgrade();
+  // The wallet key is already applied provisionally when this prompt opens,
+  // so the current utilization snapshot describes exactly the plan the user
+  // would inherit by keeping the checkbox on.
+  const util = useUtilization();
+  const inheritedPlanName = util.data?.plan?.name ?? null;
+  const nametag = sphere?.identity?.nametag ?? null;
 
   const [isOpen, setIsOpen] = useState(false);
   const [useWalletKey, setUseWalletKey] = useState(true); // default: inherit the wallet's primary key
@@ -72,10 +79,13 @@ export function AddressKeyPromptModal() {
   return (
     <BaseModal isOpen={isOpen} onClose={close} size="sm">
       <div className="p-5">
-        <div className="mb-3 flex items-center gap-2">
+        <div className="mb-1 flex items-center gap-2">
           <KeyRound className="h-5 w-5 text-orange-500" />
           <h3 className="font-semibold">No subscription key for this address</h3>
         </div>
+        {nametag && (
+          <p className="mb-2 text-sm font-mono text-orange-500">@{nametag}</p>
+        )}
         <p className="mb-4 text-sm text-neutral-500 dark:text-white/45">
           Sends from this address need an aggregator key. Use your wallet's primary key, enter an
           existing one, or buy a plan just for this address.
@@ -89,7 +99,10 @@ export function AddressKeyPromptModal() {
               onChange={(e) => setUseWalletKey(e.target.checked)}
               className="mt-0.5 accent-orange-500"
             />
-            <span>Use my wallet's primary key (address #1)</span>
+            <span>
+              Use my wallet's primary key (address #1
+              {inheritedPlanName ? <> — <span className="capitalize">{inheritedPlanName}</span> plan</> : null})
+            </span>
           </label>
         )}
 

--- a/src/components/subscription/AddressKeyPromptModal.tsx
+++ b/src/components/subscription/AddressKeyPromptModal.tsx
@@ -1,0 +1,126 @@
+/**
+ * One-time prompt shown when the user switches to an address that has no
+ * subscription key and no recorded preference (SphereProvider raises the
+ * 'subscription-address-prompt' DOM event after resolving the switch — the
+ * wallet key is already applied provisionally, so "Continue" just records
+ * the inherit choice). Buying or entering a key stores it as THIS address's
+ * own key.
+ */
+import { useEffect, useState } from 'react';
+import { KeyRound } from 'lucide-react';
+import { BaseModal } from '../wallet/ui/BaseModal';
+import { Button } from '../wallet/ui';
+import { useSphereContext } from '../../sdk/hooks/core/useSphere';
+import { setAddressPreference } from '../../sdk/subscription/keyVault';
+import { useUpgrade } from '../upgrade';
+
+const KEY_RE = /^sk_[0-9a-f]{32}$/;
+
+export function AddressKeyPromptModal() {
+  const { sphere, network, applySubscriptionKey } = useSphereContext();
+  const { openUpgrade } = useUpgrade();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [useWalletKey, setUseWalletKey] = useState(true); // default: inherit the wallet's primary key
+  const [showKeyInput, setShowKeyInput] = useState(false);
+  const [keyInput, setKeyInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const open = () => {
+      setUseWalletKey(true);
+      setShowKeyInput(false);
+      setKeyInput('');
+      setError(null);
+      setIsOpen(true);
+    };
+    window.addEventListener('subscription-address-prompt', open);
+    return () => window.removeEventListener('subscription-address-prompt', open);
+  }, []);
+
+  const close = () => setIsOpen(false);
+
+  const handleContinue = async () => {
+    if (!sphere) return close();
+    setBusy(true);
+    setError(null);
+    try {
+      if (showKeyInput && keyInput) {
+        // Own key for this address ('own' preference recorded by the vault).
+        await applySubscriptionKey(keyInput.trim(), { walletWide: false });
+      } else if (useWalletKey) {
+        // Wallet key is already applied provisionally — just remember the choice.
+        await setAddressPreference(sphere, network, 'inherit');
+      }
+      close();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to apply the key');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleBuy = () => {
+    close(); // checkout adoption stores the bought key as this address's own key
+    openUpgrade();
+  };
+
+  const keyValid = KEY_RE.test(keyInput.trim());
+  const continueDisabled = busy || (showKeyInput ? !keyValid : !useWalletKey);
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={close} size="sm">
+      <div className="p-5">
+        <div className="mb-3 flex items-center gap-2">
+          <KeyRound className="h-5 w-5 text-orange-500" />
+          <h3 className="font-semibold">No subscription key for this address</h3>
+        </div>
+        <p className="mb-4 text-sm text-neutral-500 dark:text-white/45">
+          Sends from this address need an aggregator key. Use your wallet's primary key, enter an
+          existing one, or buy a plan just for this address.
+        </p>
+
+        {!showKeyInput && (
+          <label className="mb-4 flex cursor-pointer items-start gap-2.5 text-sm">
+            <input
+              type="checkbox"
+              checked={useWalletKey}
+              onChange={(e) => setUseWalletKey(e.target.checked)}
+              className="mt-0.5 accent-orange-500"
+            />
+            <span>Use my wallet's primary key (address #1)</span>
+          </label>
+        )}
+
+        {showKeyInput && (
+          <input
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            placeholder="sk_…"
+            className="mb-4 w-full rounded-xl border border-neutral-200 bg-white px-4 py-2.5 font-mono text-sm outline-none focus:border-orange-500 dark:border-white/10 dark:bg-white/5"
+          />
+        )}
+
+        {error && <p className="mb-3 text-sm text-red-500">{error}</p>}
+
+        <Button variant="primary" fullWidth loading={busy} disabled={continueDisabled} onClick={handleContinue}>
+          Continue
+        </Button>
+
+        <div className="mt-3 flex items-center justify-center gap-4 text-sm">
+          <button
+            type="button"
+            className="text-neutral-500 underline dark:text-white/45"
+            onClick={() => { setShowKeyInput(!showKeyInput); setError(null); }}
+          >
+            {showKeyInput ? 'Use the wallet key instead' : 'Enter an existing key'}
+          </button>
+          <button type="button" className="text-neutral-500 underline dark:text-white/45" onClick={handleBuy}>
+            Buy a plan
+          </button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/subscription/AddressKeyPromptModal.tsx
+++ b/src/components/subscription/AddressKeyPromptModal.tsx
@@ -11,7 +11,7 @@
  *   quota, provisioned against the active address identity);
  * - enter a key / buy     → that key becomes this address's own key.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { KeyRound } from 'lucide-react';
 import { BaseModal } from '../wallet/ui/BaseModal';
 import { Button } from '../wallet/ui';
@@ -24,6 +24,13 @@ import { useUpgrade } from '../upgrade';
 
 const KEY_RE = /^sk_[0-9a-f]{32}$/;
 
+/** Human identifier for an address: its nametag, else a short Unicity ID. */
+function formatIdentity(nametag?: string | null, chainPubkey?: string | null): string | null {
+  if (nametag) return `@${nametag}`;
+  if (chainPubkey) return `Unicity ID · ${truncateAddress(chainPubkey, 10, 6)}`;
+  return null;
+}
+
 export function AddressKeyPromptModal() {
   const { sphere, network, applySubscriptionKey } = useSphereContext();
   const { openUpgrade } = useUpgrade();
@@ -34,6 +41,18 @@ export function AddressKeyPromptModal() {
   const inheritedPlanName = util.data?.plan?.name ?? null;
   const nametag = sphere?.identity?.nametag ?? null;
   const chainPubkey = sphere?.identity?.chainPubkey ?? null;
+
+  // Identity of the wallet's primary address (#1 / index 0) — the one whose
+  // key is inherited. Its nametag comes from the tracked-address cache; when
+  // absent (or not yet cached) we fall back to its short Unicity ID.
+  const rootIdentity = useMemo(() => {
+    try {
+      const root = sphere?.getTrackedAddress(0);
+      return formatIdentity(root?.nametag, root?.chainPubkey);
+    } catch {
+      return null;
+    }
+  }, [sphere]);
 
   const [isOpen, setIsOpen] = useState(false);
   const [useWalletKey, setUseWalletKey] = useState(true); // default: inherit the wallet's primary key
@@ -104,11 +123,7 @@ export function AddressKeyPromptModal() {
     openUpgrade();
   };
 
-  const identifier = nametag
-    ? `@${nametag}`
-    : chainPubkey
-      ? `Unicity ID · ${truncateAddress(chainPubkey, 10, 6)}`
-      : null;
+  const identifier = formatIdentity(nametag, chainPubkey);
 
   const keyValid = KEY_RE.test(keyInput.trim());
   const continueDisabled = busy || (showKeyInput && !keyValid);
@@ -135,7 +150,7 @@ export function AddressKeyPromptModal() {
               className="mt-0.5 accent-orange-500"
             />
             <span>
-              Use my wallet's primary key (address #1
+              Use my wallet's primary key ({rootIdentity ?? 'address #1'}
               {inheritedPlanName ? <> — <span className="capitalize">{inheritedPlanName}</span> plan</> : null})
             </span>
           </label>

--- a/src/components/subscription/AddressKeyPromptModal.tsx
+++ b/src/components/subscription/AddressKeyPromptModal.tsx
@@ -2,9 +2,14 @@
  * One-time prompt shown when the user switches to an address that has no
  * subscription key and no recorded preference (SphereProvider raises the
  * 'subscription-address-prompt' DOM event after resolving the switch — the
- * wallet key is already applied provisionally, so "Continue" just records
- * the inherit choice). Buying or entering a key stores it as THIS address's
- * own key.
+ * wallet key is applied provisionally meanwhile).
+ *
+ * Outcomes (each records a per-address preference so the prompt never repeats
+ * for this address):
+ * - keep the checkbox on  → inherit the wallet's primary key;
+ * - checkbox off / dismiss → this address gets its OWN free plan (separate
+ *   quota, provisioned against the active address identity);
+ * - enter a key / buy     → that key becomes this address's own key.
  */
 import { useEffect, useState } from 'react';
 import { KeyRound } from 'lucide-react';
@@ -12,7 +17,9 @@ import { BaseModal } from '../wallet/ui/BaseModal';
 import { Button } from '../wallet/ui';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
 import { useUtilization } from '../../sdk/hooks/subscription';
+import { provisionOrRecoverKey } from '../../services/subscriptionApi';
 import { setAddressPreference } from '../../sdk/subscription/keyVault';
+import { truncateAddress } from '../wallet/shared/utils/walletFileParser';
 import { useUpgrade } from '../upgrade';
 
 const KEY_RE = /^sk_[0-9a-f]{32}$/;
@@ -20,12 +27,13 @@ const KEY_RE = /^sk_[0-9a-f]{32}$/;
 export function AddressKeyPromptModal() {
   const { sphere, network, applySubscriptionKey } = useSphereContext();
   const { openUpgrade } = useUpgrade();
-  // The wallet key is already applied provisionally when this prompt opens,
-  // so the current utilization snapshot describes exactly the plan the user
-  // would inherit by keeping the checkbox on.
+  // The wallet key is applied provisionally when this prompt opens, so the
+  // current utilization snapshot describes exactly the plan the user would
+  // inherit by keeping the checkbox on.
   const util = useUtilization();
   const inheritedPlanName = util.data?.plan?.name ?? null;
   const nametag = sphere?.identity?.nametag ?? null;
+  const chainPubkey = sphere?.identity?.chainPubkey ?? null;
 
   const [isOpen, setIsOpen] = useState(false);
   const [useWalletKey, setUseWalletKey] = useState(true); // default: inherit the wallet's primary key
@@ -48,17 +56,33 @@ export function AddressKeyPromptModal() {
 
   const close = () => setIsOpen(false);
 
+  /**
+   * Give THIS address its own free plan (separate quota). Best-effort: if the
+   * gateway is unreachable, record the 'own' preference anyway so the prompt
+   * doesn't repeat — the address keeps using the wallet key until its own free
+   * key can be provisioned (fail-open).
+   */
+  const commitOwnFreePlan = async () => {
+    if (!sphere) return;
+    try {
+      const result = await provisionOrRecoverKey(sphere, { scope: 'address' });
+      await applySubscriptionKey(result.apiKey, { walletWide: false });
+    } catch {
+      await setAddressPreference(sphere, network, 'own').catch(() => {});
+    }
+  };
+
   const handleContinue = async () => {
     if (!sphere) return close();
     setBusy(true);
     setError(null);
     try {
       if (showKeyInput && keyInput) {
-        // Own key for this address ('own' preference recorded by the vault).
-        await applySubscriptionKey(keyInput.trim(), { walletWide: false });
+        await applySubscriptionKey(keyInput.trim(), { walletWide: false }); // own key for this address
       } else if (useWalletKey) {
-        // Wallet key is already applied provisionally — just remember the choice.
-        await setAddressPreference(sphere, network, 'inherit');
+        await setAddressPreference(sphere, network, 'inherit'); // wallet key already applied — record choice
+      } else {
+        await commitOwnFreePlan();
       }
       close();
     } catch (e) {
@@ -68,27 +92,38 @@ export function AddressKeyPromptModal() {
     }
   };
 
+  // Dismissing (X / backdrop) means "leave this address on its own free plan"
+  // — commit it so the prompt never repeats for this address.
+  const handleDismiss = () => {
+    void commitOwnFreePlan();
+    close();
+  };
+
   const handleBuy = () => {
     close(); // checkout adoption stores the bought key as this address's own key
     openUpgrade();
   };
 
+  const identifier = nametag
+    ? `@${nametag}`
+    : chainPubkey
+      ? `Unicity ID · ${truncateAddress(chainPubkey, 10, 6)}`
+      : null;
+
   const keyValid = KEY_RE.test(keyInput.trim());
-  const continueDisabled = busy || (showKeyInput ? !keyValid : !useWalletKey);
+  const continueDisabled = busy || (showKeyInput && !keyValid);
 
   return (
-    <BaseModal isOpen={isOpen} onClose={close} size="sm">
+    <BaseModal isOpen={isOpen} onClose={handleDismiss} size="sm">
       <div className="p-5">
         <div className="mb-1 flex items-center gap-2">
           <KeyRound className="h-5 w-5 text-orange-500" />
           <h3 className="font-semibold">No subscription key for this address</h3>
         </div>
-        {nametag && (
-          <p className="mb-2 text-sm font-mono text-orange-500">@{nametag}</p>
-        )}
+        {identifier && <p className="mb-2 text-sm font-mono text-orange-500">{identifier}</p>}
         <p className="mb-4 text-sm text-neutral-500 dark:text-white/45">
-          Sends from this address need an aggregator key. Use your wallet's primary key, enter an
-          existing one, or buy a plan just for this address.
+          Sends from this address need an aggregator key. Use your wallet's primary key, keep a free
+          plan just for this address, enter an existing key, or buy a plan.
         </p>
 
         {!showKeyInput && (
@@ -118,7 +153,7 @@ export function AddressKeyPromptModal() {
         {error && <p className="mb-3 text-sm text-red-500">{error}</p>}
 
         <Button variant="primary" fullWidth loading={busy} disabled={continueDisabled} onClick={handleContinue}>
-          Continue
+          {showKeyInput || useWalletKey ? 'Continue' : 'Continue with a free plan for this address'}
         </Button>
 
         <div className="mt-3 flex items-center justify-center gap-4 text-sm">

--- a/src/components/subscription/AddressKeyPromptModal.tsx
+++ b/src/components/subscription/AddressKeyPromptModal.tsx
@@ -39,8 +39,6 @@ export function AddressKeyPromptModal() {
   // inherit by keeping the checkbox on.
   const util = useUtilization();
   const inheritedPlanName = util.data?.plan?.name ?? null;
-  const nametag = sphere?.identity?.nametag ?? null;
-  const chainPubkey = sphere?.identity?.chainPubkey ?? null;
 
   // Identity of the wallet's primary address (#1 / index 0) — the one whose
   // key is inherited. Its nametag comes from the tracked-address cache; when
@@ -123,19 +121,16 @@ export function AddressKeyPromptModal() {
     openUpgrade();
   };
 
-  const identifier = formatIdentity(nametag, chainPubkey);
-
   const keyValid = KEY_RE.test(keyInput.trim());
   const continueDisabled = busy || (showKeyInput && !keyValid);
 
   return (
     <BaseModal isOpen={isOpen} onClose={handleDismiss} size="sm">
       <div className="p-5">
-        <div className="mb-1 flex items-center gap-2">
+        <div className="mb-3 flex items-center gap-2">
           <KeyRound className="h-5 w-5 text-orange-500" />
           <h3 className="font-semibold">No subscription key for this address</h3>
         </div>
-        {identifier && <p className="mb-2 text-sm font-mono text-orange-500">{identifier}</p>}
         <p className="mb-4 text-sm text-neutral-500 dark:text-white/45">
           Sends from this address need an aggregator key. Use your wallet's primary key, keep a free
           plan just for this address, enter an existing key, or buy a plan.

--- a/src/components/upgrade/UpgradeModal.tsx
+++ b/src/components/upgrade/UpgradeModal.tsx
@@ -14,6 +14,7 @@ import { showToast } from '../ui/toast-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { SPHERE_KEYS } from '../../sdk/queryKeys';
 import { useSphereContext } from '../../sdk/hooks';
+import { getPublicKey } from '@unicitylabs/sphere-sdk';
 import type { UpgradeReason } from './UpgradeContext';
 
 type Step = 'plans' | 'email' | 'awaiting' | 'claim' | 'success' | 'error';
@@ -57,7 +58,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const util = useUtilization();
   const checkout = useCheckout();
   const queryClient = useQueryClient();
-  const { applySubscriptionKey } = useSphereContext();
+  const { sphere, applySubscriptionKey } = useSphereContext();
 
   const [step, setStep] = useState<Step>('plans');
   const [error, setError] = useState<string | null>(null);
@@ -67,6 +68,18 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const [claimKey, setClaimKey] = useState('');
   const [claiming, setClaiming] = useState(false);
   const [newApiKey, setNewApiKey] = useState<string | null>(null);
+  const [walletWide, setWalletWide] = useState(false);
+
+  // Buying while on the root address is wallet-wide by definition; on any
+  // other address the email step offers a "make it wallet-wide" checkbox.
+  const onRootAddress = useMemo(() => {
+    if (!sphere) return true;
+    try {
+      return sphere.identity?.chainPubkey === getPublicKey(sphere.deriveAddress(0).privateKey);
+    } catch {
+      return true;
+    }
+  }, [sphere]);
 
   const currentPlanName = util.data?.plan?.name ?? null;
 
@@ -83,7 +96,10 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   };
 
   const adoptKey = async (key: string) => {
-    await applySubscriptionKey(key); // persists (cache + scoped vault) and re-inits the oracle
+    // persists (cache + scoped vault) and re-inits the oracle; on the root
+    // address (or when the checkout checkbox asked for it) the key becomes
+    // wallet-wide, otherwise it belongs to the active address only
+    await applySubscriptionKey(key, { walletWide: onRootAddress || walletWide });
     await queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.subscription.all });
     setNewApiKey(key);
     setStep('success');
@@ -145,6 +161,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
     setClaimKey('');
     setClaiming(false);
     setNewApiKey(null);
+    setWalletWide(false);
     onClose();
   };
 
@@ -219,6 +236,17 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                   placeholder="you@example.com"
                   className="w-full rounded-xl border border-neutral-200 bg-white px-4 py-2.5 text-sm outline-none focus:border-orange-500 dark:border-white/10 dark:bg-white/5"
                 />
+                {!onRootAddress && (
+                  <label className="flex cursor-pointer items-start gap-2.5 text-sm text-neutral-600 dark:text-white/60">
+                    <input
+                      type="checkbox"
+                      checked={walletWide}
+                      onChange={(e) => setWalletWide(e.target.checked)}
+                      className="mt-0.5 accent-orange-500"
+                    />
+                    <span>Make this the wallet-wide key (all addresses)</span>
+                  </label>
+                )}
                 <Button
                   variant="primary"
                   fullWidth

--- a/src/components/upgrade/UpgradeProvider.tsx
+++ b/src/components/upgrade/UpgradeProvider.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { UpgradeContext, type UpgradeReason } from './UpgradeContext';
 import { UpgradeModal } from './UpgradeModal';
 import { PlanDowngradeWatcher } from './PlanDowngradeWatcher';
+import { AddressKeyPromptModal } from '../subscription/AddressKeyPromptModal';
 
 export function UpgradeProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -18,6 +19,7 @@ export function UpgradeProvider({ children }: { children: ReactNode }) {
     <UpgradeContext.Provider value={value}>
       {children}
       <PlanDowngradeWatcher openUpgrade={openUpgrade} />
+      <AddressKeyPromptModal />
       <UpgradeModal isOpen={isOpen} reason={reason} onClose={() => setIsOpen(false)} />
     </UpgradeContext.Provider>
   );

--- a/src/components/wallet/L3/modals/SubscriptionModal.tsx
+++ b/src/components/wallet/L3/modals/SubscriptionModal.tsx
@@ -35,7 +35,9 @@ export function SubscriptionModal({ isOpen, onClose, onUpgrade }: SubscriptionMo
     setActivating(true);
     try {
       const result = await provisionOrRecoverKey(sphere);
-      await applySubscriptionKey(result.apiKey);
+      // the free key is provisioned against the wallet's index-0 identity —
+      // always store it as the WALLET-wide key, whatever address is active
+      await applySubscriptionKey(result.apiKey, { walletWide: true });
       await queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.subscription.all });
     } catch (e) {
       setActivateError(e instanceof Error ? e.message : 'Failed to activate the free plan');
@@ -121,6 +123,8 @@ export function SubscriptionModal({ isOpen, onClose, onUpgrade }: SubscriptionMo
         )}
 
         {apiKey && <ApiKeyRow apiKey={apiKey} />}
+
+        <EnterKeyRow />
       </div>
 
       <div className="px-5 pb-6">
@@ -201,6 +205,77 @@ function ApiKeyRow({ apiKey }: { apiKey: string }) {
       </div>
       <p className="mt-1.5 text-[11px] text-neutral-500 dark:text-white/40">
         Purchased keys aren't tied to your wallet identity — keep a copy. Restore recovers only the free key.
+      </p>
+    </div>
+  );
+}
+
+const ENTER_KEY_RE = /^sk_[0-9a-f]{32}$/;
+
+/**
+ * Paste-a-key affordance: keys are bearer tokens (shareable per the gateway
+ * model), so a user can adopt one given to them — or restore a purchased key
+ * after a device move. Default semantics: on the root address the key becomes
+ * wallet-wide, on any other address it becomes that address's own key.
+ */
+function EnterKeyRow() {
+  const { applySubscriptionKey } = useSphereContext();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apply = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await applySubscriptionKey(value.trim());
+      await queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.subscription.all });
+      setOpen(false);
+      setValue('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to apply the key');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-sm text-neutral-500 underline dark:text-white/45"
+      >
+        Use a different key
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-neutral-50 px-4 py-3 dark:bg-white/4 space-y-2.5">
+      <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-white/60">
+        <KeyRound className="w-4 h-4" /> Enter an API key
+      </div>
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="sk_…"
+        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm outline-none focus:border-orange-500 dark:border-white/10 dark:bg-white/5"
+      />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <div className="flex gap-2">
+        <Button variant="primary" size="sm" loading={busy} disabled={!ENTER_KEY_RE.test(value.trim())} onClick={apply}>
+          Apply
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => { setOpen(false); setError(null); }}>
+          Cancel
+        </Button>
+      </div>
+      <p className="text-[11px] text-neutral-500 dark:text-white/40">
+        Keys are transferable — you can use a key someone shared with you. Applied on your main
+        address it becomes the wallet-wide key; on another address it applies to that address only.
       </p>
     </div>
   );

--- a/src/components/wallet/onboarding/components/PlanCapabilitiesScreen.tsx
+++ b/src/components/wallet/onboarding/components/PlanCapabilitiesScreen.tsx
@@ -62,6 +62,9 @@ export function PlanCapabilitiesScreen({ planName, created, onContinue, isBusy }
           <Button variant="primary" fullWidth loading={isBusy} onClick={onContinue}>
             Enter Wallet
           </Button>
+          <p className="mt-3 text-center text-xs text-neutral-500 dark:text-white/40">
+            Already have a key? Paste it later in Settings → Subscription.
+          </p>
         </div>
       </div>
     </motion.div>,

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -14,7 +14,7 @@ import type { NametagAvailability } from "../components/NametagScreen";
 import { provisionOrRecoverKey } from "../../../../services/subscriptionApi";
 import { SUBSCRIPTION_ENABLED } from "../../../../config/subscription";
 import { setStoredSubscriptionKey } from "../../../../config/storageKeys";
-import { saveScopedKey } from "../../../../sdk/subscription/keyVault";
+import { saveWalletKey } from "../../../../sdk/subscription/keyVault";
 
 export type OnboardingStep =
   | "start"
@@ -622,7 +622,7 @@ export function useOnboardingFlow(): UseOnboardingFlowReturn {
         // used from the first init.)
         setStoredSubscriptionKey(result.apiKey);
         // Durable per-identity copy; non-fatal if it fails (cache still set).
-        await saveScopedKey(active, network, result.apiKey).catch(() => {});
+        await saveWalletKey(active, network, result.apiKey).catch(() => {});
         setPlanName(result.plan);
         setPlanCreated(result.created);
         setStep("planCapabilities");

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -50,7 +50,7 @@ export interface SphereContextValue {
   toggleIpfs: () => void;
 
   /** Persist a per-wallet subscription API key and re-init the SDK oracle with it. */
-  applySubscriptionKey: (apiKey: string) => Promise<void>;
+  applySubscriptionKey: (apiKey: string, opts?: { walletWide?: boolean }) => Promise<void>;
 
   /**
    * True when the asset path rides the wallet-api backend (S4 composition).

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -6,7 +6,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError } from '@unicitylabs/sphere-sdk';
+import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError, getPublicKey } from '@unicitylabs/sphere-sdk';
 import { sendWelcomeDM } from './welcomeDM';
 import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
@@ -27,7 +27,7 @@ import {
 } from '../config/walletApi';
 import { getActiveOracleApiKey } from './oracleKey';
 import { SUBSCRIPTION_ENABLED } from '../config/subscription';
-import { loadScopedKey, saveScopedKey } from './subscription/keyVault';
+import { resolveActiveKey, saveWalletKey, saveAddressKey } from './subscription/keyVault';
 import { provisionOrRecoverKey } from '../services/subscriptionApi';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
@@ -231,32 +231,42 @@ export function SphereProvider({
         sphereRef.current = instance;
         setSphere(instance);
 
-        // Reconcile the boot cache against this identity's scoped key so a
-        // wallet/network switch picks up ITS subscription key instead of the
-        // previous wallet's (the boot cache is a single global slot — see
-        // config/storageKeys.ts). Guarded so it only re-inits on a real
-        // difference, never in a loop. Wallets that predate the subscription
-        // feature (or whose onboarding provisioning failed) have no key at
-        // all — recover/create their free key here, same idempotent
-        // get-or-create the onboarding runs; the env-key fallback keeps the
-        // wallet fully working if this fails (non-fatal until the Phase 5
-        // cutover).
+        // Subscription key resolution (wallet-level default, per-address
+        // opt-out — see sdk/subscription/keyVault.ts). Picks the key the
+        // ACTIVE address should use and reconciles the boot cache (a single
+        // global slot — see config/storageKeys.ts); guarded so it only
+        // re-inits on a real difference, never in a loop. Wallets with no key
+        // at all (pre-feature, or onboarding provisioning failed) get their
+        // free key here — idempotent get-or-create against the wallet's
+        // index-0 identity; the env-key fallback keeps the wallet fully
+        // working if this fails (non-fatal until the Phase 5 cutover).
+        // A first visit to a keyless non-root address raises the one-time
+        // "buy / enter / use wallet key" prompt via a DOM event.
         if (SUBSCRIPTION_ENABLED) {
-          void loadScopedKey(instance, network).then(async (scoped) => {
-            if (scoped && scoped !== getStoredSubscriptionKey()) {
-              setStoredSubscriptionKey(scoped);
-              void initialize(0, true); // rebuild oracle with this identity's key
-              return;
-            }
-            if (!scoped && !getStoredSubscriptionKey() && instance.identity?.chainPubkey) {
+          const reconcileSubscriptionKey = async (promptIfNeeded: boolean) => {
+            const resolved = await resolveActiveKey(instance, network);
+            if (resolved.key && resolved.key !== getStoredSubscriptionKey()) {
+              setStoredSubscriptionKey(resolved.key);
+              void initialize(0, true); // rebuild oracle with the resolved key
+            } else if (!resolved.key && !getStoredSubscriptionKey()) {
               try {
                 const result = await provisionOrRecoverKey(instance);
-                await saveScopedKey(instance, network, result.apiKey); // also sets the boot cache
+                await saveWalletKey(instance, network, result.apiKey); // also sets the boot cache
                 void initialize(0, true); // rebuild oracle with the fresh key
               } catch (err) {
                 console.warn('subscription auto-provisioning failed; using fallback key', err);
               }
             }
+            if (promptIfNeeded && resolved.needsPrompt) {
+              window.dispatchEvent(new Event('subscription-address-prompt'));
+            }
+          };
+          void reconcileSubscriptionKey(false).catch(() => {});
+          // Live address switches don't re-run initialize(), so re-resolve on
+          // the SDK's identity event; the listener dies with the instance on
+          // the next re-init (instance.destroy()).
+          instance.on('identity:changed', () => {
+            void reconcileSubscriptionKey(true).catch(() => {});
           });
         }
         // Send welcome DMs after relay delivers historical messages (EOSE)
@@ -534,12 +544,22 @@ export function SphereProvider({
     initialize();
   }, [initialize]);
 
-  const applySubscriptionKey = useCallback(async (apiKey: string) => {
+  const applySubscriptionKey = useCallback(async (apiKey: string, opts?: { walletWide?: boolean }) => {
     setStoredSubscriptionKey(apiKey);
     const instance = sphereRef.current;
-    if (instance?.identity?.chainPubkey) {
-      // Best-effort: scoped entry is a durability upgrade, not a gate.
-      await saveScopedKey(instance, network, apiKey).catch(() => {});
+    if (instance) {
+      // Bookkeeping (best-effort — the vault entry is a durability upgrade,
+      // not a gate): while on the root address (or when explicitly asked) the
+      // key becomes WALLET-wide; on any other address it becomes that
+      // address's OWN key.
+      const rootPubkey = (() => {
+        try { return getPublicKey(instance.deriveAddress(0).privateKey); } catch { return null; }
+      })();
+      const walletWide = opts?.walletWide ?? (rootPubkey !== null && instance.identity?.chainPubkey === rootPubkey);
+      await (walletWide
+        ? saveWalletKey(instance, network, apiKey)
+        : saveAddressKey(instance, network, apiKey)
+      ).catch(() => {});
     }
     // Rebuild providers (oracle) with the new key and re-init the SDK.
     await initialize(0, true);

--- a/src/sdk/subscription/keyVault.ts
+++ b/src/sdk/subscription/keyVault.ts
@@ -1,40 +1,142 @@
 /**
- * Per-identity persistence for the SGW subscription key.
- * - Boot cache (localStorage, plaintext, sync) feeds getActiveOracleApiKey() at
- *   provider-build time — it always holds the ACTIVE identity's key.
- * - Scoped entries (sphere.getStorage(), XChaCha20-Poly1305 via the SDK's
- *   field-encryption, key derived deterministically from the seed) are the
- *   per-(network, chainPubkey) truth — they survive wallet/network switches and
- *   any restored device can decrypt them.
+ * Wallet-side bookkeeping of SGW subscription keys (gateway-side, keys are
+ * bearer tokens — nothing is address-bound there; see docs/API.md).
+ *
+ * Model (wallet-level default, per-address opt-out):
+ * - The WALLET key lives in a slot keyed by the index-0 root pubkey — stable
+ *   across active-address switches. The free key is provisioned/recovered
+ *   against index 0, and by default every address inherits this key.
+ * - An address may hold its OWN key (entered or purchased while active on
+ *   it) in a slot keyed by that address's pubkey, plus a persisted
+ *   preference: 'own' | 'inherit'. No preference and no own key means the
+ *   address was never asked — the UI shows a one-time prompt.
+ * - The boot cache (localStorage, plaintext, sync) feeds
+ *   getActiveOracleApiKey() at provider-build time with whatever key the
+ *   resolver picked for the active address.
+ *
+ * All key values are encrypted at rest (XChaCha20-Poly1305; key derived
+ * deterministically from the seed via the index-0 private key, so any
+ * restored device can decrypt). Preferences are plain strings (not secret).
  */
 import type { Sphere } from '@unicitylabs/sphere-sdk';
-import { deriveFieldEncryptionKey, encryptField, decryptField } from '@unicitylabs/sphere-sdk';
+import { deriveFieldEncryptionKey, encryptField, decryptField, getPublicKey } from '@unicitylabs/sphere-sdk';
 import { STORAGE_KEYS, setStoredSubscriptionKey } from '../../config/storageKeys';
 
-export function scopedSubscriptionSlot(network: string, chainPubkey: string): string {
-  return `${STORAGE_KEYS.SUBSCRIPTION_API_KEY}.${network}.${chainPubkey}`;
+export type AddressKeyPreference = 'own' | 'inherit';
+
+export interface ResolvedKey {
+  key: string | null;
+  /** 'own' = the address's key; 'wallet' = inherited root key; 'none' = nothing stored. */
+  source: 'own' | 'wallet' | 'none';
+  /** True when this address never made a choice — the UI should prompt once. */
+  needsPrompt: boolean;
 }
 
-function encryptionKey(sphere: Sphere): Uint8Array {
-  // Fixed derivation index — the key must not change with the active address.
-  return deriveFieldEncryptionKey(sphere.deriveAddress(0).privateKey);
+export function scopedSubscriptionSlot(network: string, pubkey: string): string {
+  return `${STORAGE_KEYS.SUBSCRIPTION_API_KEY}.${network}.${pubkey}`;
 }
 
-export async function saveScopedKey(sphere: Sphere, network: string, apiKey: string): Promise<void> {
-  const pubkey = sphere.identity?.chainPubkey;
-  if (!pubkey) throw new Error('Wallet identity unavailable');
-  await sphere.getStorage().set(scopedSubscriptionSlot(network, pubkey), encryptField(encryptionKey(sphere), apiKey));
+function preferenceSlot(network: string, pubkey: string): string {
+  return `${STORAGE_KEYS.SUBSCRIPTION_API_KEY}.pref.${network}.${pubkey}`;
+}
+
+/**
+ * The wallet's subscription identity: the index-0 address keypair — fixed
+ * derivation index so neither the wallet slot nor the encryption key changes
+ * with the active address.
+ */
+function rootIdentity(sphere: Sphere): { privateKey: string; pubkey: string } {
+  const { privateKey } = sphere.deriveAddress(0);
+  return { privateKey, pubkey: getPublicKey(privateKey) };
+}
+
+async function readKeySlot(sphere: Sphere, network: string, pubkey: string): Promise<string | null> {
+  try {
+    const blob = await sphere.getStorage().get(scopedSubscriptionSlot(network, pubkey));
+    if (!blob) return null;
+    return decryptField(deriveFieldEncryptionKey(rootIdentity(sphere).privateKey), blob);
+  } catch {
+    // Not initialized / corrupt / foreign blob — caller falls back to
+    // re-provisioning or the prompt (idempotent on the gateway).
+    return null;
+  }
+}
+
+async function writeKeySlot(sphere: Sphere, network: string, pubkey: string, apiKey: string): Promise<void> {
+  await sphere
+    .getStorage()
+    .set(scopedSubscriptionSlot(network, pubkey), encryptField(deriveFieldEncryptionKey(rootIdentity(sphere).privateKey), apiKey));
+}
+
+/** Persist the WALLET-wide key (root slot) and make it the active oracle key. */
+export async function saveWalletKey(sphere: Sphere, network: string, apiKey: string): Promise<void> {
+  await writeKeySlot(sphere, network, rootIdentity(sphere).pubkey, apiKey);
   setStoredSubscriptionKey(apiKey); // boot cache for the next provider build
 }
 
-export async function loadScopedKey(sphere: Sphere, network: string): Promise<string | null> {
+/**
+ * Persist a key as the ACTIVE address's OWN key (records the 'own'
+ * preference) and make it the active oracle key.
+ */
+export async function saveAddressKey(sphere: Sphere, network: string, apiKey: string): Promise<void> {
   const pubkey = sphere.identity?.chainPubkey;
-  if (!pubkey) return null;
-  const blob = await sphere.getStorage().get(scopedSubscriptionSlot(network, pubkey));
-  if (!blob) return null;
+  if (!pubkey) throw new Error('Wallet identity unavailable');
+  await writeKeySlot(sphere, network, pubkey, apiKey);
+  await setAddressPreference(sphere, network, 'own');
+  setStoredSubscriptionKey(apiKey);
+}
+
+export async function setAddressPreference(sphere: Sphere, network: string, pref: AddressKeyPreference): Promise<void> {
+  const pubkey = sphere.identity?.chainPubkey;
+  if (!pubkey) throw new Error('Wallet identity unavailable');
+  await sphere.getStorage().set(preferenceSlot(network, pubkey), pref);
+}
+
+async function getAddressPreference(sphere: Sphere, network: string, pubkey: string): Promise<AddressKeyPreference | null> {
   try {
-    return decryptField(encryptionKey(sphere), blob);
+    const v = await sphere.getStorage().get(preferenceSlot(network, pubkey));
+    return v === 'own' || v === 'inherit' ? v : null;
   } catch {
-    return null; // corrupt/foreign blob — caller falls back to re-provisioning
+    return null;
+  }
+}
+
+/** The wallet-wide key (root slot), if any. */
+export function loadWalletKey(sphere: Sphere, network: string): Promise<string | null> {
+  try {
+    return readKeySlot(sphere, network, rootIdentity(sphere).pubkey);
+  } catch {
+    return Promise.resolve(null);
+  }
+}
+
+/**
+ * Picks the key the ACTIVE address should use:
+ * - active address IS index 0 → the wallet key;
+ * - address has its own key → it wins;
+ * - preference 'inherit' (or 'own' with a lost slot) → the wallet key;
+ * - no own key and no preference → wallet key provisionally + needsPrompt
+ *   (the one-time "buy / enter / use wallet key" prompt).
+ */
+export async function resolveActiveKey(sphere: Sphere, network: string): Promise<ResolvedKey> {
+  try {
+    const root = rootIdentity(sphere);
+    const active = sphere.identity?.chainPubkey;
+    const walletKey = await readKeySlot(sphere, network, root.pubkey);
+
+    if (!active || active === root.pubkey) {
+      return { key: walletKey, source: walletKey ? 'wallet' : 'none', needsPrompt: false };
+    }
+
+    const own = await readKeySlot(sphere, network, active);
+    if (own) return { key: own, source: 'own', needsPrompt: false };
+
+    const pref = await getAddressPreference(sphere, network, active);
+    if (pref !== null) {
+      return { key: walletKey, source: walletKey ? 'wallet' : 'none', needsPrompt: false };
+    }
+    return { key: walletKey, source: walletKey ? 'wallet' : 'none', needsPrompt: true };
+  } catch {
+    return { key: null, source: 'none', needsPrompt: false };
   }
 }

--- a/src/services/subscriptionApi.ts
+++ b/src/services/subscriptionApi.ts
@@ -4,6 +4,7 @@
  * the returned apiKey via the X-API-Key header. Contract: design spec §4–5.
  */
 import type { Sphere } from '@unicitylabs/sphere-sdk';
+import { getPublicKey, signMessage } from '@unicitylabs/sphere-sdk';
 import { SUBSCRIPTION_API_URL, SUBSCRIPTION_MOCK } from '../config/subscription';
 import { verifySgwChallenge } from './sgwChallenge';
 import * as mock from './subscriptionApi.mock';
@@ -95,15 +96,22 @@ function postJson<T>(path: string, body: unknown, extraHeaders?: Record<string, 
  * (created=false). The challenge template is validated before signing so the
  * wallet never signs unverified server-chosen text; it is still signed
  * VERBATIM (never re-serialized) once validated.
+ *
+ * The subscription identity is ALWAYS the wallet's index-0 address key —
+ * stable across active-address switches, so one wallet maps to one gateway
+ * key and the same key is recovered on any device regardless of which
+ * address is selected. (Keys are bearer tokens; the pubkey binding exists
+ * only for this free-tier get-or-create.)
  */
 export async function provisionOrRecoverKey(sphere: Sphere): Promise<ProvisionResult> {
   if (SUBSCRIPTION_MOCK) return mock.mockProvision;
-  const pubkey = sphere.identity?.chainPubkey;
-  if (!pubkey) throw new Error('Wallet identity unavailable (no chainPubkey)');
+  const { privateKey } = sphere.deriveAddress(0);
+  if (!privateKey) throw new Error('Wallet identity unavailable (no root key)');
+  const pubkey = getPublicKey(privateKey);
 
   const { nonce, challenge } = await postJson<Challenge>('/auth/challenge', { pubkey });
   verifySgwChallenge(challenge, { pubkey, nonce }); // never sign unverified server text
-  const signature = sphere.signMessage(challenge);
+  const signature = signMessage(privateKey, challenge);
   return postJson<ProvisionResult>('/auth/verify', { nonce, signature });
 }
 

--- a/src/services/subscriptionApi.ts
+++ b/src/services/subscriptionApi.ts
@@ -97,21 +97,38 @@ function postJson<T>(path: string, body: unknown, extraHeaders?: Record<string, 
  * wallet never signs unverified server-chosen text; it is still signed
  * VERBATIM (never re-serialized) once validated.
  *
- * The subscription identity is ALWAYS the wallet's index-0 address key —
- * stable across active-address switches, so one wallet maps to one gateway
- * key and the same key is recovered on any device regardless of which
- * address is selected. (Keys are bearer tokens; the pubkey binding exists
- * only for this free-tier get-or-create.)
+ * scope 'wallet' (default): the identity is ALWAYS the wallet's index-0
+ * address key — stable across active-address switches, so one wallet maps to
+ * one gateway key and the same key is recovered on any device regardless of
+ * which address is selected.
+ * scope 'address': the ACTIVE address's own identity — gives that address its
+ * own separate free key/quota (the gateway get-or-creates per pubkey).
+ * (Keys are bearer tokens; the pubkey binding exists only for this free-tier
+ * get-or-create.)
  */
-export async function provisionOrRecoverKey(sphere: Sphere): Promise<ProvisionResult> {
+export async function provisionOrRecoverKey(
+  sphere: Sphere,
+  opts?: { scope?: 'wallet' | 'address' },
+): Promise<ProvisionResult> {
   if (SUBSCRIPTION_MOCK) return mock.mockProvision;
-  const { privateKey } = sphere.deriveAddress(0);
-  if (!privateKey) throw new Error('Wallet identity unavailable (no root key)');
-  const pubkey = getPublicKey(privateKey);
+
+  let pubkey: string;
+  let sign: (challenge: string) => string;
+  if (opts?.scope === 'address') {
+    const active = sphere.identity?.chainPubkey;
+    if (!active) throw new Error('Wallet identity unavailable (no active address)');
+    pubkey = active;
+    sign = (c) => sphere.signMessage(c); // signs with the active identity's key
+  } else {
+    const { privateKey } = sphere.deriveAddress(0);
+    if (!privateKey) throw new Error('Wallet identity unavailable (no root key)');
+    pubkey = getPublicKey(privateKey);
+    sign = (c) => signMessage(privateKey, c);
+  }
 
   const { nonce, challenge } = await postJson<Challenge>('/auth/challenge', { pubkey });
   verifySgwChallenge(challenge, { pubkey, nonce }); // never sign unverified server text
-  const signature = signMessage(privateKey, challenge);
+  const signature = sign(challenge);
   return postJson<ProvisionResult>('/auth/verify', { nonce, signature });
 }
 

--- a/tests/unit/sdk/keyVault.test.ts
+++ b/tests/unit/sdk/keyVault.test.ts
@@ -1,12 +1,27 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { saveScopedKey, loadScopedKey, scopedSubscriptionSlot } from '../../../src/sdk/subscription/keyVault';
-import { getStoredSubscriptionKey } from '../../../src/config/storageKeys';
+import { getPublicKey } from '@unicitylabs/sphere-sdk';
+import {
+  saveWalletKey,
+  saveAddressKey,
+  loadWalletKey,
+  resolveActiveKey,
+  setAddressPreference,
+  scopedSubscriptionSlot,
+} from '@/sdk/subscription/keyVault';
+import { getStoredSubscriptionKey } from '@/config/storageKeys';
 
-function fakeSphere() {
+const ROOT_PRIV = '1'.repeat(64);
+const ROOT_PUBKEY = getPublicKey(ROOT_PRIV);
+const ADDR2_PUBKEY = '02' + 'b'.repeat(64);
+
+function fakeSphere(activePubkey: string = ROOT_PUBKEY) {
   const store = new Map<string, string>();
   return {
-    deriveAddress: () => ({ privateKey: '1'.repeat(64) }),
-    identity: { chainPubkey: '02' + 'b'.repeat(64) },
+    deriveAddress: (i: number) => {
+      if (i !== 0) throw new Error('fake only derives index 0');
+      return { privateKey: ROOT_PRIV };
+    },
+    identity: { chainPubkey: activePubkey },
     getStorage: () => ({
       get: async (k: string) => store.get(k) ?? null,
       set: async (k: string, v: string) => void store.set(k, v),
@@ -16,24 +31,65 @@ function fakeSphere() {
   };
 }
 
-describe('keyVault', () => {
-  beforeEach(() => {
-    localStorage.clear();
+describe('keyVault (wallet-level default, per-address opt-out)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('saveWalletKey writes the encrypted ROOT slot regardless of active address + boot cache', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY); // active on address 2
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    expect(sphere._store.get(scopedSubscriptionSlot('testnet2', ROOT_PUBKEY))).toMatch(/^enc1\./);
+    expect(sphere._store.has(scopedSubscriptionSlot('testnet2', ADDR2_PUBKEY))).toBe(false);
+    expect(getStoredSubscriptionKey()).toBe('sk_wallet');
+    await expect(loadWalletKey(sphere as never, 'testnet2')).resolves.toBe('sk_wallet');
   });
 
-  it('round-trips an encrypted scoped key and updates the boot cache', async () => {
-    const sphere = fakeSphere();
-    await saveScopedKey(sphere as never, 'testnet2', 'sk_secret');
-    const slot = scopedSubscriptionSlot('testnet2', sphere.identity.chainPubkey);
-    expect(sphere._store.get(slot)).toMatch(/^enc1\./); // encrypted at rest, not plaintext
-    expect(getStoredSubscriptionKey()).toBe('sk_secret'); // boot cache
-    await expect(loadScopedKey(sphere as never, 'testnet2')).resolves.toBe('sk_secret');
+  it('saveAddressKey writes the ACTIVE address slot, records the own preference, updates cache', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveAddressKey(sphere as never, 'testnet2', 'sk_own');
+    expect(sphere._store.get(scopedSubscriptionSlot('testnet2', ADDR2_PUBKEY))).toMatch(/^enc1\./);
+    expect(getStoredSubscriptionKey()).toBe('sk_own');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: 'sk_own', source: 'own', needsPrompt: false });
   });
 
-  it('returns null for a missing or undecryptable entry', async () => {
-    const sphere = fakeSphere();
-    await expect(loadScopedKey(sphere as never, 'testnet2')).resolves.toBeNull();
-    sphere._store.set(scopedSubscriptionSlot('testnet2', sphere.identity.chainPubkey), 'enc1.garbage');
-    await expect(loadScopedKey(sphere as never, 'testnet2')).resolves.toBeNull();
+  it('resolves the wallet key when active address IS index 0', async () => {
+    const sphere = fakeSphere(ROOT_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', needsPrompt: false });
+  });
+
+  it('own key WINS over the wallet key for its address', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    await saveAddressKey(sphere as never, 'testnet2', 'sk_own');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved.key).toBe('sk_own');
+    expect(resolved.source).toBe('own');
+  });
+
+  it('first visit to a keyless address: inherits wallet key provisionally + needsPrompt', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', needsPrompt: true });
+  });
+
+  it('recorded inherit preference silences the prompt', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    await setAddressPreference(sphere as never, 'testnet2', 'inherit');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', needsPrompt: false });
+  });
+
+  it('returns null/none for missing or undecryptable entries', async () => {
+    const sphere = fakeSphere(ROOT_PUBKEY);
+    await expect(loadWalletKey(sphere as never, 'testnet2')).resolves.toBeNull();
+    sphere._store.set(scopedSubscriptionSlot('testnet2', ROOT_PUBKEY), 'enc1.garbage');
+    await expect(loadWalletKey(sphere as never, 'testnet2')).resolves.toBeNull();
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved.key).toBeNull();
+    expect(resolved.source).toBe('none');
   });
 });

--- a/tests/unit/services/subscriptionApi.test.ts
+++ b/tests/unit/services/subscriptionApi.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getPublicKey, recoverPubkeyFromSignature } from '@unicitylabs/sphere-sdk';
 import {
   provisionOrRecoverKey,
   getUtilization,
@@ -7,8 +8,25 @@ import {
   getOrderStatus,
 } from '@/services/subscriptionApi';
 
-const PUBKEY = '02aa'.padEnd(66, 'b');
+// The subscription identity is the wallet's INDEX-0 keypair (stable across
+// active-address switches) — real crypto, golden test pair.
+const ROOT_PRIV = '1'.repeat(64);
+const ROOT_PUBKEY = getPublicKey(ROOT_PRIV);
 const NONCE = '6f7c2e1a-8b1d-4f3e-9c5a-2d4b6e8f0a1c';
+
+/** Active address deliberately DIFFERENT from index 0 — provisioning must ignore it. */
+function fakeSphere() {
+  return {
+    deriveAddress: (i: number) => {
+      if (i !== 0) throw new Error('expected index 0');
+      return { privateKey: ROOT_PRIV };
+    },
+    identity: { chainPubkey: '02' + 'f'.repeat(64) },
+    signMessage: vi.fn(() => {
+      throw new Error('active-identity signMessage must NOT be used');
+    }),
+  };
+}
 
 function mockFetchSequence(responses: Array<{ url?: string; ok?: boolean; status?: number; json: unknown }>) {
   const fn = vi.fn();
@@ -31,12 +49,12 @@ describe('subscriptionApi', () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.unstubAllGlobals());
 
-  it('provisionOrRecoverKey validates the challenge and returns plan as string', async () => {
+  it('provisionOrRecoverKey signs with the INDEX-0 key (not the active identity) and returns plan as string', async () => {
     const challenge =
       'unicity:sgw:auth:v1\n' +
       JSON.stringify({
         network: 'testnet2',
-        pubkey: PUBKEY,
+        pubkey: ROOT_PUBKEY,
         nonce: NONCE,
         issuedAt: new Date(Date.now() - 1000).toISOString().replace(/\.\d{3}Z$/, '.000Z'),
         expiresAt: new Date(Date.now() + 4 * 60_000).toISOString().replace(/\.\d{3}Z$/, '.000Z'),
@@ -45,18 +63,20 @@ describe('subscriptionApi', () => {
       { url: '/auth/challenge', json: { nonce: NONCE, challenge, expiresAt: '2026-07-03T12:05:00.000Z' } },
       { url: '/auth/verify', json: { apiKey: 'sk_abc', plan: 'free', created: true } },
     ]);
-    const sphere = { identity: { chainPubkey: PUBKEY }, signMessage: vi.fn(() => '1f'.padEnd(130, '0')) };
+    const sphere = fakeSphere();
 
     const result = await provisionOrRecoverKey(sphere as never);
 
-    // challenge POST body carries the pubkey
+    // challenge POST body carries the ROOT pubkey, not the active identity's
     const challengeCall = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(challengeCall).toEqual({ pubkey: PUBKEY });
-    // wallet signed the exact (validated) challenge string, verbatim
-    expect(sphere.signMessage).toHaveBeenCalledWith(challenge);
-    // verify POST body carries nonce + signature (no pubkey needed — server recovers it)
+    expect(challengeCall).toEqual({ pubkey: ROOT_PUBKEY });
+    // signed VERBATIM with the index-0 key: the signature recovers to the root pubkey
     const verifyCall = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(verifyCall).toEqual({ nonce: NONCE, signature: '1f'.padEnd(130, '0') });
+    expect(verifyCall.nonce).toBe(NONCE);
+    expect(verifyCall.signature).toMatch(/^[0-9a-f]{130}$/);
+    expect(recoverPubkeyFromSignature(challenge, verifyCall.signature)).toBe(ROOT_PUBKEY);
+    // the active-identity signer was never touched
+    expect(sphere.signMessage).not.toHaveBeenCalled();
 
     expect(result).toEqual({ apiKey: 'sk_abc', plan: 'free', created: true });
   });
@@ -66,21 +86,24 @@ describe('subscriptionApi', () => {
       'unicity:sgw:auth:v1\n' +
       JSON.stringify({
         network: 'testnet2',
-        pubkey: '02' + 'a'.repeat(64),
+        pubkey: '02' + 'a'.repeat(64), // NOT the root pubkey we requested for
         nonce: NONCE,
         issuedAt: '2026-07-03T12:00:00.000Z',
         expiresAt: '2026-07-03T12:05:00.000Z',
       });
-    mockFetchSequence([{ url: '/auth/challenge', json: { nonce: NONCE, challenge: bad, expiresAt: '' } }]);
-    const sphere = { identity: { chainPubkey: PUBKEY }, signMessage: vi.fn() };
+    const fetchMock = mockFetchSequence([
+      { url: '/auth/challenge', json: { nonce: NONCE, challenge: bad, expiresAt: '' } },
+    ]);
 
-    await expect(provisionOrRecoverKey(sphere as never)).rejects.toThrow(/SGW challenge rejected/);
-    expect(sphere.signMessage).not.toHaveBeenCalled();
+    await expect(provisionOrRecoverKey(fakeSphere() as never)).rejects.toThrow(/SGW challenge rejected/);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // never reached /auth/verify
   });
 
-  it('provisionOrRecoverKey: throws if identity is missing', async () => {
-    const noIdentity = { signMessage: vi.fn() } as unknown as import('@unicitylabs/sphere-sdk').Sphere;
-    await expect(provisionOrRecoverKey(noIdentity)).rejects.toThrow(/identity/i);
+  it('provisionOrRecoverKey: throws when the root key is unavailable', async () => {
+    const noRootKey = {
+      deriveAddress: () => ({ privateKey: undefined }),
+    } as unknown as import('@unicitylabs/sphere-sdk').Sphere;
+    await expect(provisionOrRecoverKey(noRootKey)).rejects.toThrow(/root key/i);
   });
 
   it('getUtilization calls GET /api/utilization with X-API-Key and returns the flat shape', async () => {


### PR DESCRIPTION
## Summary

Resolves multi-address subscription semantics (spec open item O1), confirmed with the backend owner: **SGW keys are bearer tokens** — the gateway binds nothing at purchase (email accounting only); identity binding exists ONLY for free-tier get-or-create. Wallet model: **one key per wallet by default, per-address opt-out.**

### Model
- **Free key = the wallet's key**: provisioning/recovery always signs with the **index-0 keypair** (standalone `signMessage(priv,msg)` + `getPublicKey(priv)`), stable across active-address switches → one wallet = one gateway key, restore works from any device/address.
- **Every address inherits the wallet key by default.** An address gets its OWN key only when the user enters/buys one while active on it, or picks "own free plan".
- **First switch to a keyless address** → one-time `AddressKeyPromptModal`: use wallet's primary key (default, shows address #1's @nametag / Unicity ID + inherited plan) / keep a free plan for this address / enter existing key / buy. Unchecked or dismiss ⇒ this address gets its OWN free plan; the choice is persisted per address (never re-prompts).
- **Checkout on a non-root address** offers a "make wallet-wide" checkbox.
- **Settings → Subscription**: "Use a different key" paste affordance (bearer-token sharing / restore a purchased key after a device move). Onboarding hints it.

### Mechanics
- `keyVault`: wallet slot (root pubkey) + per-address own slots (all encrypted via `encryptField`, key derived from the seed) + persisted `inherit`/`own` preference; `resolveActiveKey()` picks the right key.
- `SphereProvider`: resolution at init AND on the SDK's `identity:changed` (live address switches re-resolve; re-init only when the key actually changes — inheriting addresses switch for free). Keyless-wallet auto-provision now goes via index 0.
- `applySubscriptionKey(apiKey, {walletWide?})`: root address ⇒ wallet-wide; other ⇒ address-own. `provisionOrRecoverKey(sphere, {scope})`: 'wallet' (index-0) | 'address' (active identity).

### Verification
`tsc -b` zero errors; **189/189 tests** (new: keyVault resolver cases, real-crypto index-0 provisioning incl. `recoverPubkeyFromSignature(...) === rootPubkey` + active-signer-never-touched assertions); lint clean; build ok. **Final whole-branch review: READY TO MERGE** (root-key-vs-active signing, `identity:changed` no-loop/no-leak, cross-wallet key bleed, encryption-at-rest, flag-off — all verified correct).

### Notes / follow-ups (Minor, deferred)
- Buying wallet-wide on a non-root address doesn't record that address's preference → the one-time prompt can re-appear on the next switch back (UX wrinkle, not a correctness bug).
- Abandoning checkout from the prompt's "Buy a plan" can re-show the prompt.
- Gateway untouched. Separate proposal for the backend: signed `attach-key` endpoint so purchased keys survive restore too.
- **Nametag-on-new-address is a SEPARATE fix** (own branch from `main`), not part of this PR.