### PR TITLE
fix(subscription): address review findings — network pin, dormancy gating, poll cancellation

### DIFF
--- a/src/components/upgrade/UpgradeModal.tsx
+++ b/src/components/upgrade/UpgradeModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Sparkles, Loader2, AlertTriangle } from 'lucide-react';
@@ -71,6 +71,12 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const [newApiKey, setNewApiKey] = useState<string | null>(null);
   const [walletWide, setWalletWide] = useState(false);
 
+  // Cancels the in-flight checkout poll when the modal closes (or a newer
+  // checkout starts). Without this the poll outlives the modal and can
+  // "ghost-adopt" a key onto whatever address is active minutes later.
+  const checkoutAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => checkoutAbortRef.current?.abort(), []);
+
   // Buying while on the root address is wallet-wide by definition; on any
   // other address the email step offers a "make it wallet-wide" checkbox.
   const onRootAddress = useMemo(() => {
@@ -130,15 +136,29 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const startCheckout = async () => {
     if (!selectedPlan) return;
     setError(null);
+    // Supersede any prior in-flight poll, then track this one so close/unmount
+    // can abort it.
+    checkoutAbortRef.current?.abort();
+    const abort = new AbortController();
+    checkoutAbortRef.current = abort;
     try {
       const { orderId, redirectUrl } = await checkout.mutateAsync({ planId: selectedPlan.planId, email });
+      // Closed (or superseded) during order creation — don't pop a payment tab
+      // or strand the modal on 'awaiting' after the user cancelled.
+      if (abort.signal.aborted) return;
       setPaymentUrl(redirectUrl);
       window.open(redirectUrl, '_blank', 'noopener,noreferrer');
       setStep('awaiting');
 
       const result = SUBSCRIPTION_MOCK
         ? { outcome: 'paid' as const, apiKey: 'sk_mock_upgraded' } // demoable without a backend
-        : await pollOrderStatus(() => getOrderStatus(orderId));
+        : await pollOrderStatus(() => getOrderStatus(orderId), { signal: abort.signal });
+
+      // Modal closed (or a newer checkout took over) while polling — do NOT
+      // adopt a key or touch step/error state on a torn-down flow.
+      if (abort.signal.aborted) return;
+
+      if (result.outcome === 'cancelled') return;
 
       if (result.outcome === 'paid' && result.apiKey) {
         await adoptKey(result.apiKey);
@@ -152,12 +172,15 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
         setError('Payment not detected yet. If you paid, open the payment return page — your API key is shown there once — then paste it via "I have a key".');
       }
     } catch (e) {
+      if (abort.signal.aborted) return; // torn down mid-checkout — stay silent
       setStep('error');
       setError(e instanceof Error ? e.message : 'Checkout failed');
     }
   };
 
   const handleClose = () => {
+    checkoutAbortRef.current?.abort(); // stop any in-flight checkout poll
+    checkoutAbortRef.current = null;
     setStep('plans');
     setError(null);
     setPaymentUrl(null);

--- a/src/components/wallet/L3/modals/SettingsModal.tsx
+++ b/src/components/wallet/L3/modals/SettingsModal.tsx
@@ -8,6 +8,7 @@ import { ConnectedSitesModal } from './ConnectedSitesModal';
 import { SubscriptionModal } from './SubscriptionModal';
 import { useUpgrade } from '../../../upgrade';
 import { useUtilization } from '../../../../sdk/hooks/subscription';
+import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -69,13 +70,15 @@ export function SettingsModal({
             onClick={() => setIsConnectedSitesOpen(true)}
           />
 
-          <MenuButton
-            icon={CreditCard}
-            color="orange"
-            label="Subscription"
-            subtitle={subscriptionSubtitle}
-            onClick={() => setIsSubscriptionOpen(true)}
-          />
+          {SUBSCRIPTION_ENABLED && (
+            <MenuButton
+              icon={CreditCard}
+              color="orange"
+              label="Subscription"
+              subtitle={subscriptionSubtitle}
+              onClick={() => setIsSubscriptionOpen(true)}
+            />
+          )}
 
           <MenuButton
             icon={Download}

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -16,6 +16,9 @@ import { SUBSCRIPTION_ENABLED } from "../../../../config/subscription";
 import { setStoredSubscriptionKey } from "../../../../config/storageKeys";
 import { saveWalletKey } from "../../../../sdk/subscription/keyVault";
 
+/** Cap onboarding's subscription provisioning; on expiry we use the env key. */
+const PROVISION_TIMEOUT_MS = 8000;
+
 export type OnboardingStep =
   | "start"
   | "restoreMethod"
@@ -611,7 +614,15 @@ export function useOnboardingFlow(): UseOnboardingFlowReturn {
     const active = importedSphereRef.current ?? sphere;
     if (SUBSCRIPTION_ENABLED && active) {
       try {
-        const result = await provisionOrRecoverKey(active);
+        // Bound provisioning: a slow/blackholed SGW must not hang wallet
+        // creation. On timeout we fall through to the env-key fallback exactly
+        // like a provisioning error would.
+        const result = await Promise.race([
+          provisionOrRecoverKey(active),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('subscription provisioning timed out')), PROVISION_TIMEOUT_MS),
+          ),
+        ]);
         // Persist ONLY — do NOT re-init here. Re-initializing now (like
         // applySubscriptionKey does) would flip walletExists to true and
         // unmount CreateWalletFlow before the capabilities screen renders.

--- a/src/sdk/hooks/subscription/useUtilization.ts
+++ b/src/sdk/hooks/subscription/useUtilization.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { getUtilization } from '../../../services/subscriptionApi';
 import { getStoredSubscriptionKey } from '../../../config/storageKeys';
+import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
 import { SPHERE_KEYS } from '../../queryKeys';
 
 /** Single read model for the subscription UI: plan + limits + usage + status. */
@@ -9,7 +10,10 @@ export function useUtilization() {
   return useQuery({
     queryKey: apiKey ? SPHERE_KEYS.subscription.utilization(apiKey) : SPHERE_KEYS.subscription.all,
     queryFn: () => getUtilization(apiKey as string),
-    enabled: !!apiKey,
+    // Gate on the feature flag (like usePlans): a leftover key from a
+    // previously-enabled deploy must not keep the SGW polled every 30s once
+    // the flag is turned off — the feature ships dormant.
+    enabled: !!apiKey && SUBSCRIPTION_ENABLED,
     refetchInterval: 30_000,
     staleTime: 15_000,
   });

--- a/src/sdk/subscription/pollOrder.ts
+++ b/src/sdk/subscription/pollOrder.ts
@@ -32,8 +32,12 @@ export async function pollOrderStatus(
     ((ms) =>
       new Promise<void>((resolve) => {
         if (signal?.aborted) { resolve(); return; }
-        const t = setTimeout(resolve, ms);
-        signal?.addEventListener('abort', () => { clearTimeout(t); resolve(); }, { once: true });
+        // Remove the listener on the normal-timer path too: with only
+        // `{ once: true }` it lingers on the signal every interval it does NOT
+        // fire, accumulating ~one per poll over the multi-minute window.
+        const onAbort = () => { clearTimeout(t); resolve(); };
+        const t = setTimeout(() => { signal?.removeEventListener('abort', onAbort); resolve(); }, ms);
+        signal?.addEventListener('abort', onAbort, { once: true });
       }));
 
   const deadline = now() + timeoutMs;

--- a/src/sdk/subscription/pollOrder.ts
+++ b/src/sdk/subscription/pollOrder.ts
@@ -5,19 +5,40 @@
  */
 import type { OrderStatusInfo } from '../../services/subscriptionApi';
 
-export interface OrderPollResult { outcome: 'paid' | 'failed' | 'timeout'; apiKey?: string }
+export interface OrderPollResult { outcome: 'paid' | 'failed' | 'timeout' | 'cancelled'; apiKey?: string }
 
 export async function pollOrderStatus(
   fetchStatus: () => Promise<OrderStatusInfo>,
-  opts: { intervalMs?: number; timeoutMs?: number; now?: () => number; sleep?: (ms: number) => Promise<void> } = {},
+  opts: {
+    intervalMs?: number;
+    timeoutMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    /** Abort the poll (e.g. the upgrade modal closed). Resolves 'cancelled'. */
+    signal?: AbortSignal;
+  } = {},
 ): Promise<OrderPollResult> {
   const intervalMs = opts.intervalMs ?? 3000;
   const timeoutMs = opts.timeoutMs ?? 5 * 60_000;
   const now = opts.now ?? (() => Date.now());
-  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const signal = opts.signal;
+  // Default sleep resolves early on abort so a closed modal stops polling
+  // within the same tick instead of after a full interval. Check `aborted`
+  // synchronously first: if the signal is ALREADY aborted, the 'abort' event
+  // has fired and addEventListener would never call back (leaving the full
+  // timer to run).
+  const sleep =
+    opts.sleep ??
+    ((ms) =>
+      new Promise<void>((resolve) => {
+        if (signal?.aborted) { resolve(); return; }
+        const t = setTimeout(resolve, ms);
+        signal?.addEventListener('abort', () => { clearTimeout(t); resolve(); }, { once: true });
+      }));
 
   const deadline = now() + timeoutMs;
   while (now() < deadline) {
+    if (signal?.aborted) return { outcome: 'cancelled' };
     try {
       const order = await fetchStatus();
       if (order.status === 'paid') return { outcome: 'paid', apiKey: order.apiKey };
@@ -27,5 +48,5 @@ export async function pollOrderStatus(
     }
     await sleep(intervalMs);
   }
-  return { outcome: 'timeout' };
+  return signal?.aborted ? { outcome: 'cancelled' } : { outcome: 'timeout' };
 }

--- a/src/services/sgwChallenge.ts
+++ b/src/services/sgwChallenge.ts
@@ -19,7 +19,7 @@ export class SgwChallengeError extends Error {
 
 export function verifySgwChallenge(
   challenge: string,
-  expect: { pubkey: string; nonce: string; nowMs?: number },
+  expect: { network: string; pubkey: string; nonce: string; nowMs?: number },
 ): void {
   if (!challenge.startsWith(SGW_CHALLENGE_PREFIX)) throw new SgwChallengeError('unexpected prefix');
 
@@ -40,6 +40,13 @@ export function verifySgwChallenge(
   }
 
   const p = payload as Record<(typeof FIELDS)[number], string>;
+  // Anti-cross-network relay: a challenge issued by ANOTHER network's SGW must
+  // not be signable here. Key derivation + the signMessage scheme are
+  // network-independent, so without this the wallet's index-0 signature over a
+  // (say) mainnet challenge is redeemable at the mainnet SGW — a confused
+  // deputy that harvests the victim's key on a network they never authenticated
+  // to. The SDK's own verifyChallengeTemplate enforces the same equality.
+  if (p.network.toLowerCase() !== expect.network.toLowerCase()) throw new SgwChallengeError('network mismatch');
   if (p.pubkey.toLowerCase() !== expect.pubkey.toLowerCase()) throw new SgwChallengeError('pubkey mismatch');
   if (p.nonce !== expect.nonce) throw new SgwChallengeError('nonce mismatch');
 

--- a/src/services/subscriptionApi.ts
+++ b/src/services/subscriptionApi.ts
@@ -6,6 +6,7 @@
 import type { Sphere } from '@unicitylabs/sphere-sdk';
 import { getPublicKey, signMessage } from '@unicitylabs/sphere-sdk';
 import { SUBSCRIPTION_API_URL, SUBSCRIPTION_MOCK } from '../config/subscription';
+import { SPHERE_NETWORK } from '../config/network';
 import { verifySgwChallenge } from './sgwChallenge';
 import * as mock from './subscriptionApi.mock';
 
@@ -127,7 +128,9 @@ export async function provisionOrRecoverKey(
   }
 
   const { nonce, challenge } = await postJson<Challenge>('/auth/challenge', { pubkey });
-  verifySgwChallenge(challenge, { pubkey, nonce }); // never sign unverified server text
+  // never sign unverified server text; pin our network so a relayed challenge
+  // from another network's SGW can't be signed here (see verifySgwChallenge).
+  verifySgwChallenge(challenge, { network: SPHERE_NETWORK, pubkey, nonce });
   const signature = sign(challenge);
   return postJson<ProvisionResult>('/auth/verify', { nonce, signature });
 }

--- a/tests/unit/sdk/gatewayErrors.test.ts
+++ b/tests/unit/sdk/gatewayErrors.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { SphereError } from '@unicitylabs/sphere-sdk';
+// The REAL transport error the classifier duck-types. Never re-exported from
+// sphere-sdk, so the canary below deep-imports it from state-transition-sdk
+// (a transitive dep). If a bump moves/renames it, this import fails loudly —
+// which is exactly the drift signal the canary exists to raise.
+import { JsonRpcNetworkError } from '@unicitylabs/state-transition-sdk/lib/api/json-rpc/JsonRpcNetworkError.js';
 import { getGatewayHttpStatus, isQuotaRateLimit, isGatewayAuthError } from '@/sdk/errors';
 
 // Fabricate the duck-typed transport error shape that JsonRpcNetworkError
-// (state-transition-sdk, never exported from sphere-sdk) satisfies today.
+// satisfies today (used for the behavioural cases; the CONTRACT CANARY below
+// pins the REAL class so a shape drift can't slip past these fakes).
 function jsonRpcNetworkError(status: number, name = 'JsonRpcNetworkError') {
   return { name, status, message: 'transport error' };
 }
@@ -81,12 +87,18 @@ describe('getGatewayHttpStatus', () => {
   // state-transition-sdk upgrade renames `name`/`status` on its transport
   // error, this is the test that should go red first, before it's discovered
   // in production as a gate that silently stops firing.
-  it('CONTRACT CANARY: duck-shape is exactly {name: string, status: number}', () => {
-    const shape = jsonRpcNetworkError(429);
-    expect(shape).toHaveProperty('name', 'JsonRpcNetworkError');
-    expect(shape).toHaveProperty('status', 429);
-    expect(typeof shape.status).toBe('number');
-    expect(getGatewayHttpStatus(shape)).toBe(429);
+  it('CONTRACT CANARY: the REAL state-transition-sdk JsonRpcNetworkError still classifies', () => {
+    // Construct the actual SDK error, not our fabricated duck — this is what
+    // makes it a canary. If a bump renames `name`/`status` (or the class),
+    // these assertions (or the import) go red before it silently stops the
+    // gate from firing in production.
+    const real = new JsonRpcNetworkError(429, 'transport error');
+    expect(real.name).toBe('JsonRpcNetworkError');
+    expect(typeof (real as { status?: unknown }).status).toBe('number');
+    expect(getGatewayHttpStatus(real)).toBe(429);
+    expect(
+      isQuotaRateLimit(new SphereError('certification unconfirmed', 'CERTIFICATION_UNCONFIRMED', real)),
+    ).toBe(true);
   });
 });
 

--- a/tests/unit/sdk/pollOrder.test.ts
+++ b/tests/unit/sdk/pollOrder.test.ts
@@ -47,6 +47,27 @@ it('resolves cancelled when aborted mid-poll', async () => {
   expect(res.outcome).toBe('cancelled');
 });
 
+it('does not leak abort listeners across intervals (default sleep cleans up on the timer path)', async () => {
+  const ac = new AbortController();
+  let added = 0, removed = 0;
+  const origAdd = ac.signal.addEventListener.bind(ac.signal);
+  const origRemove = ac.signal.removeEventListener.bind(ac.signal);
+  ac.signal.addEventListener = ((type: string, ...rest: unknown[]) => {
+    if (type === 'abort') added++;
+    return (origAdd as (...a: unknown[]) => void)(type, ...rest);
+  }) as typeof ac.signal.addEventListener;
+  ac.signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+    if (type === 'abort') removed++;
+    return (origRemove as (...a: unknown[]) => void)(type, ...rest);
+  }) as typeof ac.signal.removeEventListener;
+  // Several pending polls on real (tiny) timers, never aborted → each interval's
+  // listener must be removed when its timer fires.
+  const res = await pollOrderStatus(async () => base, { intervalMs: 2, timeoutMs: 12, signal: ac.signal });
+  expect(res.outcome).toBe('timeout');
+  expect(added).toBeGreaterThan(1); // multiple intervals actually elapsed
+  expect(removed).toBe(added);      // every listener cleaned up
+});
+
 it('the default (real-timer) sleep unblocks immediately on abort', async () => {
   // No custom `sleep` — exercises pollOrder's abortable setTimeout branch. A
   // 60s interval would hang the test if abort did not clear/resolve the timer.

--- a/tests/unit/sdk/pollOrder.test.ts
+++ b/tests/unit/sdk/pollOrder.test.ts
@@ -6,7 +6,10 @@ const instant = () => ({ intervalMs: 1, timeoutMs: 50, sleep: async () => {}, no
 
 it('resolves paid with the revealed key', async () => {
   const seq: OrderStatusInfo[] = [base, { ...base, status: 'paid', fulfilled: true, apiKey: 'sk_new' }];
-  const res = await pollOrderStatus(async () => seq.shift() ?? seq[0], { ...instant, now: (() => { let t = 0; return () => (t += 10); })() });
+  // `instant()` — CALL the factory; `{ ...instant }` spreads a function (no own
+  // enumerable props) so intervalMs/timeoutMs/sleep fall back to prod defaults
+  // and the test silently runs on a real 3s timer.
+  const res = await pollOrderStatus(async () => seq.shift() ?? seq[0], instant());
   expect(res).toEqual({ outcome: 'paid', apiKey: 'sk_new' });
 });
 
@@ -24,4 +27,33 @@ it('times out while pending, swallowing transient errors', async () => {
   let n = 0;
   const res = await pollOrderStatus(async () => { if (n++ % 2) throw new Error('net'); return base; }, instant());
   expect(res.outcome).toBe('timeout');
+});
+
+it('resolves cancelled when the signal is already aborted (never fetches)', async () => {
+  const ac = new AbortController();
+  ac.abort();
+  const fetchStatus = vi.fn(async () => base);
+  const res = await pollOrderStatus(fetchStatus, { ...instant(), signal: ac.signal });
+  expect(res.outcome).toBe('cancelled');
+  expect(fetchStatus).not.toHaveBeenCalled();
+});
+
+it('resolves cancelled when aborted mid-poll', async () => {
+  const ac = new AbortController();
+  const res = await pollOrderStatus(
+    async () => { ac.abort(); return base; }, // pending, then abort before next tick
+    { ...instant(), signal: ac.signal },
+  );
+  expect(res.outcome).toBe('cancelled');
+});
+
+it('the default (real-timer) sleep unblocks immediately on abort', async () => {
+  // No custom `sleep` — exercises pollOrder's abortable setTimeout branch. A
+  // 60s interval would hang the test if abort did not clear/resolve the timer.
+  const ac = new AbortController();
+  const res = await pollOrderStatus(
+    async () => { ac.abort(); return base; },
+    { intervalMs: 60_000, timeoutMs: 120_000, signal: ac.signal }, // real setTimeout
+  );
+  expect(res.outcome).toBe('cancelled');
 });

--- a/tests/unit/services/sgwChallenge.test.ts
+++ b/tests/unit/services/sgwChallenge.test.ts
@@ -1,5 +1,6 @@
 import { verifySgwChallenge, SgwChallengeError, SGW_CHALLENGE_PREFIX } from '@/services/sgwChallenge';
 
+const NET = 'testnet2';
 const PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
 const NONCE = '6f7c2e1a-8b1d-4f3e-9c5a-2d4b6e8f0a1c';
 const NOW = Date.parse('2026-07-03T12:00:30.000Z');
@@ -18,47 +19,56 @@ function makeChallenge(overrides: Record<string, string> = {}, bodyOverride?: st
 
 describe('verifySgwChallenge', () => {
   it('accepts a well-formed SGW challenge', () => {
-    expect(() => verifySgwChallenge(makeChallenge(), { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).not.toThrow();
+    expect(() => verifySgwChallenge(makeChallenge(), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).not.toThrow();
   });
 
   it('rejects a wrong prefix (e.g. the wallet-api prefix)', () => {
     const c = 'unicity:wallet-api:auth:v1\n' + JSON.stringify({ network: 'testnet2', pubkey: PUBKEY, nonce: NONCE, issuedAt: '2026-07-03T12:00:00.000Z', expiresAt: '2026-07-03T12:05:00.000Z' });
-    expect(() => verifySgwChallenge(c, { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(c, { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
   });
 
   it('rejects a pubkey mismatch', () => {
-    expect(() => verifySgwChallenge(makeChallenge({ pubkey: '02' + 'a'.repeat(64) }), { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge({ pubkey: '02' + 'a'.repeat(64) }), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
   });
 
   it('accepts case-insensitive pubkey echo', () => {
-    expect(() => verifySgwChallenge(makeChallenge(), { pubkey: PUBKEY.toUpperCase(), nonce: NONCE, nowMs: NOW })).not.toThrow();
+    expect(() => verifySgwChallenge(makeChallenge(), { network: NET, pubkey: PUBKEY.toUpperCase(), nonce: NONCE, nowMs: NOW })).not.toThrow();
   });
 
   it('rejects a nonce mismatch', () => {
-    expect(() => verifySgwChallenge(makeChallenge({ nonce: 'ffffffff-ffff-4fff-8fff-ffffffffffff' }), { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge({ nonce: 'ffffffff-ffff-4fff-8fff-ffffffffffff' }), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+  });
+
+  it('rejects a network mismatch (cross-network relay defense)', () => {
+    // A challenge issued by mainnet's SGW, replayed to a testnet2 wallet.
+    expect(() => verifySgwChallenge(makeChallenge({ network: 'mainnet' }), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+  });
+
+  it('accepts a case-insensitive network echo', () => {
+    expect(() => verifySgwChallenge(makeChallenge({ network: 'Testnet2' }), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).not.toThrow();
   });
 
   it('rejects an expired challenge', () => {
     const past = Date.parse('2026-07-03T12:06:00.000Z');
-    expect(() => verifySgwChallenge(makeChallenge(), { pubkey: PUBKEY, nonce: NONCE, nowMs: past })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge(), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: past })).toThrow(SgwChallengeError);
   });
 
   it('rejects issuedAt too far in the future (clock skew > 5 min)', () => {
     const early = Date.parse('2026-07-03T11:54:00.000Z');
-    expect(() => verifySgwChallenge(makeChallenge(), { pubkey: PUBKEY, nonce: NONCE, nowMs: early })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge(), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: early })).toThrow(SgwChallengeError);
   });
 
   it('rejects a validity window over 60 min', () => {
-    expect(() => verifySgwChallenge(makeChallenge({ expiresAt: '2026-07-03T13:30:00.000Z' }), { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge({ expiresAt: '2026-07-03T13:30:00.000Z' }), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
   });
 
   it('rejects multi-line or non-JSON bodies', () => {
-    expect(() => verifySgwChallenge(makeChallenge({}, '{"a":1}\n{"b":2}'), { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
-    expect(() => verifySgwChallenge(makeChallenge({}, 'not-json'), { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge({}, '{"a":1}\n{"b":2}'), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(makeChallenge({}, 'not-json'), { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
   });
 
   it('rejects missing/non-string fields', () => {
     const body = JSON.stringify({ network: 'testnet2', pubkey: PUBKEY, nonce: NONCE, issuedAt: '2026-07-03T12:00:00.000Z' }); // no expiresAt
-    expect(() => verifySgwChallenge(SGW_CHALLENGE_PREFIX + body, { pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
+    expect(() => verifySgwChallenge(SGW_CHALLENGE_PREFIX + body, { network: NET, pubkey: PUBKEY, nonce: NONCE, nowMs: NOW })).toThrow(SgwChallengeError);
   });
 });

--- a/tests/unit/services/subscriptionApi.test.ts
+++ b/tests/unit/services/subscriptionApi.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getPublicKey, recoverPubkeyFromSignature } from '@unicitylabs/sphere-sdk';
+
+// Pin the real network path: these tests exercise the actual challenge/verify
+// crypto, so SUBSCRIPTION_MOCK must be false regardless of ambient
+// VITE_SUBSCRIPTION_MOCK (a dev shell with it =true otherwise fails all 9).
+vi.mock('@/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('@/config/subscription')>()),
+  SUBSCRIPTION_MOCK: false,
+}));
 import {
   provisionOrRecoverKey,
   getUtilization,


### PR DESCRIPTION
Addresses the actionable findings from the #414 review ([comment](https://github.com/unicity-sphere/sphere/pull/414#issuecomment-4923796026)). Stacked on `feat/subscription-key-migration`. The per-address-vs-shared-key **design decision** is left to the owner and not touched here.

## Fixes

**Cross-network challenge relay** (`sgwChallenge.ts`, `subscriptionApi.ts`) — `verifySgwChallenge` now requires an expected `network` and the caller pins `SPHERE_NETWORK`. Without it, the wallet's index-0 signature over a challenge relayed from another network's SGW was redeemable there (idempotent get-or-create → victim's key). The SDK's own `verifyChallengeTemplate` enforces the same equality. Comparison is case-insensitive; added mismatch + case-insensitive tests.

**Dormancy gating** (`useUtilization.ts`, `SettingsModal.tsx`) — `useUtilization` is now gated on `SUBSCRIPTION_ENABLED` (matching `usePlans`), so a leftover key from a previously-enabled deploy can't keep the SGW polled every 30s once the flag is off; the SettingsModal "Subscription" entry is hidden when the flag is off. Makes "ships dormant" actually airtight.

**Checkout poll cancellation** (`pollOrder.ts`, `UpgradeModal.tsx`) — `pollOrderStatus` takes an `AbortSignal` (abortable sleep, resolves `'cancelled'`); `UpgradeModal` aborts the poll on close/unmount/new-checkout and guards **every** post-await mutation — including the order-creation window before `window.open` — so a cancelled checkout can't ghost-adopt a key, pop a payment tab, or strand the modal on `awaiting`.

**Onboarding timeout** (`useOnboardingFlow.ts`) — subscription provisioning is bounded by an 8s timeout that falls through to the existing env-key fallback, so a slow/blackholed SGW can't hang wallet creation.

**Test fixes** — the gateway-error `CONTRACT CANARY` now constructs the **real** `state-transition-sdk` `JsonRpcNetworkError` (deep-imported) so a shape drift fails loudly instead of asserting against a fabricated duck; `subscriptionApi.test.ts` pins `SUBSCRIPTION_MOCK=false` (ambient `VITE_SUBSCRIPTION_MOCK=true` otherwise failed all 9); `pollOrder.test.ts` calls the `instant()` factory (was spreading it → the first case silently ran on a real 3s timer) and adds abort-path coverage.

## Verification

- 227 unit tests pass (+5), incl. with ambient `VITE_SUBSCRIPTION_MOCK=true`; `tsc`, ESLint, production build all green.
- Adversarially reviewed the diff itself (multi-agent): caught a gap in my own abort work — the guard originally missed the `checkout.mutateAsync`→`window.open` window — and a latent bug where the abortable default sleep wouldn't fire on an *already-aborted* signal (would hang a poll a full interval). Both fixed, with a real-timer test that would hang without the fix.

## Not addressed (by decision)

Per-address vs wallet-wide key attribution (the `UpgradeModal` stale-memo item and the related switch-time races) collapses depending on whether the intended model is one shared key or per-address — owner's call, so left for a separate change.