### PR TITLE
feat(docker): runtime-swappable subscription config + same-origin /sgw proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,12 +57,15 @@ HMR_HOST=
 BASE_PATH=/
 
 # Subscription gateway (SGW) — per-wallet aggregator subscription keys.
-# Relative values (default /sgw) ride the dev/preview proxy (SGW_PROXY_TARGET,
-# default http://127.0.0.1:8080) — REQUIRED for the store endpoints, which send
-# no CORS headers. Absolute URLs work only for /auth/* and /api/utilization.
+# The SGW is the aggregator gateway, so when VITE_SUBSCRIPTION_API_URL is
+# unset the app derives the base from the SDK's per-network config and calls
+# it directly (all SGW endpoints serve CORS —
+# unicitynetwork/aggregator-subscription#57). Set /sgw (below) to ride the
+# dev/preview proxy to a LOCAL SGW stack instead (SGW_PROXY_TARGET, default
+# http://127.0.0.1:8080).
 # The flags compare against EXACTLY 'true'; anything else is off.
-# In the Docker image these three come from the container env at runtime
-# (SUBSCRIPTION_API_URL / SUBSCRIPTION_ENABLED / PAID_PLANS_ENABLED) via
+# In the Docker image the two flags come from the container env at runtime
+# (SUBSCRIPTION_ENABLED / PAID_PLANS_ENABLED) via
 # window.__SPHERE_RUNTIME_CONFIG__ — see deploy/runtime-config.sh and
 # src/config/subscription.ts. VITE_SUBSCRIPTION_MOCK is dev-only and
 # deliberately NOT runtime-swappable.

--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,14 @@ BASE_PATH=/
 # Relative values (default /sgw) ride the dev/preview proxy (SGW_PROXY_TARGET,
 # default http://127.0.0.1:8080) — REQUIRED for the store endpoints, which send
 # no CORS headers. Absolute URLs work only for /auth/* and /api/utilization.
+# The flags compare against EXACTLY 'true'; anything else is off.
+# In the Docker image these three come from the container env at runtime
+# (SUBSCRIPTION_API_URL / SUBSCRIPTION_ENABLED / PAID_PLANS_ENABLED) via
+# window.__SPHERE_RUNTIME_CONFIG__ — see deploy/runtime-config.sh and
+# src/config/subscription.ts. VITE_SUBSCRIPTION_MOCK is dev-only and
+# deliberately NOT runtime-swappable.
 VITE_SUBSCRIPTION_API_URL=/sgw
 VITE_SUBSCRIPTION_ENABLED=false
 VITE_SUBSCRIPTION_MOCK=false
+# Paid-plan purchases (mainnet). Off = paid plans render "Coming on Mainnet".
+#VITE_PAID_PLANS_ENABLED=false

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -84,7 +84,6 @@ jobs:
             -e AGGREGATOR_API_KEY=sk_smoke_test \
             -e SUBSCRIPTION_ENABLED=true \
             -e PAID_PLANS_ENABLED=false \
-            -e SGW_UPSTREAM=http://sgw-smoke.invalid:19999 \
             sphere-validate:${{ matrix.dockerfile }})
           trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
 
@@ -105,11 +104,12 @@ jobs:
           docker exec "$cid" sh -c "grep -rq 'quest-api.example.test' /usr/share/nginx/html" \
             || { echo "ERROR: injected SPHERE_API_URL not found in bundle"; exit 1; }
 
-          # Runtime config global: subscription values ride /runtime-config.js
-          # (window.__SPHERE_RUNTIME_CONFIG__), NOT the sed placeholders —
-          # Rollup would prune every `if (FLAG)` against a baked literal. The
-          # hook must have written the env values, index.html must load the
-          # script, and the bundle must actually read the global.
+          # Runtime config global: the subscription flags ride
+          # /runtime-config.js (window.__SPHERE_RUNTIME_CONFIG__), NOT the sed
+          # placeholders — Rollup would prune every `if (FLAG)` against a
+          # baked literal. The hook must have written the env values,
+          # index.html must load the script, and the bundle must actually
+          # read the global.
           docker exec "$cid" sh -c "cat /usr/share/nginx/html/runtime-config.js"
           docker exec "$cid" sh -c "grep -q '\"SUBSCRIPTION_ENABLED\": \"true\"' /usr/share/nginx/html/runtime-config.js" \
             || { echo "ERROR: SUBSCRIPTION_ENABLED not written to runtime-config.js"; exit 1; }
@@ -118,20 +118,11 @@ jobs:
           docker exec "$cid" sh -c "grep -rq '__SPHERE_RUNTIME_CONFIG__' /usr/share/nginx/html/assets" \
             || { echo "ERROR: bundle does not read __SPHERE_RUNTIME_CONFIG__"; exit 1; }
 
-          # /sgw reverse proxy: the runtime hook must have generated the
-          # location snippet from SGW_UPSTREAM, nginx must accept the combined
-          # config AND START despite the deliberately-unresolvable hostname
-          # (request-time DNS via variable proxy_pass — a literal hostname
-          # would be resolved once at startup and kill nginx with [emerg],
-          # crash-looping the whole app), and a request under /sgw/ must be
-          # PROXIED (502 from the dead upstream), not swallowed by the SPA
-          # fallback (which would 200 with index.html).
-          docker exec "$cid" sh -c "grep -q 'set \$sphere_sgw_upstream http://sgw-smoke.invalid:19999' /etc/nginx/snippets/sphere-sgw-location.conf" \
-            || { echo "ERROR: /sgw snippet missing or wrong upstream"; exit 1; }
+          # The SGW base URL is derived from the SDK's per-network config —
+          # the bundle must carry the gateway origin (no env var, no proxy).
+          docker exec "$cid" sh -c "grep -rq 'gateway.testnet2.unicity.network' /usr/share/nginx/html/assets" \
+            || { echo "ERROR: SDK gateway origin not found in bundle"; exit 1; }
           docker exec "$cid" nginx -t
-          out=$(docker exec "$cid" sh -c "wget -q -S -O /dev/null http://127.0.0.1/sgw/ping 2>&1 || true")
-          echo "$out" | grep -q '502' \
-            || { echo "ERROR: /sgw/ not proxied (expected 502 from unresolvable upstream); got: $out"; exit 1; }
           echo "substitution smoke ok"
 
       # #351 fail-closed: declaring wallet-api custody (REQUIRE_WALLET_API) with
@@ -148,26 +139,6 @@ jobs:
           [ "$rc" -ne 0 ] || { echo "ERROR: expected non-zero exit (fail-closed)"; exit 1; }
           echo "$out" | grep -q '#351' || { echo "ERROR: missing #351 fail-closed message"; exit 1; }
           echo "fail-closed smoke ok"
-
-      # Subscriptions fail-closed: SUBSCRIPTION_ENABLED=true with the default
-      # (relative) SUBSCRIPTION_API_URL and no SGW_UPSTREAM must refuse to
-      # start — the app would have no route from /sgw to a gateway.
-      - name: Smoke — fail-closed on SUBSCRIPTION_ENABLED without SGW_UPSTREAM
-        if: matrix.dockerfile == 'Dockerfile'
-        run: |
-          set +e
-          out=$(docker run --rm \
-            -e SPHERE_API_URL=https://quest-api.example.test \
-            -e AGGREGATOR_API_KEY=sk_smoke_test \
-            -e SUBSCRIPTION_ENABLED=true \
-            sphere-validate:${{ matrix.dockerfile }} 2>&1)
-          rc=$?
-          set -e
-          echo "$out"
-          [ "$rc" -ne 0 ] || { echo "ERROR: expected non-zero exit (fail-closed)"; exit 1; }
-          echo "$out" | grep -q 'SGW_UPSTREAM is empty' \
-            || { echo "ERROR: missing SGW_UPSTREAM fail-closed message"; exit 1; }
-          echo "subscription fail-closed smoke ok"
 
       # Smoke for the SSL image: entrypoint is tini → sphere-entrypoint.
       # We can't run the real entrypoint in CI (ssl-setup would need

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -82,6 +82,9 @@ jobs:
             -e REQUIRE_WALLET_API=true \
             -e DEV_PORTAL_URL=https://developers.example.test/ \
             -e AGGREGATOR_API_KEY=sk_smoke_test \
+            -e SUBSCRIPTION_ENABLED=true \
+            -e PAID_PLANS_ENABLED=false \
+            -e SGW_UPSTREAM=http://sgw-smoke.invalid:19999 \
             sphere-validate:${{ matrix.dockerfile }})
           trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
 
@@ -101,6 +104,34 @@ jobs:
           fi
           docker exec "$cid" sh -c "grep -rq 'quest-api.example.test' /usr/share/nginx/html" \
             || { echo "ERROR: injected SPHERE_API_URL not found in bundle"; exit 1; }
+
+          # Runtime config global: subscription values ride /runtime-config.js
+          # (window.__SPHERE_RUNTIME_CONFIG__), NOT the sed placeholders —
+          # Rollup would prune every `if (FLAG)` against a baked literal. The
+          # hook must have written the env values, index.html must load the
+          # script, and the bundle must actually read the global.
+          docker exec "$cid" sh -c "cat /usr/share/nginx/html/runtime-config.js"
+          docker exec "$cid" sh -c "grep -q '\"SUBSCRIPTION_ENABLED\": \"true\"' /usr/share/nginx/html/runtime-config.js" \
+            || { echo "ERROR: SUBSCRIPTION_ENABLED not written to runtime-config.js"; exit 1; }
+          docker exec "$cid" sh -c "grep -q 'runtime-config.js' /usr/share/nginx/html/index.html" \
+            || { echo "ERROR: index.html does not load runtime-config.js"; exit 1; }
+          docker exec "$cid" sh -c "grep -rq '__SPHERE_RUNTIME_CONFIG__' /usr/share/nginx/html/assets" \
+            || { echo "ERROR: bundle does not read __SPHERE_RUNTIME_CONFIG__"; exit 1; }
+
+          # /sgw reverse proxy: the runtime hook must have generated the
+          # location snippet from SGW_UPSTREAM, nginx must accept the combined
+          # config AND START despite the deliberately-unresolvable hostname
+          # (request-time DNS via variable proxy_pass — a literal hostname
+          # would be resolved once at startup and kill nginx with [emerg],
+          # crash-looping the whole app), and a request under /sgw/ must be
+          # PROXIED (502 from the dead upstream), not swallowed by the SPA
+          # fallback (which would 200 with index.html).
+          docker exec "$cid" sh -c "grep -q 'set \$sphere_sgw_upstream http://sgw-smoke.invalid:19999' /etc/nginx/snippets/sphere-sgw-location.conf" \
+            || { echo "ERROR: /sgw snippet missing or wrong upstream"; exit 1; }
+          docker exec "$cid" nginx -t
+          out=$(docker exec "$cid" sh -c "wget -q -S -O /dev/null http://127.0.0.1/sgw/ping 2>&1 || true")
+          echo "$out" | grep -q '502' \
+            || { echo "ERROR: /sgw/ not proxied (expected 502 from unresolvable upstream); got: $out"; exit 1; }
           echo "substitution smoke ok"
 
       # #351 fail-closed: declaring wallet-api custody (REQUIRE_WALLET_API) with
@@ -117,6 +148,26 @@ jobs:
           [ "$rc" -ne 0 ] || { echo "ERROR: expected non-zero exit (fail-closed)"; exit 1; }
           echo "$out" | grep -q '#351' || { echo "ERROR: missing #351 fail-closed message"; exit 1; }
           echo "fail-closed smoke ok"
+
+      # Subscriptions fail-closed: SUBSCRIPTION_ENABLED=true with the default
+      # (relative) SUBSCRIPTION_API_URL and no SGW_UPSTREAM must refuse to
+      # start — the app would have no route from /sgw to a gateway.
+      - name: Smoke — fail-closed on SUBSCRIPTION_ENABLED without SGW_UPSTREAM
+        if: matrix.dockerfile == 'Dockerfile'
+        run: |
+          set +e
+          out=$(docker run --rm \
+            -e SPHERE_API_URL=https://quest-api.example.test \
+            -e AGGREGATOR_API_KEY=sk_smoke_test \
+            -e SUBSCRIPTION_ENABLED=true \
+            sphere-validate:${{ matrix.dockerfile }} 2>&1)
+          rc=$?
+          set -e
+          echo "$out"
+          [ "$rc" -ne 0 ] || { echo "ERROR: expected non-zero exit (fail-closed)"; exit 1; }
+          echo "$out" | grep -q 'SGW_UPSTREAM is empty' \
+            || { echo "ERROR: missing SGW_UPSTREAM fail-closed message"; exit 1; }
+          echo "subscription fail-closed smoke ok"
 
       # Smoke for the SSL image: entrypoint is tini → sphere-entrypoint.
       # We can't run the real entrypoint in CI (ssl-setup would need

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,10 @@ image). Set these on the ECS task definition / `docker -e`:
 | `REQUIRE_WALLET_API`   | `VITE_REQUIRE_WALLET_API`  | #351 fail-closed custody flag (`''`/`false`/`0` = off) |
 | `DEV_PORTAL_URL`       | `VITE_DEV_PORTAL_URL`      | developer-portal link |
 | `AGGREGATOR_API_KEY`   | `VITE_AGGREGATOR_API_KEY`  | aggregator key (non-secret on testnet2; a real secret on mainnet) |
+| `SUBSCRIPTION_ENABLED` | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | per-wallet SGW subscription keys (exactly `true` = on) |
+| `PAID_PLANS_ENABLED`   | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | paid-plan purchases (exactly `true`; testnet leaves off) |
+| `SUBSCRIPTION_API_URL` | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | SGW base as the browser sees it (default `/sgw`) |
+| `SGW_UPSTREAM`         | — (nginx, not JS)          | same-origin `/sgw` reverse-proxy target (SGW store endpoints send no CORS) |
 
 Notes:
 - **CDN cache:** Vite's content-hashed filenames are identical across env
@@ -212,6 +216,18 @@ Notes:
   after changing any value (same as `sphere-dev-portal`).
 - **Fail-closed (#351):** if `REQUIRE_WALLET_API` is truthy but `WALLET_API_URL`
   is empty, the entrypoint exits non-zero and the container won't serve.
+- **Fail-closed (subscriptions):** `SUBSCRIPTION_ENABLED=true` with a relative
+  `SUBSCRIPTION_API_URL` (the default) and no `SGW_UPSTREAM` also refuses to
+  start — there'd be no route from `/sgw` to an SGW.
+- **Two mechanisms, not one:** plain string values (URLs, keys) ride the sed
+  placeholders. Feature FLAGS cannot — Rollup statically evaluates branch
+  conditions against baked literals and prunes every `if (FLAG)` at build
+  time — so the subscription values are served via `/runtime-config.js`
+  (`window.__SPHERE_RUNTIME_CONFIG__`, written at container start, loaded
+  before the bundle). See the header comments in `src/config/subscription.ts`
+  and `src/config/walletApi.ts` before adding a new runtime-swappable value.
+- **`VITE_SUBSCRIPTION_MOCK`** is dev-only and deliberately NOT
+  runtime-swappable (prod builds tree-shake the mock).
 - **`BASE_PATH`** stays a build-time arg (`/` for both AWS envs) — it is *not*
   runtime-swappable. The GitHub Pages branch deploys are a separate non-Docker
   build (`deploy-pages-branch.yml`) and are unaffected by this mechanism.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,8 +207,6 @@ image). Set these on the ECS task definition / `docker -e`:
 | `AGGREGATOR_API_KEY`   | `VITE_AGGREGATOR_API_KEY`  | aggregator key (non-secret on testnet2; a real secret on mainnet) |
 | `SUBSCRIPTION_ENABLED` | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | per-wallet SGW subscription keys (exactly `true` = on) |
 | `PAID_PLANS_ENABLED`   | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | paid-plan purchases (exactly `true`; testnet leaves off) |
-| `SUBSCRIPTION_API_URL` | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | SGW base as the browser sees it (default `/sgw`) |
-| `SGW_UPSTREAM`         | — (nginx, not JS)          | same-origin `/sgw` reverse-proxy target (SGW store endpoints send no CORS) |
 
 Notes:
 - **CDN cache:** Vite's content-hashed filenames are identical across env
@@ -216,16 +214,17 @@ Notes:
   after changing any value (same as `sphere-dev-portal`).
 - **Fail-closed (#351):** if `REQUIRE_WALLET_API` is truthy but `WALLET_API_URL`
   is empty, the entrypoint exits non-zero and the container won't serve.
-- **Fail-closed (subscriptions):** `SUBSCRIPTION_ENABLED=true` with a relative
-  `SUBSCRIPTION_API_URL` (the default) and no `SGW_UPSTREAM` also refuses to
-  start — there'd be no route from `/sgw` to an SGW.
 - **Two mechanisms, not one:** plain string values (URLs, keys) ride the sed
   placeholders. Feature FLAGS cannot — Rollup statically evaluates branch
   conditions against baked literals and prunes every `if (FLAG)` at build
-  time — so the subscription values are served via `/runtime-config.js`
+  time — so the subscription flags are served via `/runtime-config.js`
   (`window.__SPHERE_RUNTIME_CONFIG__`, written at container start, loaded
   before the bundle). See the header comments in `src/config/subscription.ts`
   and `src/config/walletApi.ts` before adding a new runtime-swappable value.
+- **SGW base URL needs no config:** the SGW is the aggregator gateway, derived
+  from the SDK's per-network table (`NETWORKS[SPHERE_NETWORK].aggregatorUrl`,
+  see `src/config/network.ts`); all SGW endpoints serve CORS for direct
+  browser calls (unicitynetwork/aggregator-subscription#57).
 - **`VITE_SUBSCRIPTION_MOCK`** is dev-only and deliberately NOT
   runtime-swappable (prod builds tree-shake the mock).
 - **`BASE_PATH`** stays a build-time arg (`/` for both AWS envs) — it is *not*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,14 @@ ARG VITE_WALLET_API_URL=__RUNTIME_WALLET_API_URL__
 ARG VITE_REQUIRE_WALLET_API=__RUNTIME_REQUIRE_WALLET_API__
 ARG VITE_AGGREGATOR_API_KEY=__RUNTIME_AGGREGATOR_API_KEY__
 ARG VITE_DEV_PORTAL_URL=__RUNTIME_DEV_PORTAL_URL__
-# Subscription vars (VITE_SUBSCRIPTION_*, VITE_PAID_PLANS_ENABLED) have NO
-# placeholders on purpose: feature flags can't ride the sed mechanism (Rollup
-# prunes every `if (FLAG)` against a baked literal at build time). They are
-# runtime-provided via window.__SPHERE_RUNTIME_CONFIG__ instead — the
+# The subscription flags (VITE_SUBSCRIPTION_ENABLED, VITE_PAID_PLANS_ENABLED)
+# have NO placeholders on purpose: feature flags can't ride the sed mechanism
+# (Rollup prunes every `if (FLAG)` against a baked literal at build time).
+# They are runtime-provided via window.__SPHERE_RUNTIME_CONFIG__ instead — the
 # runtime-config hook writes /runtime-config.js from the container env
-# (SUBSCRIPTION_ENABLED, PAID_PLANS_ENABLED, SUBSCRIPTION_API_URL).
+# (SUBSCRIPTION_ENABLED, PAID_PLANS_ENABLED). The SGW base URL needs no config
+# at all: it is derived from the SDK's per-network aggregator gateway
+# (src/config/subscription.ts).
 # BASE_PATH is a true build-time concern (Vite rewrites asset URLs + router
 # basename); both AWS envs serve at root, so it stays baked as `/`.
 ARG BASE_PATH=/
@@ -40,13 +42,10 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # fail-closed check in this script keeps a misconfigured task def from serving.
 COPY deploy/runtime-config.sh /docker-entrypoint.d/40-sphere-runtime-config.sh
 RUN chmod +x /docker-entrypoint.d/40-sphere-runtime-config.sh
-# The `include ...sphere-sgw-location*.conf` below is the same-origin /sgw
-# route to the subscription gateway, generated at container start from
-# $SGW_UPSTREAM by the runtime-config hook. Glob include: no file
-# (SGW_UPSTREAM unset) = no route, not a startup error. NOTE: this echo
-# collapses to a SINGLE line of nginx config (Dockerfile line continuations),
-# so never put an nginx `#` comment inside it — it would comment out the rest.
-RUN mkdir -p /etc/nginx/snippets && echo 'server { \
+# NOTE: this echo collapses to a SINGLE line of nginx config (Dockerfile line
+# continuations), so never put an nginx `#` comment inside it — it would
+# comment out the rest of the config.
+RUN echo 'server { \
     listen 80; \
     server_name _; \
     root /usr/share/nginx/html; \
@@ -60,7 +59,6 @@ RUN mkdir -p /etc/nginx/snippets && echo 'server { \
         expires 1y; \
         add_header Cache-Control "public, immutable"; \
     } \
-    include /etc/nginx/snippets/sphere-sgw-location*.conf; \
     location / { \
         try_files $uri $uri/ /index.html; \
         add_header Cache-Control "no-cache, no-store, must-revalidate"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ ARG VITE_WALLET_API_URL=__RUNTIME_WALLET_API_URL__
 ARG VITE_REQUIRE_WALLET_API=__RUNTIME_REQUIRE_WALLET_API__
 ARG VITE_AGGREGATOR_API_KEY=__RUNTIME_AGGREGATOR_API_KEY__
 ARG VITE_DEV_PORTAL_URL=__RUNTIME_DEV_PORTAL_URL__
+# Subscription vars (VITE_SUBSCRIPTION_*, VITE_PAID_PLANS_ENABLED) have NO
+# placeholders on purpose: feature flags can't ride the sed mechanism (Rollup
+# prunes every `if (FLAG)` against a baked literal at build time). They are
+# runtime-provided via window.__SPHERE_RUNTIME_CONFIG__ instead — the
+# runtime-config hook writes /runtime-config.js from the container env
+# (SUBSCRIPTION_ENABLED, PAID_PLANS_ENABLED, SUBSCRIPTION_API_URL).
 # BASE_PATH is a true build-time concern (Vite rewrites asset URLs + router
 # basename); both AWS envs serve at root, so it stays baked as `/`.
 ARG BASE_PATH=/
@@ -34,7 +40,13 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # fail-closed check in this script keeps a misconfigured task def from serving.
 COPY deploy/runtime-config.sh /docker-entrypoint.d/40-sphere-runtime-config.sh
 RUN chmod +x /docker-entrypoint.d/40-sphere-runtime-config.sh
-RUN echo 'server { \
+# The `include ...sphere-sgw-location*.conf` below is the same-origin /sgw
+# route to the subscription gateway, generated at container start from
+# $SGW_UPSTREAM by the runtime-config hook. Glob include: no file
+# (SGW_UPSTREAM unset) = no route, not a startup error. NOTE: this echo
+# collapses to a SINGLE line of nginx config (Dockerfile line continuations),
+# so never put an nginx `#` comment inside it — it would comment out the rest.
+RUN mkdir -p /etc/nginx/snippets && echo 'server { \
     listen 80; \
     server_name _; \
     root /usr/share/nginx/html; \
@@ -48,6 +60,7 @@ RUN echo 'server { \
         expires 1y; \
         add_header Cache-Control "public, immutable"; \
     } \
+    include /etc/nginx/snippets/sphere-sgw-location*.conf; \
     location / { \
         try_files $uri $uri/ /index.html; \
         add_header Cache-Control "no-cache, no-store, must-revalidate"; \

--- a/Dockerfile.ssl
+++ b/Dockerfile.ssl
@@ -19,6 +19,9 @@ ARG VITE_WALLET_API_URL=__RUNTIME_WALLET_API_URL__
 ARG VITE_REQUIRE_WALLET_API=__RUNTIME_REQUIRE_WALLET_API__
 ARG VITE_AGGREGATOR_API_KEY=__RUNTIME_AGGREGATOR_API_KEY__
 ARG VITE_DEV_PORTAL_URL=__RUNTIME_DEV_PORTAL_URL__
+# Subscription vars have NO placeholders on purpose — they are runtime-provided
+# via window.__SPHERE_RUNTIME_CONFIG__ (/runtime-config.js, written at container
+# start by sphere-runtime-config). See the note in the main Dockerfile.
 ARG BASE_PATH=/
 ENV VITE_SPHERE_API_URL=$VITE_SPHERE_API_URL \
     VITE_WALLET_API_URL=$VITE_WALLET_API_URL \

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -140,6 +140,10 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Cache-Control "public, immutable";
     }
+    # Same-origin /sgw route to the subscription gateway; the snippet is
+    # generated (or removed) from \$SGW_UPSTREAM by sphere-runtime-config,
+    # which runs below, before nginx starts. Glob include: no file = no route.
+    include /etc/nginx/snippets/sphere-sgw-location*.conf;
     location / {
         try_files \$uri \$uri/ /index.html;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
@@ -161,6 +165,14 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
+    # Same-origin /sgw route (see the SSL server block above for details).
+    include /etc/nginx/snippets/sphere-sgw-location*.conf;
+    # runtime-config.js carries per-environment flags rewritten at container
+    # start; heuristic caching would pin stale flag values across env flips
+    # (the other server blocks get this via their no-cache location /).
+    location = /runtime-config.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
     location / {
         try_files \$uri \$uri/ /index.html;
     }

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -140,10 +140,6 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Cache-Control "public, immutable";
     }
-    # Same-origin /sgw route to the subscription gateway; the snippet is
-    # generated (or removed) from \$SGW_UPSTREAM by sphere-runtime-config,
-    # which runs below, before nginx starts. Glob include: no file = no route.
-    include /etc/nginx/snippets/sphere-sgw-location*.conf;
     location / {
         try_files \$uri \$uri/ /index.html;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
@@ -165,8 +161,6 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-    # Same-origin /sgw route (see the SSL server block above for details).
-    include /etc/nginx/snippets/sphere-sgw-location*.conf;
     # runtime-config.js carries per-environment flags rewritten at container
     # start; heuristic caching would pin stale flag values across env flips
     # (the other server blocks get this via their no-cache location /).

--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
-# Per-environment public config at container start — three jobs:
+# Per-environment public config at container start — two jobs:
 #   1. sed the baked __RUNTIME_*__ placeholders in the built JS (string values);
 #   2. write /runtime-config.js (window.__SPHERE_RUNTIME_CONFIG__) for values
-#      that must gate feature branches at runtime (subscriptions);
-#   3. generate the nginx /sgw reverse-proxy snippet from SGW_UPSTREAM.
+#      that must gate feature branches at runtime (the subscription flags).
 #
 # Why this exists: Vite *inlines* `import.meta.env.VITE_*` into the static
 # bundle at `vite build`, so a normal build is environment-locked — a runtime
@@ -27,14 +26,13 @@
 #   SUBSCRIPTION_ENABLED   per-wallet SGW subscription keys — the app checks
 #                          for EXACTLY 'true'; anything else leaves it off
 #   PAID_PLANS_ENABLED     paid-plan purchases (EXACTLY 'true'; testnet: off)
-#   SUBSCRIPTION_API_URL   SGW base as the BROWSER sees it (default /sgw,
-#                          which rides the same-origin proxy below)
-#   SGW_UPSTREAM           subscription-gateway origin the nginx /sgw
-#                          reverse proxy forwards to (plain http(s) URL);
-#                          unset = no /sgw route is generated
 #
-# (VITE_SUBSCRIPTION_MOCK is intentionally NOT part of this contract — mock
-# mode is dev-only and stays a build-time constant; see src/config/subscription.ts.)
+# The SGW base URL is NOT part of this contract: the SGW is the aggregator
+# gateway, so the app derives it from the SDK's per-network config (see
+# src/config/subscription.ts) — all SGW endpoints serve CORS for direct
+# browser calls (unicitynetwork/aggregator-subscription#57).
+# (VITE_SUBSCRIPTION_MOCK is intentionally NOT part of this contract either —
+# mock mode is dev-only and stays a build-time constant.)
 #
 # Runs as a stock-nginx `/docker-entrypoint.d/` hook (POSIX sh, BusyBox-safe)
 # and is also invoked from deploy/entrypoint.sh in the SSL image.
@@ -68,7 +66,7 @@ if [ -z "${WALLET_API_URL-}" ]; then
   log "         local-custody bundle; the app would target its own origin as wallet-api."
 fi
 
-# ── Fail-closed (subscriptions) ──────────────────────────────────────────────
+# ── Subscription flag sanity ─────────────────────────────────────────────────
 # The app enables these flags only on EXACTLY 'true' (src/config/subscription.ts),
 # so catch near-miss spellings ('TRUE', '1', 'yes') an operator would expect
 # to work — for BOTH flags; PAID_PLANS_ENABLED's flip is the one-shot mainnet
@@ -80,22 +78,6 @@ for flag in SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
     *) log "WARNING: $flag='$fv' does NOT enable it — the app checks for exactly 'true'" ;;
   esac
 done
-if [ "${SUBSCRIPTION_ENABLED-}" = true ]; then sub_enabled=1; else sub_enabled=0; fi
-# A relative SUBSCRIPTION_API_URL (the default /sgw) resolves against the app's
-# own origin, so it only works if this container also serves the reverse proxy
-# below. Enabling subscriptions without that route would make every SGW call
-# hit the SPA fallback and get index.html instead of JSON — refuse to start so
-# the misconfiguration surfaces in the orchestrator, not as broken onboarding.
-sub_api_url="${SUBSCRIPTION_API_URL:-/sgw}"
-case "$sub_api_url" in
-  /*) if [ "$sub_enabled" = 1 ] && [ -z "${SGW_UPSTREAM-}" ]; then
-        log "ERROR: SUBSCRIPTION_ENABLED=true with a relative SUBSCRIPTION_API_URL ('$sub_api_url')"
-        log "       but SGW_UPSTREAM is empty — there is no route from '$sub_api_url' to an SGW."
-        log "       Set SGW_UPSTREAM to the subscription-gateway origin (or an absolute"
-        log "       SUBSCRIPTION_API_URL, which only works for the CORS-enabled endpoints)."
-        exit 1
-      fi ;;
-esac
 
 # ── Build the substitution program ───────────────────────────────────────────
 # Escape the replacement for a sed `s|...|...|` command: backslash, the `|`
@@ -113,7 +95,7 @@ add __RUNTIME_DEV_PORTAL_URL__     "${DEV_PORTAL_URL-}"
 add __RUNTIME_AGGREGATOR_API_KEY__ "${AGGREGATOR_API_KEY-}"
 
 # ── Runtime config global (window.__SPHERE_RUNTIME_CONFIG__) ────────────────
-# The subscription values do NOT ride the sed mechanism above: Rollup
+# The subscription flags do NOT ride the sed mechanism above: Rollup
 # statically evaluates branch conditions against baked literals at build time
 # and prunes every `if (FLAG)` in the app, so a substituted placeholder can
 # never turn a feature ON (see src/config/subscription.ts). Instead they are
@@ -127,7 +109,7 @@ add __RUNTIME_AGGREGATOR_API_KEY__ "${AGGREGATOR_API_KEY-}"
 nl='
 '
 cr=$(printf '\r')
-for v in SUBSCRIPTION_API_URL SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
+for v in SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
   eval "val=\${$v-}"
   case "$val" in
     *"$nl"* | *"$cr"*)
@@ -136,14 +118,10 @@ for v in SUBSCRIPTION_API_URL SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
   esac
 done
 json_escape() { printf '%s' "$1" | sed -e 's/[\\"]/\\&/g'; }
-# The RAW env values go in (no /sgw default here): empty means "not set on the
-# container", and the app resolves empty -> build-time VITE_* -> '/sgw', so a
-# value pinned at image build time stays honored.
 cat > "$WEBROOT/runtime-config.js" <<EOF
 // Generated at container start by sphere-runtime-config — do not edit.
 // Empty values fall back to the build-time VITE_* env (src/config/subscription.ts).
 window.__SPHERE_RUNTIME_CONFIG__ = {
-  "SUBSCRIPTION_API_URL": "$(json_escape "${SUBSCRIPTION_API_URL-}")",
   "SUBSCRIPTION_ENABLED": "$(json_escape "${SUBSCRIPTION_ENABLED-}")",
   "PAID_PLANS_ENABLED": "$(json_escape "${PAID_PLANS_ENABLED-}")"
 };
@@ -156,90 +134,6 @@ for v in SPHERE_API_URL DEV_PORTAL_URL AGGREGATOR_API_KEY; do
   eval "val=\${$v-}"
   [ -z "$val" ] && log "WARNING: \$$v is unset; substituting empty string"
 done
-
-# ── nginx /sgw reverse proxy (same-origin SGW route) ─────────────────────────
-# The SGW store endpoints send no CORS headers, so the browser reaches the SGW
-# through a same-origin /sgw route on this container — the production mirror of
-# the vite dev proxy (`/sgw/<path>` -> `${SGW_UPSTREAM}/<path>`, prefix
-# stripped). The server configs (Dockerfile + deploy/entrypoint.sh) include
-# this snippet by GLOB (`sphere-sgw-location*.conf`) so a missing file means
-# "no route", not an nginx startup error. Regenerated on every container start.
-SGW_SNIPPET_DIR="${SPHERE_SGW_SNIPPET_DIR:-/etc/nginx/snippets}"
-SGW_SNIPPET="$SGW_SNIPPET_DIR/sphere-sgw-location.conf"
-if [ -n "${SGW_UPSTREAM-}" ]; then
-  # The value is interpolated into nginx config, so validate hard: an http(s)
-  # ORIGIN only — scheme://host[:port], conservative charset, no path (the
-  # variable proxy_pass below would silently ignore one), nothing that could
-  # terminate the directive and inject config. grep is line-based, so reject
-  # embedded newlines first (a payload after a newline would otherwise be
-  # invisible to the pattern match).
-  if [ "$(printf '%s' "$SGW_UPSTREAM" | wc -l)" -ne 0 ]; then
-    log "ERROR: SGW_UPSTREAM contains a newline — refusing to write nginx config."
-    exit 1
-  fi
-  sgw_upstream="${SGW_UPSTREAM%/}"
-  if ! printf '%s\n' "$sgw_upstream" | grep -Eq '^https?://[A-Za-z0-9._-]+(:[0-9]+)?$'; then
-    log "ERROR: SGW_UPSTREAM must be an http(s) ORIGIN — scheme://host[:port], no path,"
-    log "       host charset [A-Za-z0-9._-] — got: '$SGW_UPSTREAM'"
-    exit 1
-  fi
-  # Request-time DNS: a literal proxy_pass hostname is resolved ONCE at nginx
-  # startup and is FATAL if unresolvable — that would crash-loop the whole
-  # wallet app on a DNS blip, and rotated upstream IPs (the gateway publishes
-  # short-TTL records) would go stale for the container's lifetime. Putting
-  # the upstream in a variable defers resolution to request time, which needs
-  # an explicit resolver: use the container's own nameservers (VPC DNS on
-  # ECS, embedded DNS under docker) from resolv.conf. IPv6 entries get
-  # bracketed; scoped (%iface) entries are skipped.
-  resolvers=$(awk '/^nameserver/ { ns=$2; if (ns ~ /%/) next; if (ns ~ /:/) ns="["ns"]"; r = r ns " " } END { printf "%s", r }' /etc/resolv.conf 2>/dev/null || true)
-  mkdir -p "$SGW_SNIPPET_DIR"
-  if [ -n "$resolvers" ]; then
-    cat > "$SGW_SNIPPET" <<EOF
-# Generated at container start by sphere-runtime-config from \$SGW_UPSTREAM.
-# Same-origin route to the subscription gateway, mirroring the vite dev proxy:
-# /sgw/<path> -> ${sgw_upstream}/<path> (the /sgw prefix is stripped).
-# The upstream rides a VARIABLE so nginx resolves it per request (short TTL)
-# instead of once-at-startup (which is fatal when unresolvable); the rewrite
-# does the prefix strip that a literal proxy_pass URI would have done.
-location /sgw/ {
-    resolver ${resolvers}valid=30s;
-    resolver_timeout 5s;
-    set \$sphere_sgw_upstream ${sgw_upstream};
-    rewrite ^/sgw(/.*)\$ \$1 break;
-    proxy_pass \$sphere_sgw_upstream;
-    proxy_http_version 1.1;
-    # SNI + Host for TLS upstreams behind name-based routing (ALB/CloudFront).
-    proxy_ssl_server_name on;
-    proxy_set_header X-Forwarded-Proto \$scheme;
-    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-}
-EOF
-  else
-    # No usable nameserver found (unusual). Fall back to a literal proxy_pass:
-    # resolution happens once at nginx startup, and an unresolvable host is
-    # fatal there — degraded but functional; the log line calls it out.
-    log "WARNING: no nameserver found in /etc/resolv.conf — /sgw upstream will be"
-    log "         resolved once at nginx startup (fatal if unresolvable, never re-resolved)."
-    cat > "$SGW_SNIPPET" <<EOF
-# Generated at container start by sphere-runtime-config from \$SGW_UPSTREAM.
-# Same-origin route to the subscription gateway (startup-time DNS fallback —
-# no nameserver was found in resolv.conf for request-time resolution).
-location /sgw/ {
-    proxy_pass ${sgw_upstream}/;
-    proxy_http_version 1.1;
-    proxy_ssl_server_name on;
-    proxy_set_header X-Forwarded-Proto \$scheme;
-    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
-}
-EOF
-  fi
-  log "wrote $SGW_SNIPPET (/sgw -> $sgw_upstream)"
-else
-  # Stale-route guard: an earlier start of this container may have written the
-  # snippet; SGW_UPSTREAM now unset must mean NO /sgw route.
-  rm -f "$SGW_SNIPPET"
-  log "SGW_UPSTREAM unset; no /sgw reverse proxy configured"
-fi
 
 # ── Apply over the built JS (one sed program, all files) ─────────────────────
 # `-exec ... \;` (not `+`) for portability across BusyBox (alpine image) and

--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
-# Substitute per-environment public config into the already-built JS bundle.
+# Per-environment public config at container start — three jobs:
+#   1. sed the baked __RUNTIME_*__ placeholders in the built JS (string values);
+#   2. write /runtime-config.js (window.__SPHERE_RUNTIME_CONFIG__) for values
+#      that must gate feature branches at runtime (subscriptions);
+#   3. generate the nginx /sgw reverse-proxy snippet from SGW_UPSTREAM.
 #
 # Why this exists: Vite *inlines* `import.meta.env.VITE_*` into the static
 # bundle at `vite build`, so a normal build is environment-locked — a runtime
@@ -15,11 +19,22 @@
 # changing any of these values.
 #
 # Runtime contract — set these on the ECS task definition / `docker -e`:
-#   SPHERE_API_URL       quest-api base (marketplace / user / maintenance)
-#   WALLET_API_URL       wallet-api backend base (S4 asset custody)
-#   REQUIRE_WALLET_API   #351 fail-closed custody flag ('' / false / 0 = off)
-#   DEV_PORTAL_URL       developer-portal link target
-#   AGGREGATOR_API_KEY   aggregator API key (non-secret on testnet2)
+#   SPHERE_API_URL         quest-api base (marketplace / user / maintenance)
+#   WALLET_API_URL         wallet-api backend base (S4 asset custody)
+#   REQUIRE_WALLET_API     #351 fail-closed custody flag ('' / false / 0 = off)
+#   DEV_PORTAL_URL         developer-portal link target
+#   AGGREGATOR_API_KEY     aggregator API key (non-secret on testnet2)
+#   SUBSCRIPTION_ENABLED   per-wallet SGW subscription keys — the app checks
+#                          for EXACTLY 'true'; anything else leaves it off
+#   PAID_PLANS_ENABLED     paid-plan purchases (EXACTLY 'true'; testnet: off)
+#   SUBSCRIPTION_API_URL   SGW base as the BROWSER sees it (default /sgw,
+#                          which rides the same-origin proxy below)
+#   SGW_UPSTREAM           subscription-gateway origin the nginx /sgw
+#                          reverse proxy forwards to (plain http(s) URL);
+#                          unset = no /sgw route is generated
+#
+# (VITE_SUBSCRIPTION_MOCK is intentionally NOT part of this contract — mock
+# mode is dev-only and stays a build-time constant; see src/config/subscription.ts.)
 #
 # Runs as a stock-nginx `/docker-entrypoint.d/` hook (POSIX sh, BusyBox-safe)
 # and is also invoked from deploy/entrypoint.sh in the SSL image.
@@ -43,6 +58,44 @@ if [ "$require_wallet_api" = 1 ] && [ -z "${WALLET_API_URL-}" ]; then
   log "       refusing to start (would silently change the custody model, #351)."
   exit 1
 fi
+# Even without REQUIRE_WALLET_API, an empty WALLET_API_URL is broken in the
+# Docker bundle: the compiled getWalletApiBaseUrl() cannot fall back to the
+# legacy local-custody composition (its unset-branch is compile-time
+# eliminated against the placeholder — see src/config/walletApi.ts) and would
+# compose wallet-api against the app's own origin. Warn loudly.
+if [ -z "${WALLET_API_URL-}" ]; then
+  log "WARNING: WALLET_API_URL is empty — this image cannot compose the legacy"
+  log "         local-custody bundle; the app would target its own origin as wallet-api."
+fi
+
+# ── Fail-closed (subscriptions) ──────────────────────────────────────────────
+# The app enables these flags only on EXACTLY 'true' (src/config/subscription.ts),
+# so catch near-miss spellings ('TRUE', '1', 'yes') an operator would expect
+# to work — for BOTH flags; PAID_PLANS_ENABLED's flip is the one-shot mainnet
+# switch where a silent no-op costs the most.
+for flag in SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
+  eval "fv=\${$flag-}"
+  case "$fv" in
+    '' | true | false | 0) ;;
+    *) log "WARNING: $flag='$fv' does NOT enable it — the app checks for exactly 'true'" ;;
+  esac
+done
+if [ "${SUBSCRIPTION_ENABLED-}" = true ]; then sub_enabled=1; else sub_enabled=0; fi
+# A relative SUBSCRIPTION_API_URL (the default /sgw) resolves against the app's
+# own origin, so it only works if this container also serves the reverse proxy
+# below. Enabling subscriptions without that route would make every SGW call
+# hit the SPA fallback and get index.html instead of JSON — refuse to start so
+# the misconfiguration surfaces in the orchestrator, not as broken onboarding.
+sub_api_url="${SUBSCRIPTION_API_URL:-/sgw}"
+case "$sub_api_url" in
+  /*) if [ "$sub_enabled" = 1 ] && [ -z "${SGW_UPSTREAM-}" ]; then
+        log "ERROR: SUBSCRIPTION_ENABLED=true with a relative SUBSCRIPTION_API_URL ('$sub_api_url')"
+        log "       but SGW_UPSTREAM is empty — there is no route from '$sub_api_url' to an SGW."
+        log "       Set SGW_UPSTREAM to the subscription-gateway origin (or an absolute"
+        log "       SUBSCRIPTION_API_URL, which only works for the CORS-enabled endpoints)."
+        exit 1
+      fi ;;
+esac
 
 # ── Build the substitution program ───────────────────────────────────────────
 # Escape the replacement for a sed `s|...|...|` command: backslash, the `|`
@@ -59,12 +112,134 @@ add __RUNTIME_REQUIRE_WALLET_API__ "${REQUIRE_WALLET_API-}"
 add __RUNTIME_DEV_PORTAL_URL__     "${DEV_PORTAL_URL-}"
 add __RUNTIME_AGGREGATOR_API_KEY__ "${AGGREGATOR_API_KEY-}"
 
+# ── Runtime config global (window.__SPHERE_RUNTIME_CONFIG__) ────────────────
+# The subscription values do NOT ride the sed mechanism above: Rollup
+# statically evaluates branch conditions against baked literals at build time
+# and prunes every `if (FLAG)` in the app, so a substituted placeholder can
+# never turn a feature ON (see src/config/subscription.ts). Instead they are
+# served as a tiny classic script the app loads before the bundle
+# (src/index.html), rewritten here from the container env on every start.
+# Empty values fall back to the build-time VITE_* env inside the app.
+# LF *and* CR are rejected: both are JS LineTerminators, and a raw one inside
+# the generated string literal would SyntaxError the whole file — the global
+# would never be assigned and every value here would silently fall back (a
+# trailing \r from a CRLF .env paste is exactly how that happens).
+nl='
+'
+cr=$(printf '\r')
+for v in SUBSCRIPTION_API_URL SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
+  eval "val=\${$v-}"
+  case "$val" in
+    *"$nl"* | *"$cr"*)
+      log "ERROR: \$$v contains a line break (CR or LF) — refusing to write runtime-config.js."
+      exit 1 ;;
+  esac
+done
+json_escape() { printf '%s' "$1" | sed -e 's/[\\"]/\\&/g'; }
+# The RAW env values go in (no /sgw default here): empty means "not set on the
+# container", and the app resolves empty -> build-time VITE_* -> '/sgw', so a
+# value pinned at image build time stays honored.
+cat > "$WEBROOT/runtime-config.js" <<EOF
+// Generated at container start by sphere-runtime-config — do not edit.
+// Empty values fall back to the build-time VITE_* env (src/config/subscription.ts).
+window.__SPHERE_RUNTIME_CONFIG__ = {
+  "SUBSCRIPTION_API_URL": "$(json_escape "${SUBSCRIPTION_API_URL-}")",
+  "SUBSCRIPTION_ENABLED": "$(json_escape "${SUBSCRIPTION_ENABLED-}")",
+  "PAID_PLANS_ENABLED": "$(json_escape "${PAID_PLANS_ENABLED-}")"
+};
+EOF
+log "wrote $WEBROOT/runtime-config.js"
+
 # Visibility: warn (don't fail) when a public var is unset — it substitutes to
 # an empty string, which is almost always an operator mistake worth seeing.
 for v in SPHERE_API_URL DEV_PORTAL_URL AGGREGATOR_API_KEY; do
   eval "val=\${$v-}"
   [ -z "$val" ] && log "WARNING: \$$v is unset; substituting empty string"
 done
+
+# ── nginx /sgw reverse proxy (same-origin SGW route) ─────────────────────────
+# The SGW store endpoints send no CORS headers, so the browser reaches the SGW
+# through a same-origin /sgw route on this container — the production mirror of
+# the vite dev proxy (`/sgw/<path>` -> `${SGW_UPSTREAM}/<path>`, prefix
+# stripped). The server configs (Dockerfile + deploy/entrypoint.sh) include
+# this snippet by GLOB (`sphere-sgw-location*.conf`) so a missing file means
+# "no route", not an nginx startup error. Regenerated on every container start.
+SGW_SNIPPET_DIR="${SPHERE_SGW_SNIPPET_DIR:-/etc/nginx/snippets}"
+SGW_SNIPPET="$SGW_SNIPPET_DIR/sphere-sgw-location.conf"
+if [ -n "${SGW_UPSTREAM-}" ]; then
+  # The value is interpolated into nginx config, so validate hard: an http(s)
+  # ORIGIN only — scheme://host[:port], conservative charset, no path (the
+  # variable proxy_pass below would silently ignore one), nothing that could
+  # terminate the directive and inject config. grep is line-based, so reject
+  # embedded newlines first (a payload after a newline would otherwise be
+  # invisible to the pattern match).
+  if [ "$(printf '%s' "$SGW_UPSTREAM" | wc -l)" -ne 0 ]; then
+    log "ERROR: SGW_UPSTREAM contains a newline — refusing to write nginx config."
+    exit 1
+  fi
+  sgw_upstream="${SGW_UPSTREAM%/}"
+  if ! printf '%s\n' "$sgw_upstream" | grep -Eq '^https?://[A-Za-z0-9._-]+(:[0-9]+)?$'; then
+    log "ERROR: SGW_UPSTREAM must be an http(s) ORIGIN — scheme://host[:port], no path,"
+    log "       host charset [A-Za-z0-9._-] — got: '$SGW_UPSTREAM'"
+    exit 1
+  fi
+  # Request-time DNS: a literal proxy_pass hostname is resolved ONCE at nginx
+  # startup and is FATAL if unresolvable — that would crash-loop the whole
+  # wallet app on a DNS blip, and rotated upstream IPs (the gateway publishes
+  # short-TTL records) would go stale for the container's lifetime. Putting
+  # the upstream in a variable defers resolution to request time, which needs
+  # an explicit resolver: use the container's own nameservers (VPC DNS on
+  # ECS, embedded DNS under docker) from resolv.conf. IPv6 entries get
+  # bracketed; scoped (%iface) entries are skipped.
+  resolvers=$(awk '/^nameserver/ { ns=$2; if (ns ~ /%/) next; if (ns ~ /:/) ns="["ns"]"; r = r ns " " } END { printf "%s", r }' /etc/resolv.conf 2>/dev/null || true)
+  mkdir -p "$SGW_SNIPPET_DIR"
+  if [ -n "$resolvers" ]; then
+    cat > "$SGW_SNIPPET" <<EOF
+# Generated at container start by sphere-runtime-config from \$SGW_UPSTREAM.
+# Same-origin route to the subscription gateway, mirroring the vite dev proxy:
+# /sgw/<path> -> ${sgw_upstream}/<path> (the /sgw prefix is stripped).
+# The upstream rides a VARIABLE so nginx resolves it per request (short TTL)
+# instead of once-at-startup (which is fatal when unresolvable); the rewrite
+# does the prefix strip that a literal proxy_pass URI would have done.
+location /sgw/ {
+    resolver ${resolvers}valid=30s;
+    resolver_timeout 5s;
+    set \$sphere_sgw_upstream ${sgw_upstream};
+    rewrite ^/sgw(/.*)\$ \$1 break;
+    proxy_pass \$sphere_sgw_upstream;
+    proxy_http_version 1.1;
+    # SNI + Host for TLS upstreams behind name-based routing (ALB/CloudFront).
+    proxy_ssl_server_name on;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+}
+EOF
+  else
+    # No usable nameserver found (unusual). Fall back to a literal proxy_pass:
+    # resolution happens once at nginx startup, and an unresolvable host is
+    # fatal there — degraded but functional; the log line calls it out.
+    log "WARNING: no nameserver found in /etc/resolv.conf — /sgw upstream will be"
+    log "         resolved once at nginx startup (fatal if unresolvable, never re-resolved)."
+    cat > "$SGW_SNIPPET" <<EOF
+# Generated at container start by sphere-runtime-config from \$SGW_UPSTREAM.
+# Same-origin route to the subscription gateway (startup-time DNS fallback —
+# no nameserver was found in resolv.conf for request-time resolution).
+location /sgw/ {
+    proxy_pass ${sgw_upstream}/;
+    proxy_http_version 1.1;
+    proxy_ssl_server_name on;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+}
+EOF
+  fi
+  log "wrote $SGW_SNIPPET (/sgw -> $sgw_upstream)"
+else
+  # Stale-route guard: an earlier start of this container may have written the
+  # snippet; SGW_UPSTREAM now unset must mean NO /sgw route.
+  rm -f "$SGW_SNIPPET"
+  log "SGW_UPSTREAM unset; no /sgw reverse proxy configured"
+fi
 
 # ── Apply over the built JS (one sed program, all files) ─────────────────────
 # `-exec ... \;` (not `+`) for portability across BusyBox (alpine image) and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,9 @@ services:
       REQUIRE_WALLET_API: "true"
       DEV_PORTAL_URL: https://developers.staging.unicity.network/
       AGGREGATOR_API_KEY: sk_ddc3cfcc001e4a28ac3fad7407f99590
-      # Subscriptions (SGW) ship dormant. To turn on: SUBSCRIPTION_ENABLED to
-      # exactly "true" AND SGW_UPSTREAM to the subscription-gateway origin
-      # (generates the same-origin /sgw nginx route the browser needs — the
-      # SGW store endpoints send no CORS). The container refuses to start on
-      # SUBSCRIPTION_ENABLED=true without a route to an SGW.
+      # Subscriptions (SGW) ship dormant; set exactly "true" to turn on.
+      # The SGW base URL needs no config — the app derives it from the SDK's
+      # per-network aggregator gateway and calls it directly (CORS-enabled;
+      # unicitynetwork/aggregator-subscription#57).
       SUBSCRIPTION_ENABLED: "false"
       PAID_PLANS_ENABLED: "false"
-      # The SGW fronts the aggregator, so its origin is the aggregator gateway:
-      # SGW_UPSTREAM: https://gateway.testnet2.unicity.network
-      # SUBSCRIPTION_API_URL: /sgw   # browser-side base; default /sgw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,13 @@ services:
       REQUIRE_WALLET_API: "true"
       DEV_PORTAL_URL: https://developers.staging.unicity.network/
       AGGREGATOR_API_KEY: sk_ddc3cfcc001e4a28ac3fad7407f99590
+      # Subscriptions (SGW) ship dormant. To turn on: SUBSCRIPTION_ENABLED to
+      # exactly "true" AND SGW_UPSTREAM to the subscription-gateway origin
+      # (generates the same-origin /sgw nginx route the browser needs — the
+      # SGW store endpoints send no CORS). The container refuses to start on
+      # SUBSCRIPTION_ENABLED=true without a route to an SGW.
+      SUBSCRIPTION_ENABLED: "false"
+      PAID_PLANS_ENABLED: "false"
+      # The SGW fronts the aggregator, so its origin is the aggregator gateway:
+      # SGW_UPSTREAM: https://gateway.testnet2.unicity.network
+      # SUBSCRIPTION_API_URL: /sgw   # browser-side base; default /sgw

--- a/public/runtime-config.js
+++ b/public/runtime-config.js
@@ -1,0 +1,8 @@
+// Default runtime config for dev / GitHub Pages builds: empty, so values
+// fall back to the VITE_* env baked at build time (src/config/subscription.ts).
+// In the Docker image this file is OVERWRITTEN at container start by
+// deploy/runtime-config.sh from the container env — that's what makes the
+// build-once image's feature flags swappable per environment. Loaded as a
+// classic script BEFORE the app bundle (src/index.html), so the values are
+// visible at module-init time.
+window.__SPHERE_RUNTIME_CONFIG__ = {};

--- a/src/config/network.ts
+++ b/src/config/network.ts
@@ -1,0 +1,10 @@
+import type { NetworkType } from '@unicitylabs/sphere-sdk';
+
+/**
+ * The Unicity network this build targets. Single source of truth — used by
+ * SphereProvider (main.tsx) and for deriving per-network service URLs
+ * (src/config/subscription.ts). The network is a BUILD-time decision: the SDK
+ * bakes per-network URLs, relays and registries from its NETWORKS table, so a
+ * mainnet deployment is a different build, not a runtime flip.
+ */
+export const SPHERE_NETWORK: NetworkType = 'testnet2';

--- a/src/config/subscription.ts
+++ b/src/config/subscription.ts
@@ -1,32 +1,37 @@
+import { NETWORKS } from '@unicitylabs/sphere-sdk';
+import { SPHERE_NETWORK } from './network';
+
 /**
- * Subscription gateway (SGW) config. Env-driven so each environment points at
- * its own SGW host. When SUBSCRIPTION_ENABLED is false the app keeps using the
- * static VITE_AGGREGATOR_API_KEY and no subscription calls are made.
+ * Subscription gateway (SGW) config. When SUBSCRIPTION_ENABLED is false the
+ * app keeps using the static VITE_AGGREGATOR_API_KEY and no subscription
+ * calls are made.
  *
- * Default is a relative path so the store endpoints (`/api/paymento/*`, which
- * send no CORS headers) ride the same-origin dev/preview proxy (see
- * vite.config.ts `/sgw` entry, target `SGW_PROXY_TARGET`). In the Docker
- * image the same relative path is served by an nginx reverse proxy generated
- * at container start from `SGW_UPSTREAM` (deploy/runtime-config.sh).
+ * The SGW *is* the aggregator gateway (it fronts the aggregator's write
+ * path), so its base URL is derived from the SDK's per-network config — no
+ * env var needed, and it follows the network automatically like every other
+ * backend URL. All SGW endpoints serve CORS for browser calls
+ * (unicitynetwork/aggregator-subscription#57), so the wallet talks to it
+ * directly. VITE_SUBSCRIPTION_API_URL remains as a dev override: the local
+ * SGW compose stack is reached via the same-origin `/sgw` vite proxy
+ * (SGW_PROXY_TARGET, see vite.config.ts).
  *
- * WHY window.__SPHERE_RUNTIME_CONFIG__ and not a `__RUNTIME_*__` sed
- * placeholder: the Docker image is built once and promoted across
- * environments, so these values must be swappable at container start. The
- * sed-placeholder mechanism cannot carry a FEATURE FLAG — Rollup statically
- * evaluates branch conditions during tree-shaking, following const bindings
- * across modules, so every `if (SUBSCRIPTION_ENABLED)` in the app gets pruned
- * against the baked literal (`'__RUNTIME_…__' === 'true'` → false) and the
- * feature is compile-time OFF no matter what the container substitutes (this
- * actually happened; see also the note in src/config/walletApi.ts). Reading
- * from a window global set before the bundle loads (public/runtime-config.js,
- * rewritten at container start by deploy/runtime-config.sh) keeps the value
- * genuinely unknown at build time, so no branch can fold. Dev and GitHub
- * Pages builds ship the default empty config and fall back to the VITE_* env
- * baked at build time.
+ * WHY the flags read window.__SPHERE_RUNTIME_CONFIG__ and not a
+ * `__RUNTIME_*__` sed placeholder: the Docker image is built once and
+ * promoted across environments, so the flags must be swappable at container
+ * start. The sed-placeholder mechanism cannot carry a FEATURE FLAG — Rollup
+ * statically evaluates branch conditions during tree-shaking, following
+ * const bindings across modules, so every `if (SUBSCRIPTION_ENABLED)` in the
+ * app gets pruned against the baked literal (`'__RUNTIME_…__' === 'true'` →
+ * false) and the feature is compile-time OFF no matter what the container
+ * substitutes (this actually happened; see also the note in
+ * src/config/walletApi.ts). Reading from a window global set before the
+ * bundle loads (public/runtime-config.js, rewritten at container start by
+ * deploy/runtime-config.sh) keeps the value genuinely unknown at build time,
+ * so no branch can fold. Dev and GitHub Pages builds ship the default empty
+ * config and fall back to the VITE_* env baked at build time.
  */
 
 interface SphereRuntimeConfig {
-  SUBSCRIPTION_API_URL?: string;
   SUBSCRIPTION_ENABLED?: string;
   PAID_PLANS_ENABLED?: string;
 }
@@ -51,12 +56,9 @@ function setting(
 }
 
 function resolveSubscriptionApiUrl(): string {
-  const value = setting(
-    'SUBSCRIPTION_API_URL',
-    import.meta.env.VITE_SUBSCRIPTION_API_URL as string | undefined,
-  );
-  if (value === undefined || value === '') return '/sgw';
-  return value;
+  const raw = import.meta.env.VITE_SUBSCRIPTION_API_URL as string | undefined;
+  if (raw !== undefined && raw !== '') return raw;
+  return NETWORKS[SPHERE_NETWORK].aggregatorUrl;
 }
 export const SUBSCRIPTION_API_URL = resolveSubscriptionApiUrl();
 

--- a/src/config/subscription.ts
+++ b/src/config/subscription.ts
@@ -5,15 +5,76 @@
  *
  * Default is a relative path so the store endpoints (`/api/paymento/*`, which
  * send no CORS headers) ride the same-origin dev/preview proxy (see
- * vite.config.ts `/sgw` entry, target `SGW_PROXY_TARGET`).
+ * vite.config.ts `/sgw` entry, target `SGW_PROXY_TARGET`). In the Docker
+ * image the same relative path is served by an nginx reverse proxy generated
+ * at container start from `SGW_UPSTREAM` (deploy/runtime-config.sh).
+ *
+ * WHY window.__SPHERE_RUNTIME_CONFIG__ and not a `__RUNTIME_*__` sed
+ * placeholder: the Docker image is built once and promoted across
+ * environments, so these values must be swappable at container start. The
+ * sed-placeholder mechanism cannot carry a FEATURE FLAG — Rollup statically
+ * evaluates branch conditions during tree-shaking, following const bindings
+ * across modules, so every `if (SUBSCRIPTION_ENABLED)` in the app gets pruned
+ * against the baked literal (`'__RUNTIME_…__' === 'true'` → false) and the
+ * feature is compile-time OFF no matter what the container substitutes (this
+ * actually happened; see also the note in src/config/walletApi.ts). Reading
+ * from a window global set before the bundle loads (public/runtime-config.js,
+ * rewritten at container start by deploy/runtime-config.sh) keeps the value
+ * genuinely unknown at build time, so no branch can fold. Dev and GitHub
+ * Pages builds ship the default empty config and fall back to the VITE_* env
+ * baked at build time.
  */
-export const SUBSCRIPTION_API_URL =
-  import.meta.env.VITE_SUBSCRIPTION_API_URL ?? '/sgw';
 
+interface SphereRuntimeConfig {
+  SUBSCRIPTION_API_URL?: string;
+  SUBSCRIPTION_ENABLED?: string;
+  PAID_PLANS_ENABLED?: string;
+}
+
+/**
+ * Runtime value if present and non-empty, else the build-time env value.
+ * Empty string means "not set on the container env" (runtime-config.sh always
+ * writes all keys), so it must not shadow a value baked at build time.
+ */
+function setting(
+  key: keyof SphereRuntimeConfig,
+  envValue: string | undefined,
+): string | undefined {
+  const config =
+    typeof window === 'undefined'
+      ? undefined
+      : (window as { __SPHERE_RUNTIME_CONFIG__?: SphereRuntimeConfig })
+          .__SPHERE_RUNTIME_CONFIG__;
+  const value = config?.[key];
+  if (value === undefined || value === '') return envValue;
+  return value;
+}
+
+function resolveSubscriptionApiUrl(): string {
+  const value = setting(
+    'SUBSCRIPTION_API_URL',
+    import.meta.env.VITE_SUBSCRIPTION_API_URL as string | undefined,
+  );
+  if (value === undefined || value === '') return '/sgw';
+  return value;
+}
+export const SUBSCRIPTION_API_URL = resolveSubscriptionApiUrl();
+
+/** Exactly 'true' enables; anything else (including 'TRUE', '1') is off. */
 export const SUBSCRIPTION_ENABLED =
-  import.meta.env.VITE_SUBSCRIPTION_ENABLED === 'true';
+  setting(
+    'SUBSCRIPTION_ENABLED',
+    import.meta.env.VITE_SUBSCRIPTION_ENABLED as string | undefined,
+  ) === 'true';
 
-/** When true, the SGW client returns canned data instead of hitting the network — lets the UI be built before the backend is live. */
+/**
+ * When true, the SGW client returns canned data instead of hitting the
+ * network — lets the UI be built before the backend is live. Deliberately
+ * NOT runtime-swappable (not part of the runtime config): mock mode is
+ * dev-only, and with the env unset at build time the comparison folds to
+ * `false` so production builds tree-shake the canned data. Never wire this
+ * into the Docker runtime-config mechanism.
+ */
 export const SUBSCRIPTION_MOCK =
   import.meta.env.VITE_SUBSCRIPTION_MOCK === 'true';
 
@@ -23,4 +84,7 @@ export const SUBSCRIPTION_MOCK =
  * plan is usable. Flip to 'true' for mainnet once the store is live.
  */
 export const PAID_PLANS_ENABLED =
-  import.meta.env.VITE_PAID_PLANS_ENABLED === 'true';
+  setting(
+    'PAID_PLANS_ENABLED',
+    import.meta.env.VITE_PAID_PLANS_ENABLED as string | undefined,
+  ) === 'true';

--- a/src/config/walletApi.ts
+++ b/src/config/walletApi.ts
@@ -10,6 +10,27 @@
  * origin, which is how the dev/preview proxy in vite.config.ts is reached —
  * the backend serves no CORS headers, so cross-origin browser calls need the
  * local proxy (production deployments must solve this at the edge).
+ *
+ * Docker runtime substitution — READ BEFORE EDITING: the Docker image bakes
+ * `__RUNTIME_*__` placeholder strings for these env vars and sed-rewrites
+ * them at container start (deploy/runtime-config.sh). Know what survives into
+ * that bundle: Rollup statically evaluates BRANCH conditions against the
+ * baked literals (following const bindings, across modules) and prunes them —
+ * in Docker images the `if (!raw)` branch of getWalletApiBaseUrl(), with the
+ * whole #351 throw and the legacy `return null` fallback, is compile-time
+ * eliminated, and isWalletApiRequired() is tree-shaken with it. The #351 half
+ * is guarded at runtime by the fail-closed check in deploy/runtime-config.sh
+ * (container refuses to start); the legacy half has NO runtime equivalent —
+ * an empty WALLET_API_URL makes the compiled getWalletApiBaseUrl() return the
+ * app's own origin instead of null, so legacy local-custody composition is
+ * unreachable in Docker images and deployments must always set
+ * WALLET_API_URL (runtime-config.sh warns). Expression-position string
+ * comparisons (isWalletApiEnabled's `raw !== ''`) DO survive and stay
+ * runtime-decided — that is what keeps enable/disable working at runtime.
+ * A value that must gate `if` branches at runtime cannot use the placeholder
+ * mechanism at all: use window.__SPHERE_RUNTIME_CONFIG__ instead (see
+ * src/config/subscription.ts). Non-Docker builds (dev, GitHub Pages) bake
+ * real values, so all of this folds correctly per environment there.
  */
 
 /** Engine override for the LOCAL compose stack (smoke tests / local dev). */
@@ -46,6 +67,9 @@ export function isWalletApiRequired(): boolean {
  */
 export function getWalletApiBaseUrl(): string | null {
   const raw = import.meta.env.VITE_WALLET_API_URL as string | undefined;
+  // NOTE: in Docker images this branch is compile-time-eliminated against the
+  // baked placeholder (see file header); deploy/runtime-config.sh enforces
+  // #351 there. This code path is live in dev / GitHub Pages builds.
   if (!raw) {
     if (isWalletApiRequired()) {
       throw new Error(
@@ -67,13 +91,10 @@ export function getWalletApiBaseUrl(): string | null {
  * SphereProvider catches it and surfaces a visible initialization error.
  */
 export function isWalletApiEnabled(): boolean {
-  // Bind to a variable and reference it more than once: a single inline
-  // `!!import.meta.env.VITE_WALLET_API_URL` lets esbuild constant-fold the
-  // build-time value to `true` and strip the literal — which deletes the
-  // __RUNTIME_WALLET_API_URL__ placeholder the Docker image relies on
-  // (deploy/runtime-config.sh substitutes it at container start). Keeping
-  // `raw` as a multiply-referenced variable preserves the literal, exactly
-  // like isWalletApiRequired() above.
+  // The `!!raw` term folds to `true` against the baked placeholder; the
+  // `raw !== ''` term is what survives into the Docker bundle and keeps this
+  // a runtime decision after substitution (see file header). Don't reduce
+  // this to a bare truthiness test.
   const raw = import.meta.env.VITE_WALLET_API_URL as string | undefined;
   return !!raw && raw !== '';
 }

--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,11 @@
         document.documentElement.classList.add(theme);
       })();
     </script>
+    <!-- Runtime-swappable public config for build-once/promote-many Docker
+         images (window.__SPHERE_RUNTIME_CONFIG__). Classic script: executes
+         before the module bundle below. Rewritten at container start by
+         deploy/runtime-config.sh; dev/Pages ship the empty default. -->
+    <script src="/runtime-config.js"></script>
   </head>
   <body style="margin: 0;">
     <div id="root"></div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import { SphereProvider } from './sdk/SphereProvider'
 import { ServicesProvider } from './contexts/ServicesProvider'
 import { ConnectProvider } from './components/connect'
 import { UpgradeProvider } from './components/upgrade'
+import { SPHERE_NETWORK } from './config/network'
 import { ToastContainer } from './components/ui/Toast'
 import { ErrorFallback } from './components/ui/ErrorFallback'
 
@@ -30,7 +31,7 @@ createRoot(document.getElementById('root')!, {
 }).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <SphereProvider network="testnet2">
+      <SphereProvider network={SPHERE_NETWORK}>
         <ServicesProvider>
           {/* UpgradeProvider MUST wrap ConnectProvider: ConnectProvider renders
               ConnectIntentHandler (and its modals, e.g. SendIntentModal →

--- a/tests/unit/config/subscription.test.ts
+++ b/tests/unit/config/subscription.test.ts
@@ -29,20 +29,17 @@ describe('runtime config global (window.__SPHERE_RUNTIME_CONFIG__)', () => {
     vi.resetModules();
   });
 
-  it('runtime values win over build-time env', async () => {
+  it('runtime flag values win over build-time env', async () => {
     vi.stubEnv('VITE_SUBSCRIPTION_ENABLED', 'false');
     vi.stubEnv('VITE_PAID_PLANS_ENABLED', 'false');
-    vi.stubEnv('VITE_SUBSCRIPTION_API_URL', '/env-sgw');
     (window as RuntimeWindow).__SPHERE_RUNTIME_CONFIG__ = {
       SUBSCRIPTION_ENABLED: 'true',
       PAID_PLANS_ENABLED: 'true',
-      SUBSCRIPTION_API_URL: '/runtime-sgw',
     };
     vi.resetModules();
     const cfg = await import('@/config/subscription');
     expect(cfg.SUBSCRIPTION_ENABLED).toBe(true);
     expect(cfg.PAID_PLANS_ENABLED).toBe(true);
-    expect(cfg.SUBSCRIPTION_API_URL).toBe('/runtime-sgw');
   });
 
   it('empty runtime values (unset container env) fall back to build-time env', async () => {
@@ -50,7 +47,6 @@ describe('runtime config global (window.__SPHERE_RUNTIME_CONFIG__)', () => {
     vi.stubEnv('VITE_PAID_PLANS_ENABLED', ''); // pin: ambient env must not leak in
     (window as RuntimeWindow).__SPHERE_RUNTIME_CONFIG__ = {
       SUBSCRIPTION_ENABLED: '',
-      SUBSCRIPTION_API_URL: '',
       PAID_PLANS_ENABLED: '',
     };
     vi.resetModules();
@@ -70,10 +66,18 @@ describe('runtime config global (window.__SPHERE_RUNTIME_CONFIG__)', () => {
     expect(cfg.PAID_PLANS_ENABLED).toBe(false);
   });
 
-  it('defaults SUBSCRIPTION_API_URL to /sgw when nothing is set anywhere', async () => {
+  it('SUBSCRIPTION_API_URL: VITE override wins, else derives from the SDK network table', async () => {
+    vi.stubEnv('VITE_SUBSCRIPTION_API_URL', '/sgw');
+    vi.resetModules();
+    let cfg = await import('@/config/subscription');
+    expect(cfg.SUBSCRIPTION_API_URL).toBe('/sgw');
+
     vi.stubEnv('VITE_SUBSCRIPTION_API_URL', '');
     vi.resetModules();
-    const cfg = await import('@/config/subscription');
-    expect(cfg.SUBSCRIPTION_API_URL).toBe('/sgw');
+    cfg = await import('@/config/subscription');
+    const { NETWORKS } = await import('@unicitylabs/sphere-sdk');
+    const { SPHERE_NETWORK } = await import('@/config/network');
+    expect(cfg.SUBSCRIPTION_API_URL).toBe(NETWORKS[SPHERE_NETWORK].aggregatorUrl);
+    expect(cfg.SUBSCRIPTION_API_URL).toMatch(/^https:\/\//);
   });
 });

--- a/tests/unit/config/subscription.test.ts
+++ b/tests/unit/config/subscription.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { STORAGE_KEYS, getStoredSubscriptionKey, setStoredSubscriptionKey } from '@/config/storageKeys';
 
 describe('subscription storage key', () => {
@@ -12,5 +12,68 @@ describe('subscription storage key', () => {
     expect(getStoredSubscriptionKey()).toBeNull();
     setStoredSubscriptionKey('key_abc123');
     expect(getStoredSubscriptionKey()).toBe('key_abc123');
+  });
+});
+
+// The module reads window.__SPHERE_RUNTIME_CONFIG__ at import time (that's
+// how the Docker image swaps values per environment without a rebuild), so
+// each case resets the module registry and re-imports.
+describe('runtime config global (window.__SPHERE_RUNTIME_CONFIG__)', () => {
+  type RuntimeWindow = typeof window & {
+    __SPHERE_RUNTIME_CONFIG__?: Record<string, string>;
+  };
+
+  afterEach(() => {
+    delete (window as RuntimeWindow).__SPHERE_RUNTIME_CONFIG__;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('runtime values win over build-time env', async () => {
+    vi.stubEnv('VITE_SUBSCRIPTION_ENABLED', 'false');
+    vi.stubEnv('VITE_PAID_PLANS_ENABLED', 'false');
+    vi.stubEnv('VITE_SUBSCRIPTION_API_URL', '/env-sgw');
+    (window as RuntimeWindow).__SPHERE_RUNTIME_CONFIG__ = {
+      SUBSCRIPTION_ENABLED: 'true',
+      PAID_PLANS_ENABLED: 'true',
+      SUBSCRIPTION_API_URL: '/runtime-sgw',
+    };
+    vi.resetModules();
+    const cfg = await import('@/config/subscription');
+    expect(cfg.SUBSCRIPTION_ENABLED).toBe(true);
+    expect(cfg.PAID_PLANS_ENABLED).toBe(true);
+    expect(cfg.SUBSCRIPTION_API_URL).toBe('/runtime-sgw');
+  });
+
+  it('empty runtime values (unset container env) fall back to build-time env', async () => {
+    vi.stubEnv('VITE_SUBSCRIPTION_ENABLED', 'true');
+    vi.stubEnv('VITE_PAID_PLANS_ENABLED', ''); // pin: ambient env must not leak in
+    (window as RuntimeWindow).__SPHERE_RUNTIME_CONFIG__ = {
+      SUBSCRIPTION_ENABLED: '',
+      SUBSCRIPTION_API_URL: '',
+      PAID_PLANS_ENABLED: '',
+    };
+    vi.resetModules();
+    const cfg = await import('@/config/subscription');
+    expect(cfg.SUBSCRIPTION_ENABLED).toBe(true);
+    expect(cfg.PAID_PLANS_ENABLED).toBe(false);
+  });
+
+  it('only exactly "true" enables the flags', async () => {
+    (window as RuntimeWindow).__SPHERE_RUNTIME_CONFIG__ = {
+      SUBSCRIPTION_ENABLED: 'TRUE',
+      PAID_PLANS_ENABLED: '1',
+    };
+    vi.resetModules();
+    const cfg = await import('@/config/subscription');
+    expect(cfg.SUBSCRIPTION_ENABLED).toBe(false);
+    expect(cfg.PAID_PLANS_ENABLED).toBe(false);
+  });
+
+  it('defaults SUBSCRIPTION_API_URL to /sgw when nothing is set anywhere', async () => {
+    vi.stubEnv('VITE_SUBSCRIPTION_API_URL', '');
+    vi.resetModules();
+    const cfg = await import('@/config/subscription');
+    expect(cfg.SUBSCRIPTION_API_URL).toBe('/sgw');
   });
 });


### PR DESCRIPTION
Stacked on #414 — completes "Enabling later" **step 1** of its plan: the build-once/promote-many image's **task definition can now turn subscriptions on/off** without a rebuild.

## Runtime contract (ECS task def / `docker -e`)

| Env var | Rides | Effect |
|---|---|---|
| `SUBSCRIPTION_ENABLED` | `/runtime-config.js` → `window.__SPHERE_RUNTIME_CONFIG__` | exactly `true` = per-wallet SGW keys on |
| `PAID_PLANS_ENABLED` | same | exactly `true` = paid plans purchasable (mainnet) |

That's the whole contract. **The SGW base URL needs no config**: the SGW is the aggregator gateway, so the app derives it from the SDK's per-network table (`NETWORKS[SPHERE_NETWORK].aggregatorUrl`, new `src/config/network.ts` shared with `SphereProvider`) and calls it directly — all SGW endpoints serve CORS (fixed in unicitynetwork/aggregator-subscription#57, verified live including error responses). `VITE_SUBSCRIPTION_API_URL` remains a dev-only override for the local SGW compose stack via the vite `/sgw` proxy. The 5 existing `__RUNTIME_*__` sed placeholders are untouched.

**Enabling on staging = `SUBSCRIPTION_ENABLED=true` on the task def + CDN invalidation.** Nothing else.

## Why the flags don't ride sed placeholders

Rollup statically evaluates branch conditions against baked literals (following const bindings across modules) and **prunes every `if (FLAG)` at build time** — verified empirically: with placeholder ARGs baked, `quotaGate`'s allow/deny logic and the SendModal quota warning were physically absent from `dist/`. sed can rewrite a surviving string; it cannot resurrect deleted code, so a placeholder flag ships permanently OFF. (The existing `REQUIRE_WALLET_API` placeholder is already dead in published bundles for exactly this reason — now documented in `walletApi.ts`, and `runtime-config.sh` warns when `WALLET_API_URL` is empty.) The flags therefore come from a tiny classic script (`/runtime-config.js`, served `no-cache`) written at container start from the container env and loaded before the bundle; dev/Pages builds ship an empty default and fall back to the baked `VITE_*` env.

## Guard rails

- Near-miss flag spellings (`TRUE`, `1`) log a warning on both flags — the app compares against exactly `'true'`.
- CR/LF in flag values are refused at start: a raw CR would SyntaxError the generated JS and silently disable all runtime config.
- `VITE_SUBSCRIPTION_MOCK` is deliberately **not** runtime-swappable (dev-only; prod builds tree-shake the mock).

## Test plan

- 222/222 unit tests (incl. runtime-global contract tests + SDK-derived URL test), `tsc`, ESLint.
- Sandbox tests of `runtime-config.sh`: flag writing, CR/LF/quote injection, near-miss warnings, #351 unchanged, empty-`WALLET_API_URL` warning.
- Local `docker build` + container smokes: boots with `SUBSCRIPTION_ENABLED=true` and zero SGW config, runtime-config.js contents + `no-cache` header, SDK gateway origin present in bundle, bundle reads the global, quota-gate code present (not tree-shaken), placeholders substituted.
- `docker-validate.yml` CI smoke covers the same assertions.
- Adversarially reviewed (multi-agent, first revision): 10 findings confirmed → fixed or made obsolete by this simplification.

## History

The first revision (8e8f367) also shipped a runtime-generated nginx `/sgw` reverse proxy (`SGW_UPSTREAM`) because the SGW store endpoints lacked CORS. That was removed in 060f820 after unicitynetwork/aggregator-subscription#57 was fixed and deployed — direct calls work for everything now, so the proxy, its env var, and its fail-closed check are gone (−138 lines).