### PR TITLE
fix(subscription): show the plan showcase in onboarding (match the upgrade modal)

### DIFF
--- a/src/components/wallet/onboarding/components/PlanCapabilitiesScreen.tsx
+++ b/src/components/wallet/onboarding/components/PlanCapabilitiesScreen.tsx
@@ -9,8 +9,10 @@ import { motion } from 'framer-motion';
 import { Sparkles } from 'lucide-react';
 import { Button } from '../../ui';
 import { PlansGrid } from '../../../subscription/PlansGrid';
+import { CurrentPlanShowcase } from '../../../subscription/CurrentPlanShowcase';
 import { usePlans, useUtilization } from '../../../../sdk/hooks/subscription';
 import { syntheticCurrentPlan } from '../../../subscription/planFeatures';
+import { PAID_PLANS_ENABLED } from '../../../../config/subscription';
 
 interface PlanCapabilitiesScreenProps {
   /** Plan NAME provisioned during finalize (fallback header copy if utilization hasn't loaded yet). */
@@ -50,13 +52,17 @@ export function PlanCapabilitiesScreen({ planName, created, onContinue, isBusy }
             {created ? 'Your plan is ready' : 'Subscription restored'}
           </h2>
           <p className="mt-1.5 text-sm text-neutral-500 dark:text-white/45">
-            {currentName
-              ? `You're on the ${currentName} plan — here's everything you can upgrade to.`
-              : 'Your subscription is active.'}
+            {!currentName
+              ? 'Your subscription is active.'
+              : PAID_PLANS_ENABLED
+                ? `You're on the ${currentName} plan — here's everything you can upgrade to.`
+                : `You're all set on the ${currentName} plan.`}
           </p>
         </div>
 
-        {list.length > 0 && <PlansGrid plans={list} currentPlanName={currentName} />}
+        {PAID_PLANS_ENABLED
+          ? list.length > 0 && <PlansGrid plans={list} currentPlanName={currentName} />
+          : <CurrentPlanShowcase util={util.data ?? null} />}
 
         <div className="mx-auto mt-10 w-full max-w-xs">
           <Button variant="primary" fullWidth loading={isBusy} onClick={onContinue}>


### PR DESCRIPTION
## What

The onboarding **"Your plan is ready"** screen (`PlanCapabilitiesScreen`) still rendered the old two-card grid — free `PlanCard` + a boxy "Coming on Mainnet" card — while `UpgradeModal` already used the premium `CurrentPlanShowcase`. Same free-tier state, two different looks; onboarding was the weaker first impression.

Now onboarding renders the **same `CurrentPlanShowcase`** (live limit meters + mainnet teaser) when paid plans are off, and only falls back to `PlansGrid` once `PAID_PLANS_ENABLED` is true (paid plans purchasable). The subtitle no longer promises "everything you can upgrade to" in the free-only state.

The utilization data the showcase needs is already fetched here (`useUtilization()`), so this is a drop-in swap mirroring `UpgradeModal`.

## Why

Consistency + a stronger onboarding moment: one polished plan surface instead of two divergent designs.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- Visual: onboarding after wallet create/restore shows the showcase (not the old grid).