### PR TITLE
feat(subscription): individual key per address by default (inherit opt-in) + UI polish

### DIFF
--- a/src/components/subscription/AddressKeyPromptModal.tsx
+++ b/src/components/subscription/AddressKeyPromptModal.tsx
@@ -1,24 +1,22 @@
 /**
- * One-time prompt shown when the user switches to an address that has no
- * subscription key and no recorded preference (SphereProvider raises the
- * 'subscription-address-prompt' DOM event after resolving the switch — the
- * wallet key is applied provisionally meanwhile).
+ * Shown when the user switches to an address that has no key of its own AND
+ * index 0 is on a PAID plan (SphereProvider raises 'subscription-address-prompt'
+ * only in that case — a free primary plan just auto-gives this address its own
+ * free key, no prompt). The single decision: share the paid primary plan, or
+ * keep an individual free plan for this address.
  *
- * Outcomes (each records a per-address preference so the prompt never repeats
- * for this address):
- * - keep the checkbox on  → inherit the wallet's primary key;
- * - checkbox off / dismiss → this address gets its OWN free plan (separate
- *   quota, provisioned against the active address identity);
- * - enter a key / buy     → that key becomes this address's own key.
+ * Outcomes (each records a per-address preference so the prompt never repeats):
+ * - checkbox ON  → inherit the primary (index-0) key — shares its paid plan;
+ * - checkbox OFF / dismiss → this address gets its OWN free plan;
+ * - enter a key / buy → that key becomes this address's own key.
  */
 import { useEffect, useMemo, useState } from 'react';
 import { KeyRound } from 'lucide-react';
 import { BaseModal } from '../wallet/ui/BaseModal';
 import { Button } from '../wallet/ui';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
-import { useUtilization } from '../../sdk/hooks/subscription';
-import { provisionOrRecoverKey } from '../../services/subscriptionApi';
-import { setAddressPreference } from '../../sdk/subscription/keyVault';
+import { provisionOrRecoverKey, getUtilization } from '../../services/subscriptionApi';
+import { setAddressPreference, loadWalletKey } from '../../sdk/subscription/keyVault';
 import { truncateAddress } from '../wallet/shared/utils/walletFileParser';
 import { useUpgrade } from '../upgrade';
 
@@ -34,15 +32,9 @@ function formatIdentity(nametag?: string | null, chainPubkey?: string | null): s
 export function AddressKeyPromptModal() {
   const { sphere, network, applySubscriptionKey } = useSphereContext();
   const { openUpgrade } = useUpgrade();
-  // The wallet key is applied provisionally when this prompt opens, so the
-  // current utilization snapshot describes exactly the plan the user would
-  // inherit by keeping the checkbox on.
-  const util = useUtilization();
-  const inheritedPlanName = util.data?.plan?.name ?? null;
 
   // Identity of the wallet's primary address (#1 / index 0) — the one whose
-  // key is inherited. Its nametag comes from the tracked-address cache; when
-  // absent (or not yet cached) we fall back to its short Unicity ID.
+  // paid plan the checkbox would share.
   const rootIdentity = useMemo(() => {
     try {
       const root = sphere?.getTrackedAddress(0);
@@ -53,31 +45,47 @@ export function AddressKeyPromptModal() {
   }, [sphere]);
 
   const [isOpen, setIsOpen] = useState(false);
-  const [useWalletKey, setUseWalletKey] = useState(true); // default: inherit the wallet's primary key
+  const [shareKey, setShareKey] = useState(false); // default: individual free plan for this address
   const [showKeyInput, setShowKeyInput] = useState(false);
   const [keyInput, setKeyInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [walletKey, setWalletKey] = useState<string | null>(null);
+  const [rootPlanName, setRootPlanName] = useState<string | null>(null);
 
   useEffect(() => {
     const open = () => {
-      setUseWalletKey(true);
+      setShareKey(false);
       setShowKeyInput(false);
       setKeyInput('');
       setError(null);
       setIsOpen(true);
+      // Load the primary key + its (paid) plan name to label the checkbox.
+      if (sphere) {
+        void loadWalletKey(sphere, network)
+          .then(async (wk) => {
+            setWalletKey(wk);
+            if (wk) {
+              try {
+                setRootPlanName((await getUtilization(wk)).plan?.name ?? null);
+              } catch {
+                setRootPlanName(null);
+              }
+            }
+          })
+          .catch(() => {});
+      }
     };
     window.addEventListener('subscription-address-prompt', open);
     return () => window.removeEventListener('subscription-address-prompt', open);
-  }, []);
+  }, [sphere, network]);
 
   const close = () => setIsOpen(false);
 
   /**
    * Give THIS address its own free plan (separate quota). Best-effort: if the
    * gateway is unreachable, record the 'own' preference anyway so the prompt
-   * doesn't repeat — the address keeps using the wallet key until its own free
-   * key can be provisioned (fail-open).
+   * doesn't repeat — the address is re-provisioned on the next switch (fail-open).
    */
   const commitOwnFreePlan = async () => {
     if (!sphere) return;
@@ -96,8 +104,10 @@ export function AddressKeyPromptModal() {
     try {
       if (showKeyInput && keyInput) {
         await applySubscriptionKey(keyInput.trim(), { walletWide: false }); // own key for this address
-      } else if (useWalletKey) {
-        await setAddressPreference(sphere, network, 'inherit'); // wallet key already applied — record choice
+      } else if (shareKey && walletKey) {
+        // Inherit the primary key: record the choice, then make it the active key.
+        await setAddressPreference(sphere, network, 'inherit');
+        await applySubscriptionKey(walletKey, { walletWide: true });
       } else {
         await commitOwnFreePlan();
       }
@@ -109,8 +119,7 @@ export function AddressKeyPromptModal() {
     }
   };
 
-  // Dismissing (X / backdrop) means "leave this address on its own free plan"
-  // — commit it so the prompt never repeats for this address.
+  // Dismissing (X / backdrop) = keep this address on its own free plan.
   const handleDismiss = () => {
     void commitOwnFreePlan();
     close();
@@ -129,24 +138,24 @@ export function AddressKeyPromptModal() {
       <div className="p-5">
         <div className="mb-3 flex items-center gap-2">
           <KeyRound className="h-5 w-5 text-orange-500" />
-          <h3 className="font-semibold">No subscription key for this address</h3>
+          <h3 className="font-semibold">Plan for this address</h3>
         </div>
         <p className="mb-4 text-sm text-neutral-500 dark:text-white/45">
-          Sends from this address need an aggregator key. Use your wallet's primary key, keep a free
-          plan just for this address, enter an existing key, or buy a plan.
+          By default this address gets its own free plan. Your primary address is on a paid plan —
+          you can share it here instead, enter an existing key, or buy a separate plan.
         </p>
 
         {!showKeyInput && (
           <label className="mb-4 flex cursor-pointer items-start gap-2.5 text-sm">
             <input
               type="checkbox"
-              checked={useWalletKey}
-              onChange={(e) => setUseWalletKey(e.target.checked)}
+              checked={shareKey}
+              onChange={(e) => setShareKey(e.target.checked)}
               className="mt-0.5 accent-orange-500"
             />
             <span>
-              Use my wallet's primary key ({rootIdentity ?? 'address #1'}
-              {inheritedPlanName ? <> — <span className="capitalize">{inheritedPlanName}</span> plan</> : null})
+              Share my primary key ({rootIdentity ?? 'address #1'}
+              {rootPlanName ? <> — <span className="capitalize">{rootPlanName}</span> plan</> : null})
             </span>
           </label>
         )}
@@ -163,7 +172,7 @@ export function AddressKeyPromptModal() {
         {error && <p className="mb-3 text-sm text-red-500">{error}</p>}
 
         <Button variant="primary" fullWidth loading={busy} disabled={continueDisabled} onClick={handleContinue}>
-          {showKeyInput || useWalletKey ? 'Continue' : 'Continue with a free plan for this address'}
+          {showKeyInput || shareKey ? 'Continue' : 'Continue with a free plan for this address'}
         </Button>
 
         <div className="mt-3 flex items-center justify-center gap-4 text-sm">
@@ -172,7 +181,7 @@ export function AddressKeyPromptModal() {
             className="text-neutral-500 underline dark:text-white/45"
             onClick={() => { setShowKeyInput(!showKeyInput); setError(null); }}
           >
-            {showKeyInput ? 'Use the wallet key instead' : 'Enter an existing key'}
+            {showKeyInput ? 'Back' : 'Enter an existing key'}
           </button>
           <button type="button" className="text-neutral-500 underline dark:text-white/45" onClick={handleBuy}>
             Buy a plan

--- a/src/components/upgrade/UpgradeSuccess.tsx
+++ b/src/components/upgrade/UpgradeSuccess.tsx
@@ -3,7 +3,7 @@
  * a spring-popped check with a pulsing ring, a light confetti burst, the new
  * plan name, and the limits/features it unlocked.
  */
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Check, Copy, Sparkles } from 'lucide-react';
 import { Button } from '../wallet/ui';
@@ -53,6 +53,13 @@ interface UpgradeSuccessProps {
 }
 
 export function UpgradeSuccess({ plan, apiKey, onDone }: UpgradeSuccessProps) {
+  const [copied, setCopied] = useState(false);
+  const copyKey = () => {
+    if (!apiKey) return;
+    navigator.clipboard.writeText(apiKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
   const features = plan ? planFeatures(plan) : [];
 
   return (
@@ -123,11 +130,11 @@ export function UpgradeSuccess({ plan, apiKey, onDone }: UpgradeSuccessProps) {
             <span className="text-xs font-medium text-yellow-600 dark:text-yellow-400">Your new API key</span>
             <button
               type="button"
-              aria-label="Copy API key"
-              onClick={() => navigator.clipboard.writeText(apiKey)}
+              aria-label={copied ? 'Copied' : 'Copy API key'}
+              onClick={copyKey}
               className="rounded p-1 text-yellow-600 hover:bg-yellow-500/15 dark:text-yellow-400"
             >
-              <Copy className="h-3.5 w-3.5" />
+              {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
             </button>
           </div>
           <code className="block break-all font-mono text-xs">{apiKey}</code>

--- a/src/components/wallet/L3/modals/SettingsModal.tsx
+++ b/src/components/wallet/L3/modals/SettingsModal.tsx
@@ -7,6 +7,7 @@ import { AddressManagerModal } from './AddressManagerModal';
 import { ConnectedSitesModal } from './ConnectedSitesModal';
 import { SubscriptionModal } from './SubscriptionModal';
 import { useUpgrade } from '../../../upgrade';
+import { useUtilization } from '../../../../sdk/hooks/subscription';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -27,6 +28,13 @@ export function SettingsModal({
   const [isConnectedSitesOpen, setIsConnectedSitesOpen] = useState(false);
   const [isSubscriptionOpen, setIsSubscriptionOpen] = useState(false);
   const { openUpgrade } = useUpgrade();
+
+  // Show the active address's current plan in the row subtitle, e.g. "Free plan".
+  const util = useUtilization();
+  const planName = util.data?.plan?.name;
+  const subscriptionSubtitle = planName
+    ? `${planName.charAt(0).toUpperCase()}${planName.slice(1)} plan`
+    : 'Manage your plan';
 
   return (
     <>
@@ -65,7 +73,7 @@ export function SettingsModal({
             icon={CreditCard}
             color="orange"
             label="Subscription"
-            subtitle="Manage your plan"
+            subtitle={subscriptionSubtitle}
             onClick={() => setIsSubscriptionOpen(true)}
           />
 

--- a/src/components/wallet/L3/modals/SubscriptionModal.tsx
+++ b/src/components/wallet/L3/modals/SubscriptionModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CreditCard, Sparkles, Zap, Timer, KeyRound, Eye, EyeOff, Copy, Loader2 } from 'lucide-react';
+import { CreditCard, Sparkles, Zap, Timer, KeyRound, Eye, EyeOff, Copy, Check, Loader2 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, Button, EmptyState, AlertMessage } from '../../ui';
@@ -184,7 +184,13 @@ function ResetRow({ resetAt, active, loading }: { resetAt: string | null; active
 
 function ApiKeyRow({ apiKey }: { apiKey: string }) {
   const [visible, setVisible] = useState(false);
+  const [copied, setCopied] = useState(false);
   const masked = `${apiKey.slice(0, 5)}…${apiKey.slice(-4)}`;
+  const copy = () => {
+    navigator.clipboard.writeText(apiKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
   return (
     <div className="rounded-2xl bg-neutral-50 px-4 py-3 dark:bg-white/4">
       <div className="flex items-center justify-between text-sm">
@@ -197,9 +203,9 @@ function ApiKeyRow({ apiKey }: { apiKey: string }) {
             className="rounded p-1 text-neutral-400 hover:text-neutral-700 dark:hover:text-white">
             {visible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
           </button>
-          <button type="button" aria-label="Copy key" onClick={() => navigator.clipboard.writeText(apiKey)}
+          <button type="button" aria-label={copied ? 'Copied' : 'Copy key'} onClick={copy}
             className="rounded p-1 text-neutral-400 hover:text-neutral-700 dark:hover:text-white">
-            <Copy className="h-3.5 w-3.5" />
+            {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
           </button>
         </span>
       </div>

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -27,7 +27,7 @@ import {
 } from '../config/walletApi';
 import { getActiveOracleApiKey } from './oracleKey';
 import { SUBSCRIPTION_ENABLED } from '../config/subscription';
-import { resolveActiveKey, saveWalletKey, saveAddressKey } from './subscription/keyVault';
+import { resolveActiveKey, saveWalletKey, saveAddressKey, loadWalletKey } from './subscription/keyVault';
 import { isPaidPlan } from './subscription/usage';
 import { provisionOrRecoverKey, getUtilization } from '../services/subscriptionApi';
 
@@ -232,47 +232,61 @@ export function SphereProvider({
         sphereRef.current = instance;
         setSphere(instance);
 
-        // Subscription key resolution (wallet-level default, per-address
-        // opt-out — see sdk/subscription/keyVault.ts). Picks the key the
-        // ACTIVE address should use and reconciles the boot cache (a single
-        // global slot — see config/storageKeys.ts); guarded so it only
-        // re-inits on a real difference, never in a loop. Wallets with no key
-        // at all (pre-feature, or onboarding provisioning failed) get their
-        // free key here — idempotent get-or-create against the wallet's
-        // index-0 identity; the env-key fallback keeps the wallet fully
-        // working if this fails (non-fatal until the Phase 5 cutover).
-        // A first visit to a keyless non-root address raises the one-time
-        // "buy / enter / use wallet key" prompt via a DOM event.
+        // Subscription key resolution (INDIVIDUAL per address by default;
+        // inherit is opt-in — see sdk/subscription/keyVault.ts). Reconciles
+        // the boot cache (a single global slot — config/storageKeys.ts);
+        // guarded so it only re-inits on a real difference, never in a loop.
+        // - resolved 'own'/'wallet' with a key → use it;
+        // - index 0 with no key yet → provision the wallet (index-0) free key;
+        // - any other address with no key → give it its OWN free key, EXCEPT
+        //   when index 0 is on a PAID plan and no choice was made yet, where a
+        //   one-time prompt first offers to share that paid plan (inherit).
+        // The env-key fallback keeps the wallet working if provisioning fails.
         if (SUBSCRIPTION_ENABLED) {
+          const applyResolved = async (key: string) => {
+            if (key !== getStoredSubscriptionKey()) {
+              setStoredSubscriptionKey(key);
+              void initialize(0, true); // rebuild oracle with the resolved key
+            }
+          };
+          const provisionOwn = async (scope: 'wallet' | 'address') => {
+            try {
+              const result = await provisionOrRecoverKey(instance, { scope });
+              await (scope === 'wallet'
+                ? saveWalletKey(instance, network, result.apiKey)
+                : saveAddressKey(instance, network, result.apiKey)); // both set the boot cache
+              void initialize(0, true);
+            } catch (err) {
+              console.warn('subscription auto-provisioning failed; using fallback key', err);
+            }
+          };
           const reconcileSubscriptionKey = async (promptIfNeeded: boolean) => {
             const resolved = await resolveActiveKey(instance, network);
-            if (resolved.key && resolved.key !== getStoredSubscriptionKey()) {
-              setStoredSubscriptionKey(resolved.key);
-              void initialize(0, true); // rebuild oracle with the resolved key
-            } else if (!resolved.key && !getStoredSubscriptionKey()) {
-              try {
-                const result = await provisionOrRecoverKey(instance);
-                await saveWalletKey(instance, network, result.apiKey); // also sets the boot cache
-                void initialize(0, true); // rebuild oracle with the fresh key
-              } catch (err) {
-                console.warn('subscription auto-provisioning failed; using fallback key', err);
-              }
+            if (resolved.key) {
+              await applyResolved(resolved.key);
+              return;
             }
-            if (promptIfNeeded && resolved.needsPrompt && resolved.key) {
-              // Only prompt when the inherited wallet key is on a PAID plan —
-              // then sharing that quota vs. giving this address its own free
-              // plan is a real choice. On a free wallet key the two are
-              // equivalent, so silently inherit (no modal). Metering failure
-              // → don't nag.
-              try {
-                const util = await getUtilization(resolved.key);
-                if (isPaidPlan(util.activeUntil)) {
-                  window.dispatchEvent(new Event('subscription-address-prompt'));
+            // needs-own: index 0 → wallet key; else this address's own key.
+            const isRoot = instance.identity?.chainPubkey === getPublicKey(instance.deriveAddress(0).privateKey);
+            if (isRoot) {
+              await provisionOwn('wallet');
+              return;
+            }
+            // Offer inheriting index 0's plan only when it's PAID and undecided.
+            if (promptIfNeeded && resolved.undecided) {
+              const walletKey = await loadWalletKey(instance, network);
+              if (walletKey) {
+                try {
+                  if (isPaidPlan((await getUtilization(walletKey)).activeUntil)) {
+                    window.dispatchEvent(new Event('subscription-address-prompt'));
+                    return; // wait for the user's choice
+                  }
+                } catch {
+                  // metering unavailable → fall through to an own free key
                 }
-              } catch {
-                // ignore — a free/unknown plan never prompts
               }
             }
+            await provisionOwn('address');
           };
           void reconcileSubscriptionKey(false).catch(() => {});
           // Live address switches don't re-run initialize(), so re-resolve on

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -28,7 +28,8 @@ import {
 import { getActiveOracleApiKey } from './oracleKey';
 import { SUBSCRIPTION_ENABLED } from '../config/subscription';
 import { resolveActiveKey, saveWalletKey, saveAddressKey } from './subscription/keyVault';
-import { provisionOrRecoverKey } from '../services/subscriptionApi';
+import { isPaidPlan } from './subscription/usage';
+import { provisionOrRecoverKey, getUtilization } from '../services/subscriptionApi';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
   ? '/coingecko'
@@ -257,8 +258,20 @@ export function SphereProvider({
                 console.warn('subscription auto-provisioning failed; using fallback key', err);
               }
             }
-            if (promptIfNeeded && resolved.needsPrompt) {
-              window.dispatchEvent(new Event('subscription-address-prompt'));
+            if (promptIfNeeded && resolved.needsPrompt && resolved.key) {
+              // Only prompt when the inherited wallet key is on a PAID plan —
+              // then sharing that quota vs. giving this address its own free
+              // plan is a real choice. On a free wallet key the two are
+              // equivalent, so silently inherit (no modal). Metering failure
+              // → don't nag.
+              try {
+                const util = await getUtilization(resolved.key);
+                if (isPaidPlan(util.activeUntil)) {
+                  window.dispatchEvent(new Event('subscription-address-prompt'));
+                }
+              } catch {
+                // ignore — a free/unknown plan never prompts
+              }
             }
           };
           void reconcileSubscriptionKey(false).catch(() => {});

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -243,37 +243,46 @@ export function SphereProvider({
         //   one-time prompt first offers to share that paid plan (inherit).
         // The env-key fallback keeps the wallet working if provisioning fails.
         if (SUBSCRIPTION_ENABLED) {
-          const applyResolved = async (key: string) => {
+          // `reinit` is only allowed on the initial load — NEVER on a live
+          // address switch: initialize(0, true) destroys+rebuilds the whole
+          // Sphere (transport + wallet-api realtime socket), which would flash
+          // "Reconnecting" on every switch. Keys are bearer tokens, so the
+          // active session sends fine on whatever key is loaded; the resolved
+          // per-address key is written to the vault + boot cache and takes
+          // effect on the next natural init (reload / network switch). Proper
+          // fix is a runtime oracle-key setter in the SDK (follow-up).
+          const applyResolved = async (key: string, reinit: boolean) => {
             if (key !== getStoredSubscriptionKey()) {
               setStoredSubscriptionKey(key);
-              void initialize(0, true); // rebuild oracle with the resolved key
+              if (reinit) void initialize(0, true);
             }
           };
-          const provisionOwn = async (scope: 'wallet' | 'address') => {
+          const provisionOwn = async (scope: 'wallet' | 'address', reinit: boolean) => {
             try {
               const result = await provisionOrRecoverKey(instance, { scope });
               await (scope === 'wallet'
                 ? saveWalletKey(instance, network, result.apiKey)
                 : saveAddressKey(instance, network, result.apiKey)); // both set the boot cache
-              void initialize(0, true);
+              if (reinit) void initialize(0, true);
             } catch (err) {
               console.warn('subscription auto-provisioning failed; using fallback key', err);
             }
           };
-          const reconcileSubscriptionKey = async (promptIfNeeded: boolean) => {
+          const reconcileSubscriptionKey = async (initialLoad: boolean) => {
             const resolved = await resolveActiveKey(instance, network);
             if (resolved.key) {
-              await applyResolved(resolved.key);
+              await applyResolved(resolved.key, initialLoad);
               return;
             }
             // needs-own: index 0 → wallet key; else this address's own key.
             const isRoot = instance.identity?.chainPubkey === getPublicKey(instance.deriveAddress(0).privateKey);
             if (isRoot) {
-              await provisionOwn('wallet');
+              await provisionOwn('wallet', initialLoad);
               return;
             }
-            // Offer inheriting index 0's plan only when it's PAID and undecided.
-            if (promptIfNeeded && resolved.undecided) {
+            // Offer inheriting index 0's plan only when it's PAID and undecided
+            // (only on a live switch — never during the initial load).
+            if (!initialLoad && resolved.undecided) {
               const walletKey = await loadWalletKey(instance, network);
               if (walletKey) {
                 try {
@@ -286,14 +295,14 @@ export function SphereProvider({
                 }
               }
             }
-            await provisionOwn('address');
+            await provisionOwn('address', initialLoad);
           };
-          void reconcileSubscriptionKey(false).catch(() => {});
-          // Live address switches don't re-run initialize(), so re-resolve on
-          // the SDK's identity event; the listener dies with the instance on
-          // the next re-init (instance.destroy()).
+          void reconcileSubscriptionKey(true).catch(() => {});
+          // Re-resolve on a live address switch (initialLoad=false → NO
+          // re-init, so no transport/realtime reconnect). The listener dies
+          // with the instance on the next re-init (instance.destroy()).
           instance.on('identity:changed', () => {
-            void reconcileSubscriptionKey(true).catch(() => {});
+            void reconcileSubscriptionKey(false).catch(() => {});
           });
         }
         // Send welcome DMs after relay delivers historical messages (EOSE)

--- a/src/sdk/subscription/keyVault.ts
+++ b/src/sdk/subscription/keyVault.ts
@@ -2,17 +2,19 @@
  * Wallet-side bookkeeping of SGW subscription keys (gateway-side, keys are
  * bearer tokens — nothing is address-bound there; see docs/API.md).
  *
- * Model (wallet-level default, per-address opt-out):
- * - The WALLET key lives in a slot keyed by the index-0 root pubkey — stable
- *   across active-address switches. The free key is provisioned/recovered
- *   against index 0, and by default every address inherits this key.
- * - An address may hold its OWN key (entered or purchased while active on
- *   it) in a slot keyed by that address's pubkey, plus a persisted
- *   preference: 'own' | 'inherit'. No preference and no own key means the
- *   address was never asked — the UI shows a one-time prompt.
+ * Model (INDIVIDUAL per address by default; inherit is opt-in):
+ * - Each address gets its OWN key by default (its own free plan / quota),
+ *   stored in a slot keyed by that address's pubkey. Address index 0's own
+ *   key doubles as the "wallet key" (the one another address can inherit).
+ * - An address inherits the wallet (index-0) key ONLY when its persisted
+ *   preference is 'inherit' — the opt-in the user makes via the prompt's
+ *   checkbox, useful when index 0 holds a PAID plan to share.
+ * - No own key and no preference ⇒ this address still needs a key: the caller
+ *   provisions its own free key silently, EXCEPT when index 0 is on a paid
+ *   plan, where a one-time prompt first offers "share the paid plan (inherit)".
  * - The boot cache (localStorage, plaintext, sync) feeds
  *   getActiveOracleApiKey() at provider-build time with whatever key the
- *   resolver picked for the active address.
+ *   resolver/caller picked for the active address.
  *
  * All key values are encrypted at rest (XChaCha20-Poly1305; key derived
  * deterministically from the seed via the index-0 private key, so any
@@ -25,11 +27,17 @@ import { STORAGE_KEYS, setStoredSubscriptionKey } from '../../config/storageKeys
 export type AddressKeyPreference = 'own' | 'inherit';
 
 export interface ResolvedKey {
+  /** The resolved key, or null when the address still needs one provisioned. */
   key: string | null;
-  /** 'own' = the address's key; 'wallet' = inherited root key; 'none' = nothing stored. */
-  source: 'own' | 'wallet' | 'none';
-  /** True when this address never made a choice — the UI should prompt once. */
-  needsPrompt: boolean;
+  /**
+   * 'own'       — the active address's own key (or index-0's wallet key);
+   * 'wallet'    — inheriting the index-0 wallet key (preference 'inherit');
+   * 'needs-own' — no key yet; the caller must provision this address's own key
+   *               (or, if index 0 is paid and `undecided`, prompt first).
+   */
+  source: 'own' | 'wallet' | 'needs-own';
+  /** True only for 'needs-own' with NO recorded preference (paid case may prompt). */
+  undecided: boolean;
 }
 
 export function scopedSubscriptionSlot(network: string, pubkey: string): string {
@@ -111,32 +119,37 @@ export function loadWalletKey(sphere: Sphere, network: string): Promise<string |
 }
 
 /**
- * Picks the key the ACTIVE address should use:
- * - active address IS index 0 → the wallet key;
- * - address has its own key → it wins;
- * - preference 'inherit' (or 'own' with a lost slot) → the wallet key;
- * - no own key and no preference → wallet key provisionally + needsPrompt
- *   (the one-time "buy / enter / use wallet key" prompt).
+ * Picks the key the ACTIVE address should use (INDIVIDUAL by default):
+ * - active address IS index 0 → its own key IS the wallet key ('wallet');
+ * - address has its own key → it wins ('own');
+ * - preference 'inherit' → the wallet key ('wallet');
+ * - otherwise → 'needs-own' (the caller provisions this address's own key,
+ *   or prompts first when index 0 is paid and no choice was made yet).
  */
 export async function resolveActiveKey(sphere: Sphere, network: string): Promise<ResolvedKey> {
   try {
     const root = rootIdentity(sphere);
     const active = sphere.identity?.chainPubkey;
-    const walletKey = await readKeySlot(sphere, network, root.pubkey);
 
+    // Index 0: its own key is the wallet key. null ⇒ needs first-time provision.
     if (!active || active === root.pubkey) {
-      return { key: walletKey, source: walletKey ? 'wallet' : 'none', needsPrompt: false };
+      const walletKey = await readKeySlot(sphere, network, root.pubkey);
+      return { key: walletKey, source: walletKey ? 'wallet' : 'needs-own', undecided: false };
     }
 
     const own = await readKeySlot(sphere, network, active);
-    if (own) return { key: own, source: 'own', needsPrompt: false };
+    if (own) return { key: own, source: 'own', undecided: false };
 
     const pref = await getAddressPreference(sphere, network, active);
-    if (pref !== null) {
-      return { key: walletKey, source: walletKey ? 'wallet' : 'none', needsPrompt: false };
+    if (pref === 'inherit') {
+      const walletKey = await readKeySlot(sphere, network, root.pubkey);
+      return { key: walletKey, source: walletKey ? 'wallet' : 'needs-own', undecided: false };
     }
-    return { key: walletKey, source: walletKey ? 'wallet' : 'none', needsPrompt: true };
+
+    // Default: this address needs its OWN key. `undecided` iff no preference yet
+    // (so the paid-plan case can offer inherit before auto-provisioning).
+    return { key: null, source: 'needs-own', undecided: pref === null };
   } catch {
-    return { key: null, source: 'none', needsPrompt: false };
+    return { key: null, source: 'needs-own', undecided: false };
   }
 }

--- a/src/sdk/subscription/usage.ts
+++ b/src/sdk/subscription/usage.ts
@@ -4,6 +4,16 @@ export function usagePercent(used: number, limit: number): number {
   return Math.min(100, Math.round((used / limit) * 100));
 }
 
+/**
+ * A subscription snapshot is on a PAID plan iff it carries an expiry.
+ * Free (and gateway-demoted-from-expired) keys have `activeUntil === null`.
+ * Used to decide whether inheriting the wallet key onto a new address is a
+ * real choice worth prompting for (only paid plans are).
+ */
+export function isPaidPlan(activeUntil: string | null | undefined): boolean {
+  return activeUntil != null;
+}
+
 /** Human-readable expiry; '—' when there is no expiry. */
 export function formatExpiry(iso: string | null): string {
   if (!iso) return '—';

--- a/tests/unit/sdk/keyVault.test.ts
+++ b/tests/unit/sdk/keyVault.test.ts
@@ -31,7 +31,7 @@ function fakeSphere(activePubkey: string = ROOT_PUBKEY) {
   };
 }
 
-describe('keyVault (wallet-level default, per-address opt-out)', () => {
+describe('keyVault (individual per address by default; inherit is opt-in)', () => {
   beforeEach(() => localStorage.clear());
 
   it('saveWalletKey writes the encrypted ROOT slot regardless of active address + boot cache', async () => {
@@ -43,53 +43,66 @@ describe('keyVault (wallet-level default, per-address opt-out)', () => {
     await expect(loadWalletKey(sphere as never, 'testnet2')).resolves.toBe('sk_wallet');
   });
 
-  it('saveAddressKey writes the ACTIVE address slot, records the own preference, updates cache', async () => {
+  it('index 0 resolves to its own (wallet) key', async () => {
+    const sphere = fakeSphere(ROOT_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', undecided: false });
+  });
+
+  it('index 0 with no key yet → needs-own (first-time provision)', async () => {
+    const sphere = fakeSphere(ROOT_PUBKEY);
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: null, source: 'needs-own', undecided: false });
+  });
+
+  it('a fresh non-root address needs its OWN key by default (NOT inherit)', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet'); // primary exists…
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: null, source: 'needs-own', undecided: true }); // …but address 2 does NOT inherit it
+  });
+
+  it('saveAddressKey gives the active address its own key (own wins)', async () => {
     const sphere = fakeSphere(ADDR2_PUBKEY);
     await saveAddressKey(sphere as never, 'testnet2', 'sk_own');
     expect(sphere._store.get(scopedSubscriptionSlot('testnet2', ADDR2_PUBKEY))).toMatch(/^enc1\./);
     expect(getStoredSubscriptionKey()).toBe('sk_own');
     const resolved = await resolveActiveKey(sphere as never, 'testnet2');
-    expect(resolved).toEqual({ key: 'sk_own', source: 'own', needsPrompt: false });
+    expect(resolved).toEqual({ key: 'sk_own', source: 'own', undecided: false });
   });
 
-  it('resolves the wallet key when active address IS index 0', async () => {
-    const sphere = fakeSphere(ROOT_PUBKEY);
-    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
-    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
-    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', needsPrompt: false });
-  });
-
-  it('own key WINS over the wallet key for its address', async () => {
+  it("only a recorded 'inherit' preference makes an address use the wallet key", async () => {
     const sphere = fakeSphere(ADDR2_PUBKEY);
     await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
-    await saveAddressKey(sphere as never, 'testnet2', 'sk_own');
+    await setAddressPreference(sphere as never, 'testnet2', 'inherit');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', undecided: false });
+  });
+
+  it("preference 'own' with a lost slot → needs-own but no longer undecided (re-provision, don't prompt)", async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    await setAddressPreference(sphere as never, 'testnet2', 'own');
+    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
+    expect(resolved).toEqual({ key: null, source: 'needs-own', undecided: false });
+  });
+
+  it('own key WINS over a set inherit preference', async () => {
+    const sphere = fakeSphere(ADDR2_PUBKEY);
+    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
+    await setAddressPreference(sphere as never, 'testnet2', 'inherit');
+    await saveAddressKey(sphere as never, 'testnet2', 'sk_own'); // overrides pref back to 'own'
     const resolved = await resolveActiveKey(sphere as never, 'testnet2');
     expect(resolved.key).toBe('sk_own');
     expect(resolved.source).toBe('own');
   });
 
-  it('first visit to a keyless address: inherits wallet key provisionally + needsPrompt', async () => {
-    const sphere = fakeSphere(ADDR2_PUBKEY);
-    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
-    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
-    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', needsPrompt: true });
-  });
-
-  it('recorded inherit preference silences the prompt', async () => {
-    const sphere = fakeSphere(ADDR2_PUBKEY);
-    await saveWalletKey(sphere as never, 'testnet2', 'sk_wallet');
-    await setAddressPreference(sphere as never, 'testnet2', 'inherit');
-    const resolved = await resolveActiveKey(sphere as never, 'testnet2');
-    expect(resolved).toEqual({ key: 'sk_wallet', source: 'wallet', needsPrompt: false });
-  });
-
-  it('returns null/none for missing or undecryptable entries', async () => {
+  it('undecryptable root slot → index 0 reads as needs-own', async () => {
     const sphere = fakeSphere(ROOT_PUBKEY);
-    await expect(loadWalletKey(sphere as never, 'testnet2')).resolves.toBeNull();
     sphere._store.set(scopedSubscriptionSlot('testnet2', ROOT_PUBKEY), 'enc1.garbage');
     await expect(loadWalletKey(sphere as never, 'testnet2')).resolves.toBeNull();
     const resolved = await resolveActiveKey(sphere as never, 'testnet2');
-    expect(resolved.key).toBeNull();
-    expect(resolved.source).toBe('none');
+    expect(resolved).toEqual({ key: null, source: 'needs-own', undecided: false });
   });
 });

--- a/tests/unit/sdk/usage.test.ts
+++ b/tests/unit/sdk/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { usagePercent, formatExpiry, msUntil, formatCountdown } from '@/sdk/subscription/usage';
+import { usagePercent, formatExpiry, msUntil, formatCountdown, isPaidPlan } from '@/sdk/subscription/usage';
 
 describe('usagePercent', () => {
   it('computes a rounded percentage', () => {
@@ -48,5 +48,16 @@ describe('formatCountdown', () => {
   });
   it('shows seconds under a minute', () => {
     expect(formatCountdown(45_000)).toBe('45s');
+  });
+});
+
+describe('isPaidPlan', () => {
+  it('is true only when an expiry is present (paid plan)', () => {
+    expect(isPaidPlan('2026-08-01T00:00:00Z')).toBe(true);
+  });
+
+  it('is false for free/demoted keys (no expiry) and unknown values', () => {
+    expect(isPaidPlan(null)).toBe(false);
+    expect(isPaidPlan(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
Refines the multi-address subscription model per feedback, plus UI polish. Builds on the merged #405.

## Model change — individual by default, inherit opt-in
Reverses the default:
- **Each address gets its OWN free key by default** (its own quota), not the wallet key.
- **Inheriting index 0's key is opt-in** via the prompt checkbox — useful only to **share a PAID plan** onto another address.
- **The prompt only appears when index 0 is on a PAID plan** and the address hasn't decided yet. On a free primary plan there's nothing to decide → the address silently gets its own free key, no modal.

Mechanics: `resolveActiveKey` now returns `'needs-own'` for undecided non-root addresses; `SphereProvider` provisions an address-scoped free key (`scope:'address'`) unless the paid+undecided case raises the share-plan prompt. The prompt's checkbox defaults **off** (own free plan); checking it records `'inherit'` and applies the primary key. Dismiss = own free plan.

## UI polish
- Copy buttons (API-key row, upgrade-success key box) now flash a green check on success, consistent with the rest of the app.
- Settings → Subscription row shows the current plan name (e.g. "Free plan") instead of the static "Manage your plan".
- Address prompt labels the checkbox with index 0's Unicity ID (@nametag / short pubkey) + its paid plan name.

## Verification
`tsc -b` zero errors; **193/193** tests (keyVault resolver rewritten for the new model); lint clean.

## Note on the branch
Includes the recovered "prompt only when paid" commit (`919eeb96`) that landed after #405 merged. Base is the restored `feat/subscription-key-migration`.