### PR TITLE
feat(subscription): hide paid plans behind "Coming on Mainnet" + free-plan showcase

### DIFF
--- a/src/components/subscription/CurrentPlanShowcase.tsx
+++ b/src/components/subscription/CurrentPlanShowcase.tsx
@@ -1,0 +1,132 @@
+/**
+ * "Your plan" hero for the free-tier state (testnet, paid plans not yet live).
+ * Presents the plan the way a top-tier product surfaces a usage panel —
+ * confident type, restraint, live usage meters against the limits, one accent —
+ * and frames mainnet as an aspirational roadmap, not a paywall.
+ *
+ * Motion is purposeful: the card settles in, meters fill and the numbers count
+ * up once. Under reduced-motion the final state renders immediately.
+ */
+import { useEffect, useState } from 'react';
+import { motion, animate, useMotionValue, useReducedMotion } from 'framer-motion';
+import { ArrowUpRight, Sparkles } from 'lucide-react';
+import type { UtilizationInfo } from '../../services/subscriptionApi';
+
+function CountUp({ to }: { to: number }) {
+  const reduce = useReducedMotion();
+  const mv = useMotionValue(0);
+  const [display, setDisplay] = useState(reduce ? to : 0);
+
+  useEffect(() => {
+    if (reduce) {
+      setDisplay(to);
+      return;
+    }
+    const controls = animate(mv, to, {
+      duration: 0.9,
+      ease: [0.16, 1, 0.3, 1],
+      onUpdate: (v) => setDisplay(Math.round(v)),
+    });
+    return controls.stop;
+  }, [to, reduce, mv]);
+
+  return <>{display.toLocaleString()}</>;
+}
+
+function UsageMeter({ label, used, max, sublabel }: { label: string; used: number; max: number; sublabel: string }) {
+  const reduce = useReducedMotion();
+  const pct = max > 0 ? Math.min(100, Math.round((used / max) * 100)) : 0;
+  const bar = pct >= 90 ? 'bg-red-500' : pct >= 70 ? 'bg-orange-500' : 'bg-emerald-500';
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <span className="text-sm font-medium text-neutral-700 dark:text-white/70">{label}</span>
+        <span className="font-mono text-sm tabular-nums text-neutral-500 dark:text-white/50">
+          <CountUp to={used} /> / {max.toLocaleString()}
+        </span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-neutral-200 dark:bg-white/8">
+        <motion.div
+          className={`h-full rounded-full ${bar}`}
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: reduce ? 0 : 1, ease: [0.16, 1, 0.3, 1], delay: reduce ? 0 : 0.15 }}
+        />
+      </div>
+      <div className="mt-1.5 text-xs text-neutral-400 dark:text-white/40">{sublabel}</div>
+    </div>
+  );
+}
+
+export function CurrentPlanShowcase({ util }: { util: UtilizationInfo | null }) {
+  const reduce = useReducedMotion();
+  const u = util?.utilization;
+  const maxDay = u?.maxPerDay ?? util?.plan?.requestsPerDay ?? 0;
+  const maxMinute = u?.maxPerMinute ?? util?.plan?.requestsPerMinute ?? 0;
+
+  return (
+    <div className="relative mx-auto max-w-xl">
+      {/* Subtle overhead glow — depth, not spectacle */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 -top-10 -z-10 mx-auto h-40 max-w-md rounded-full opacity-70 blur-3xl"
+        style={{
+          background:
+            'radial-gradient(55% 60% at 50% 0%, rgba(16,185,129,0.22), transparent 70%), radial-gradient(45% 50% at 70% 10%, rgba(249,115,22,0.16), transparent 70%)',
+        }}
+      />
+
+      <motion.div
+        initial={reduce ? { opacity: 0 } : { opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+        className="overflow-hidden rounded-3xl border border-neutral-200/80 bg-white/70 shadow-[0_24px_60px_-30px_rgba(0,0,0,0.35)] backdrop-blur-sm dark:border-white/10 dark:bg-white/3"
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 p-7 pb-6 sm:p-8 sm:pb-7">
+          <div className="min-w-0">
+            <h2 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white sm:text-4xl">Free</h2>
+            <p className="mt-1.5 text-sm text-neutral-500 dark:text-white/50">
+              Generous limits to build and transact — at no cost.
+            </p>
+          </div>
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-500/12 px-3 py-1 text-xs font-medium text-emerald-500">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            Active
+          </span>
+        </div>
+
+        {/* Live usage meters */}
+        <div className="space-y-5 border-y border-neutral-200/70 bg-neutral-50/50 px-7 py-6 sm:px-8 dark:border-white/8 dark:bg-white/2">
+          <UsageMeter
+            label="Today"
+            used={u?.consumedPerDay ?? 0}
+            max={maxDay}
+            sublabel={`${(u?.availablePerDay ?? maxDay).toLocaleString()} commitments remaining`}
+          />
+          <UsageMeter
+            label="This minute"
+            used={u?.consumedPerMinute ?? 0}
+            max={maxMinute}
+            sublabel="Refills continuously"
+          />
+        </div>
+
+        {/* Mainnet roadmap — aspirational, not a paywall */}
+        <div className="flex items-center justify-between gap-3 p-7 pt-6 sm:px-8">
+          <div className="min-w-0">
+            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-neutral-400 dark:text-white/40">
+              <Sparkles className="h-3.5 w-3.5 text-orange-500" />
+              Coming on mainnet
+            </div>
+            <p className="text-sm text-neutral-600 dark:text-white/60">
+              Higher limits and pro tools, for when you scale up.
+            </p>
+          </div>
+          <ArrowUpRight className="h-5 w-5 shrink-0 text-orange-500/70" />
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/subscription/PaidPlansComingSoonCard.tsx
+++ b/src/components/subscription/PaidPlansComingSoonCard.tsx
@@ -1,0 +1,36 @@
+/**
+ * Placeholder shown in place of the individual paid plans while they aren't
+ * purchasable yet (testnet). Deliberately vague — the concrete tiers/prices
+ * are not finalized, so it only signals that paid tiers are coming on mainnet.
+ * Matches PlanCard's dimensions so it sits cleanly in the plans row.
+ */
+import { motion, type Variants } from 'framer-motion';
+import { Sparkles } from 'lucide-react';
+
+export function PaidPlansComingSoonCard({ variants }: { variants?: Variants }) {
+  return (
+    <motion.div
+      variants={variants}
+      className="relative flex w-full flex-col rounded-2xl border border-dashed border-neutral-300 bg-neutral-50 p-6 opacity-75 sm:w-58 dark:border-white/12 dark:bg-white/3"
+    >
+      <span className="absolute right-4 top-4 rounded-full bg-white/10 px-2.5 py-0.5 text-[11px] font-medium text-neutral-500 dark:text-white/50">
+        Coming on Mainnet
+      </span>
+
+      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-xl bg-orange-500/10">
+        <Sparkles className="h-4 w-4 text-orange-500" />
+      </div>
+
+      <h3 className="text-lg font-semibold text-neutral-900 dark:text-white">Paid plans</h3>
+      <p className="mt-2 text-sm leading-relaxed text-neutral-500 dark:text-white/45">
+        Higher daily and per-minute limits for heavier usage — arriving on mainnet.
+      </p>
+
+      <div className="mt-5 min-h-10">
+        <div className="w-full rounded-xl border border-neutral-200 py-2 text-center text-sm font-medium text-neutral-400 dark:border-white/10 dark:text-white/40">
+          Coming on Mainnet
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/subscription/PlanCard.tsx
+++ b/src/components/subscription/PlanCard.tsx
@@ -3,7 +3,7 @@
  * price → CTA → derived feature checklist, with Popular/Current badges) while
  * reusing Sphere's existing styling tokens.
  */
-import { motion } from 'framer-motion';
+import { motion, type Variants } from 'framer-motion';
 import { Check } from 'lucide-react';
 import { Button } from '../wallet/ui';
 import type { PlanInfo } from '../../services/subscriptionApi';
@@ -17,24 +17,26 @@ interface PlanCardProps {
   onSelect?: (plan: PlanInfo) => void;
   loading?: boolean;
   disabled?: boolean;
+  /** Mount variants (supplied by PlansGrid for the staggered reveal). */
+  variants?: Variants;
 }
 
-export function PlanCard({ plan, current, popular, onSelect, loading, disabled }: PlanCardProps) {
+export function PlanCard({ plan, current, popular, onSelect, loading, disabled, variants }: PlanCardProps) {
   const price = formatPlanPrice(plan);
   const features = planFeatures(plan);
   const showCta = !!onSelect && !current;
-  const accent = current ? 'emerald' : popular ? 'orange' : 'neutral';
 
   return (
     <motion.div
-      whileHover={showCta ? { y: -3 } : undefined}
-      transition={{ duration: 0.15 }}
-      className={`relative flex flex-col rounded-2xl border p-6 ${
+      variants={variants}
+      whileHover={showCta ? { y: -6 } : undefined}
+      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      className={`group relative flex w-full flex-col rounded-2xl border p-6 transition-shadow duration-300 sm:w-58 ${
         current
           ? 'border-emerald-500/30 bg-emerald-500/6'
           : popular
-            ? 'border-orange-500/40 bg-orange-500/6 shadow-[0_0_0_1px_rgba(249,115,22,0.15)]'
-            : 'border-neutral-200 bg-neutral-50 dark:border-white/8 dark:bg-white/4'
+            ? 'border-orange-500/40 bg-orange-500/6 shadow-[0_0_0_1px_rgba(249,115,22,0.15)] hover:shadow-[0_18px_40px_-16px_rgba(249,115,22,0.45)]'
+            : 'border-neutral-200 bg-neutral-50 hover:border-orange-500/30 hover:shadow-[0_18px_40px_-20px_rgba(0,0,0,0.5)] dark:border-white/8 dark:bg-white/4'
       }`}
     >
       {/* Badge (Current takes precedence over Popular) */}
@@ -51,11 +53,7 @@ export function PlanCard({ plan, current, popular, onSelect, loading, disabled }
       {/* Name */}
       <h3
         className={`text-lg font-semibold capitalize ${
-          accent === 'emerald'
-            ? 'text-emerald-500'
-            : accent === 'orange'
-              ? 'text-orange-500'
-              : 'text-neutral-900 dark:text-white'
+          current ? 'text-emerald-500' : popular ? 'text-orange-500' : 'text-neutral-900 dark:text-white'
         }`}
       >
         {plan.name}

--- a/src/components/subscription/PlansGrid.tsx
+++ b/src/components/subscription/PlansGrid.tsx
@@ -1,10 +1,17 @@
 /**
- * Responsive grid of plan cards. Auto-fits columns to the available width
- * (1 column on a narrow wallet panel, several side-by-side in a full-screen
- * modal on desktop), regardless of how many plans the SGW returns.
+ * Plan cards laid out as a centered wrap: on a wide modal the plans sit in one
+ * row; when they wrap, the trailing row stays centered (no orphaned card
+ * hugging the left). Cards reveal in an orchestrated left-to-right stagger.
+ *
+ * While paid plans aren't purchasable (testnet, PAID_PLANS_ENABLED off), the
+ * concrete paid tiers are hidden behind a single "Paid plans — Coming on
+ * Mainnet" placeholder (tiers/prices aren't finalized yet).
  */
+import { motion, useReducedMotion, type Variants } from 'framer-motion';
 import { PlanCard } from './PlanCard';
-import { isPopularPlan } from './planFeatures';
+import { PaidPlansComingSoonCard } from './PaidPlansComingSoonCard';
+import { isPopularPlan, isFreePlan } from './planFeatures';
+import { PAID_PLANS_ENABLED } from '../../config/subscription';
 import type { PlanInfo } from '../../services/subscriptionApi';
 
 interface PlansGridProps {
@@ -20,9 +27,28 @@ interface PlansGridProps {
 }
 
 export function PlansGrid({ plans, currentPlanName, onSelect, loadingPlanId, disabled }: PlansGridProps) {
+  const reduce = useReducedMotion();
+
+  const container: Variants = {
+    hidden: {},
+    show: { transition: { staggerChildren: reduce ? 0 : 0.07, delayChildren: reduce ? 0 : 0.05 } },
+  };
+  const item: Variants = {
+    hidden: reduce ? { opacity: 0 } : { opacity: 0, y: 20, scale: 0.97 },
+    show: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.4, ease: [0.16, 1, 0.3, 1] } },
+  };
+
+  const freePlans = plans.filter(isFreePlan);
+  const paidPlans = plans.filter((p) => !isFreePlan(p));
+
   return (
-    <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
-      {plans.map((plan) => (
+    <motion.div
+      variants={container}
+      initial="hidden"
+      animate="show"
+      className="flex flex-wrap justify-center gap-5"
+    >
+      {freePlans.map((plan) => (
         <PlanCard
           key={plan.planId}
           plan={plan}
@@ -31,8 +57,24 @@ export function PlansGrid({ plans, currentPlanName, onSelect, loadingPlanId, dis
           onSelect={onSelect}
           loading={loadingPlanId === plan.planId}
           disabled={disabled}
+          variants={item}
         />
       ))}
-    </div>
+
+      {PAID_PLANS_ENABLED
+        ? paidPlans.map((plan) => (
+            <PlanCard
+              key={plan.planId}
+              plan={plan}
+              current={plan.name.toLowerCase() === (currentPlanName ?? '').toLowerCase()}
+              popular={isPopularPlan(plan)}
+              onSelect={onSelect}
+              loading={loadingPlanId === plan.planId}
+              disabled={disabled}
+              variants={item}
+            />
+          ))
+        : paidPlans.length > 0 && <PaidPlansComingSoonCard variants={item} />}
+    </motion.div>
   );
 }

--- a/src/components/upgrade/UpgradeModal.tsx
+++ b/src/components/upgrade/UpgradeModal.tsx
@@ -4,12 +4,13 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { X, Sparkles, Loader2, AlertTriangle } from 'lucide-react';
 import { Button } from '../wallet/ui';
 import { PlansGrid } from '../subscription/PlansGrid';
+import { CurrentPlanShowcase } from '../subscription/CurrentPlanShowcase';
 import { UpgradeSuccess } from './UpgradeSuccess';
 import { usePlans, useUtilization, useCheckout } from '../../sdk/hooks/subscription';
 import { pollOrderStatus } from '../../sdk/subscription/pollOrder';
 import { getOrderStatus, type PlanInfo } from '../../services/subscriptionApi';
 import { syntheticCurrentPlan, formatPlanPrice } from '../subscription/planFeatures';
-import { SUBSCRIPTION_MOCK } from '../../config/subscription';
+import { SUBSCRIPTION_MOCK, PAID_PLANS_ENABLED } from '../../config/subscription';
 import { showToast } from '../ui/toast-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { SPHERE_KEYS } from '../../sdk/queryKeys';
@@ -84,13 +85,17 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const currentPlanName = util.data?.plan?.name ?? null;
 
   // plans step: grid gets [synthetic current card, ...store plans]
-  const gridPlans = useMemo(() => {
-    const current = util.data ? syntheticCurrentPlan(util.data) : null;
-    return current ? [current, ...(plans.data ?? [])] : (plans.data ?? []);
-  }, [plans.data, util.data]);
+  const freePlan = useMemo(() => (util.data ? syntheticCurrentPlan(util.data) : null), [util.data]);
+  const gridPlans = useMemo(
+    () => (freePlan ? [freePlan, ...(plans.data ?? [])] : (plans.data ?? [])),
+    [plans.data, freePlan],
+  );
 
   const handleSelect = (plan: PlanInfo) => {
     if (plan.name.toLowerCase() === (currentPlanName ?? '').toLowerCase()) return;
+    // Paid plans aren't purchasable yet (testnet) — the card shows "Coming on
+    // Mainnet" and no CTA; this guards any other entry path.
+    if (!PAID_PLANS_ENABLED && plan.priceCents > 0) return;
     setSelectedPlan(plan);
     setStep('email');
   };
@@ -179,7 +184,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
           <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-4 sm:px-8">
             <div className="flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-orange-500" />
-              <span className="text-lg font-semibold">Choose your plan</span>
+              <span className="text-lg font-semibold">{PAID_PLANS_ENABLED ? 'Choose your plan' : 'Your plan'}</span>
             </div>
             <button
               type="button"
@@ -191,8 +196,27 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
             </button>
           </div>
 
-          <div className="mx-auto w-full max-w-5xl px-4 pb-20 sm:px-8">
-            {step === 'plans' && (
+          <motion.div
+            className="mx-auto w-full max-w-6xl px-4 pb-20 sm:px-8"
+            initial={{ opacity: 0, y: 18, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.98 }}
+            transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+          >
+            {step === 'plans' && !PAID_PLANS_ENABLED && (
+              <>
+                <UpgradeReasonBanner reason={reason} />
+                {util.isLoading ? (
+                  <div className="py-20 text-center text-neutral-400">
+                    <Loader2 className="mx-auto h-6 w-6 animate-spin" />
+                  </div>
+                ) : (
+                  <CurrentPlanShowcase util={util.data ?? null} />
+                )}
+              </>
+            )}
+
+            {step === 'plans' && PAID_PLANS_ENABLED && (
               <>
                 <div className="mb-8 text-center">
                   <h2 className="text-2xl font-bold sm:text-3xl">Unlock more commitments</h2>
@@ -318,7 +342,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                 </div>
               </div>
             )}
-          </div>
+          </motion.div>
         </motion.div>
       )}
     </AnimatePresence>,

--- a/src/components/wallet/L3/modals/SubscriptionModal.tsx
+++ b/src/components/wallet/L3/modals/SubscriptionModal.tsx
@@ -95,7 +95,9 @@ export function SubscriptionModal({ isOpen, onClose, onUpgrade }: SubscriptionMo
                 <span className="font-semibold font-mono capitalize">{plan.name} plan</span>
               </div>
               <div className="text-xs text-neutral-500 dark:text-white/45">
-                Renews / expires: {formatExpiry(data?.activeUntil ?? null)}
+                {data?.activeUntil
+                  ? `Renews / expires: ${formatExpiry(data.activeUntil)}`
+                  : 'Never expires — free plan'}
               </div>
             </div>
 

--- a/src/config/subscription.ts
+++ b/src/config/subscription.ts
@@ -16,3 +16,11 @@ export const SUBSCRIPTION_ENABLED =
 /** When true, the SGW client returns canned data instead of hitting the network — lets the UI be built before the backend is live. */
 export const SUBSCRIPTION_MOCK =
   import.meta.env.VITE_SUBSCRIPTION_MOCK === 'true';
+
+/**
+ * Whether PAID plans can be purchased. Off by default on testnet — paid plans
+ * render as "Coming on Mainnet" (visible but not selectable); only the free
+ * plan is usable. Flip to 'true' for mainnet once the store is live.
+ */
+export const PAID_PLANS_ENABLED =
+  import.meta.env.VITE_PAID_PLANS_ENABLED === 'true';


### PR DESCRIPTION
## What

On testnet paid plans aren't purchasable yet (`PAID_PLANS_ENABLED=false`), so this reworks the upgrade/plan surfaces to lead with the **free tier** instead of a paywall grid:

- **`CurrentPlanShowcase`** (new) — a "Your plan" hero for the free state: live usage meters (Today / This minute) against the actual limits, animated fills + count-up, and an aspirational "Coming on mainnet" teaser (not a paywall). Shown in `UpgradeModal` when paid plans are off.
- **`PaidPlansComingSoonCard`** (new) — a single "Paid plans — Coming on Mainnet" placeholder that replaces the concrete paid tiers (tiers/prices aren't finalized).
- **`PlanCard` / `PlansGrid`** — centered wrap layout + orchestrated staggered reveal so the cards no longer sit in a lopsided 2-row grid.
- **`SubscriptionModal`** — free keys now read **"Never expires — free plan"** instead of a bare "Renews / expires: —" (`activeUntil` is `null` for free; there's genuinely no expiry).
- **`PAID_PLANS_ENABLED`** config flag (default `false`; flip `true` for mainnet once the store is live).

## Why

The prior grid showed unfinished paid tiers and an empty "expires" field on free — it read like a paywall / a bug. This makes the free tier feel first-class and frames paid as a future, not a wall.

## Ships dormant

The subscription feature is gated by `SUBSCRIPTION_ENABLED`, which is **not wired into the Docker runtime-config mechanism yet**, so promoted images ship with subscriptions off — this PR only changes what's shown *when the feature is on*. Enabling it in a deployed env is a separate deploy-wiring change (Dockerfile ARGs + `runtime-config.sh` + a same-origin `/sgw` nginx proxy) tracked as a follow-up.

## Test plan

- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm run test:run` — 193 passed
- `npm run build` — OK