### PR TITLE
fix: stop the storage:degraded toast storm — bump sphere-sdk 0.11.5 + toast cooldown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.4",
+        "@unicitylabs/sphere-sdk": "0.11.5",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.4.tgz",
-      "integrity": "sha512-MigL1aEaQKY+O14Z+jRDoNsvuHZgZUy+GJQeDKq3r2uGOGB3bN/moEdhNcpxwvQmlaPauJakyGoZXW4zV8yo7Q==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.5.tgz",
+      "integrity": "sha512-RNh7VW5NcIS7ra6H3gRZCJpNQroURwJWP+QTO9tdSypnO2VDQTMBTnZPCKu7kn4fMKhUdDEsHAT7gpvA9CMXUg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.4",
+    "@unicitylabs/sphere-sdk": "0.11.5",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -15,12 +15,18 @@ interface SDKDirectMessage {
   recipientPubkey: string;
 }
 
+// One degraded-storage toast (and Sentry event) per provider per window —
+// the SDK emits storage:degraded per failed background save (sphere-sdk#642).
+const STORAGE_DEGRADED_TOAST_COOLDOWN_MS = 5 * 60 * 1000;
+
 export function useSphereEvents(): void {
   const { sphere } = useSphereContext();
   const queryClient = useQueryClient();
   const invalidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track seen transfer IDs to prevent duplicate toasts from Nostr re-deliveries
   const seenTransferIdsRef = useRef<Set<string>>(new Set());
+  // Last storage:degraded toast per providerId — cooldown against toast storms
+  const degradedToastAtRef = useRef<Map<string, number>>(new Map());
 
   // When sphere instance changes (new wallet, delete, import) —
   // immediately sync identity cache so the UI never shows stale data
@@ -169,7 +175,20 @@ export function useSphereEvents(): void {
     // sphere-sdk#515 F2: a background custody save failed — the active
     // custody provider rejected a write. Surface it (never log-only); the
     // SEND pipeline already fails hard on its own writes.
+    // sphere-sdk#642: the SDK emits one event PER failed save — during a
+    // backend degradation that is one per incoming token (the 2026-07-07
+    // red-toast storm, Sentry SPHERE-2/-3). The condition is per-provider,
+    // self-healing, and not user-actionable per occurrence, so toast (and
+    // thereby report to Sentry) at most once per provider per cooldown;
+    // repeats within the window stay visible in the console.
     const handleStorageDegraded = (data: { providerId: string; error: string }) => {
+      const now = Date.now();
+      const last = degradedToastAtRef.current.get(data.providerId) ?? 0;
+      if (now - last < STORAGE_DEGRADED_TOAST_COOLDOWN_MS) {
+        console.warn(`storage:degraded (toast suppressed) ${data.providerId}: ${data.error}`);
+        return;
+      }
+      degradedToastAtRef.current.set(data.providerId, now);
       showToast(
         `Token storage degraded (${data.providerId}): a background save failed — ${data.error}`,
         'error',


### PR DESCRIPTION
Two changes that together resolve the 2026-07-07 `storage:degraded` red-toast storm (Sentry SPHERE-2/-3, the swap wallet with a large incoming-transaction history):

## 1. Root-cause fix — bump `@unicitylabs/sphere-sdk` 0.11.4 → 0.11.5

0.11.5 ships [sphere-sdk#646](https://github.com/unicity-sphere/sphere-sdk/pull/646) (closes sphere-sdk#642): the heavy-wallet request storm fix — single-flight `load()`, incremental history hydration (steady-state resync costs ~1 history page instead of re-paging 100 every 30s), and a wallet-api client request timeout. This is what actually stops the 30s full-reload storm that starved the background token-storage saves into the failures that emitted `storage:degraded`.

## 2. Defense-in-depth — cooldown the `storage:degraded` toast

The SDK emits `storage:degraded` once per failed background save; during a backend degradation that is one red toast **and one Sentry event per incoming token**. The condition is per-provider, self-healing, and not user-actionable per occurrence, so `useSphereEvents` now shows the first toast (still mirrored to Sentry via toast-utils) and suppresses repeats for the same provider for 5 minutes, logging them to the console. This caps the spam even if the backend degrades for some other reason the SDK fix doesn't cover.

## Test plan

`npx tsc --noEmit`, `npm run lint`, `npm run test:run` (93 tests), `npm run build` — all green with 0.11.5 installed. Verified the merged #646 fix is present in the published 0.11.5 dist.