### PR TITLE
fix(subscription): AGGREGATOR_API_KEY required only when subs off, ignored when on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ VITE_DEV_PORTAL_URL=https://developers.staging.unicity.network/
 # Aggregator (state-transition gateway) API key.
 # The testnet2 value below is NOT a secret — safe to keep here and in docs.
 # For mainnet this MUST be a real secret: set it only in the deploy env, never commit it.
+# Used ONLY when subscriptions are OFF: with VITE_SUBSCRIPTION_ENABLED=true the
+# per-wallet SGW key replaces it and this value is ignored entirely.
 VITE_AGGREGATOR_API_KEY=sk_ddc3cfcc001e4a28ac3fad7407f99590
 
 # wallet-api backend (S4 provider swap). When set, the ASSET path rides the

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -76,12 +76,13 @@ jobs:
       - name: Smoke — runtime config substitution
         if: matrix.dockerfile == 'Dockerfile'
         run: |
+          # Note: NO AGGREGATOR_API_KEY here — SUBSCRIPTION_ENABLED=true must
+          # start without it (per-wallet keys replace it, and it is ignored).
           cid=$(docker run -d \
             -e SPHERE_API_URL=https://quest-api.example.test \
             -e WALLET_API_URL=https://wallet-api.example.test \
             -e REQUIRE_WALLET_API=true \
             -e DEV_PORTAL_URL=https://developers.example.test/ \
-            -e AGGREGATOR_API_KEY=sk_smoke_test \
             -e SUBSCRIPTION_ENABLED=true \
             -e PAID_PLANS_ENABLED=false \
             sphere-validate:${{ matrix.dockerfile }})
@@ -139,6 +140,41 @@ jobs:
           [ "$rc" -ne 0 ] || { echo "ERROR: expected non-zero exit (fail-closed)"; exit 1; }
           echo "$out" | grep -q '#351' || { echo "ERROR: missing #351 fail-closed message"; exit 1; }
           echo "fail-closed smoke ok"
+
+      # AGGREGATOR_API_KEY is REQUIRED when subscriptions are off (it's then the
+      # only oracle credential) and IGNORED when they're on. Verify both.
+      - name: Smoke — AGGREGATOR_API_KEY required iff subscriptions off
+        if: matrix.dockerfile == 'Dockerfile'
+        run: |
+          # (a) subscriptions OFF + no AGGREGATOR_API_KEY → refuse to start.
+          set +e
+          out=$(docker run --rm \
+            -e SPHERE_API_URL=https://quest-api.example.test \
+            -e DEV_PORTAL_URL=https://developers.example.test/ \
+            sphere-validate:${{ matrix.dockerfile }} 2>&1)
+          rc=$?
+          set -e
+          echo "$out"
+          [ "$rc" -ne 0 ] || { echo "ERROR: expected non-zero exit (AGGREGATOR_API_KEY required when subs off)"; exit 1; }
+          echo "$out" | grep -q 'AGGREGATOR_API_KEY is empty' \
+            || { echo "ERROR: missing AGGREGATOR_API_KEY fail-closed message"; exit 1; }
+
+          # (b) subscriptions ON + no AGGREGATOR_API_KEY → starts fine (ignored).
+          cid=$(docker run -d \
+            -e SPHERE_API_URL=https://quest-api.example.test \
+            -e WALLET_API_URL=https://wallet-api.example.test \
+            -e REQUIRE_WALLET_API=true \
+            -e DEV_PORTAL_URL=https://developers.example.test/ \
+            -e SUBSCRIPTION_ENABLED=true \
+            sphere-validate:${{ matrix.dockerfile }})
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+          for _ in $(seq 1 20); do
+            docker logs "$cid" 2>&1 | grep -q "applied runtime config" && break
+            sleep 0.5
+          done
+          [ "$(docker inspect -f '{{.State.Running}}' "$cid")" = "true" ] \
+            || { echo "ERROR: container should start with subs on and no AGGREGATOR_API_KEY"; docker logs "$cid" 2>&1 | tail; exit 1; }
+          echo "aggregator-key conditional smoke ok"
 
       # Smoke for the SSL image: entrypoint is tini → sphere-entrypoint.
       # We can't run the real entrypoint in CI (ssl-setup would need

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -147,10 +147,16 @@ jobs:
         if: matrix.dockerfile == 'Dockerfile'
         run: |
           # (a) subscriptions OFF + no AGGREGATOR_API_KEY → refuse to start.
+          # Same baseline as the other smokes (WALLET_API_URL + REQUIRE_WALLET_API=false,
+          # SUBSCRIPTION_ENABLED=false explicit) so the ONLY missing var is
+          # AGGREGATOR_API_KEY and the failure is unambiguously attributable to it.
           set +e
           out=$(docker run --rm \
             -e SPHERE_API_URL=https://quest-api.example.test \
+            -e WALLET_API_URL=https://wallet-api.example.test \
+            -e REQUIRE_WALLET_API=false \
             -e DEV_PORTAL_URL=https://developers.example.test/ \
+            -e SUBSCRIPTION_ENABLED=false \
             sphere-validate:${{ matrix.dockerfile }} 2>&1)
           rc=$?
           set -e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ image). Set these on the ECS task definition / `docker -e`:
 | `WALLET_API_URL`       | `VITE_WALLET_API_URL`      | wallet-api backend (S4 asset custody) |
 | `REQUIRE_WALLET_API`   | `VITE_REQUIRE_WALLET_API`  | #351 fail-closed custody flag (`''`/`false`/`0` = off) |
 | `DEV_PORTAL_URL`       | `VITE_DEV_PORTAL_URL`      | developer-portal link |
-| `AGGREGATOR_API_KEY`   | `VITE_AGGREGATOR_API_KEY`  | aggregator key (non-secret on testnet2; a real secret on mainnet) |
+| `AGGREGATOR_API_KEY`   | `VITE_AGGREGATOR_API_KEY`  | aggregator key (non-secret on testnet2; a real secret on mainnet). **Required only when `SUBSCRIPTION_ENABLED` != `true`; ignored when subscriptions are on** (per-wallet SGW keys replace it) |
 | `SUBSCRIPTION_ENABLED` | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | per-wallet SGW subscription keys (exactly `true` = on) |
 | `PAID_PLANS_ENABLED`   | `window.__SPHERE_RUNTIME_CONFIG__` (not a placeholder) | paid-plan purchases (exactly `true`; testnet leaves off) |
 

--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -89,7 +89,7 @@ done
 #                       is REQUIRED — without it the app has no key to sign L3
 #                       state transitions; fail closed rather than ship a wallet
 #                       that can't send.
-if [ "${SUBSCRIPTION_ENABLED-}" = true ]; then
+if [ "${SUBSCRIPTION_ENABLED-}" = "true" ]; then
   [ -n "${AGGREGATOR_API_KEY-}" ] && \
     log "NOTE: AGGREGATOR_API_KEY is set but ignored — SUBSCRIPTION_ENABLED=true uses per-wallet keys."
 elif [ -z "${AGGREGATOR_API_KEY-}" ]; then

--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -22,7 +22,9 @@
 #   WALLET_API_URL         wallet-api backend base (S4 asset custody)
 #   REQUIRE_WALLET_API     #351 fail-closed custody flag ('' / false / 0 = off)
 #   DEV_PORTAL_URL         developer-portal link target
-#   AGGREGATOR_API_KEY     aggregator API key (non-secret on testnet2)
+#   AGGREGATOR_API_KEY     aggregator API key (non-secret on testnet2) —
+#                          REQUIRED only when SUBSCRIPTION_ENABLED != 'true';
+#                          IGNORED when subscriptions are on (per-wallet keys)
 #   SUBSCRIPTION_ENABLED   per-wallet SGW subscription keys — the app checks
 #                          for EXACTLY 'true'; anything else leaves it off
 #   PAID_PLANS_ENABLED     paid-plan purchases (EXACTLY 'true'; testnet: off)
@@ -79,6 +81,23 @@ for flag in SUBSCRIPTION_ENABLED PAID_PLANS_ENABLED; do
   esac
 done
 
+# ── AGGREGATOR_API_KEY requirement (conditional on subscriptions) ─────────────
+# The two oracle-key modes are mutually exclusive (src/sdk/oracleKey.ts):
+#   Subscriptions ON  → the per-wallet SGW key is the oracle credential and the
+#                       static AGGREGATOR_API_KEY is IGNORED (not required).
+#   Subscriptions OFF → AGGREGATOR_API_KEY is the ONLY oracle credential, so it
+#                       is REQUIRED — without it the app has no key to sign L3
+#                       state transitions; fail closed rather than ship a wallet
+#                       that can't send.
+if [ "${SUBSCRIPTION_ENABLED-}" = true ]; then
+  [ -n "${AGGREGATOR_API_KEY-}" ] && \
+    log "NOTE: AGGREGATOR_API_KEY is set but ignored — SUBSCRIPTION_ENABLED=true uses per-wallet keys."
+elif [ -z "${AGGREGATOR_API_KEY-}" ]; then
+  log "ERROR: AGGREGATOR_API_KEY is empty and SUBSCRIPTION_ENABLED is not 'true' —"
+  log "       refusing to start (the app would have no aggregator key to send with)."
+  exit 1
+fi
+
 # ── Build the substitution program ───────────────────────────────────────────
 # Escape the replacement for a sed `s|...|...|` command: backslash, the `|`
 # delimiter, and `&` (whole-match backreference) are the only specials.
@@ -130,7 +149,8 @@ log "wrote $WEBROOT/runtime-config.js"
 
 # Visibility: warn (don't fail) when a public var is unset — it substitutes to
 # an empty string, which is almost always an operator mistake worth seeing.
-for v in SPHERE_API_URL DEV_PORTAL_URL AGGREGATOR_API_KEY; do
+# (AGGREGATOR_API_KEY is handled by the conditional requirement above, not here.)
+for v in SPHERE_API_URL DEV_PORTAL_URL; do
   eval "val=\${$v-}"
   [ -z "$val" ] && log "WARNING: \$$v is unset; substituting empty string"
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,14 @@ services:
       WALLET_API_URL: https://wallet-api.staging.unicity.network
       REQUIRE_WALLET_API: "true"
       DEV_PORTAL_URL: https://developers.staging.unicity.network/
+      # Required only while subscriptions are OFF (below); ignored when they're
+      # on. With SUBSCRIPTION_ENABLED=false the container refuses to start
+      # without it.
       AGGREGATOR_API_KEY: sk_ddc3cfcc001e4a28ac3fad7407f99590
       # Subscriptions (SGW) ship dormant; set exactly "true" to turn on.
       # The SGW base URL needs no config — the app derives it from the SDK's
       # per-network aggregator gateway and calls it directly (CORS-enabled;
-      # unicitynetwork/aggregator-subscription#57).
+      # unicitynetwork/aggregator-subscription#57). When on, the per-wallet SGW
+      # key replaces AGGREGATOR_API_KEY (which is then ignored).
       SUBSCRIPTION_ENABLED: "false"
       PAID_PLANS_ENABLED: "false"

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -627,10 +627,10 @@ export function useOnboardingFlow(): UseOnboardingFlowReturn {
         // applySubscriptionKey does) would flip walletExists to true and
         // unmount CreateWalletFlow before the capabilities screen renders.
         // The stored key becomes the ACTIVE oracle key on the SDK's next
-        // initialize() (page reload / re-init); until then the env
-        // VITE_AGGREGATOR_API_KEY remains the Phase-1 fallback. (Phase 5
-        // will move provisioning ahead of the nametag mint so the key is
-        // used from the first init.)
+        // initialize() (which the finalize flow triggers before any send). With
+        // subscriptions on the env key is NOT a fallback (oracleKey.ts ignores
+        // it), so the pre-reinit oracle simply carries no key — fine, because
+        // no L3 send happens on the onboarding screens.
         setStoredSubscriptionKey(result.apiKey);
         // Durable per-identity copy; non-fatal if it fails (cache still set).
         await saveWalletKey(active, network, result.apiKey).catch(() => {});

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -129,10 +129,12 @@ function buildProviders(network: NetworkType, apiKey?: string): SphereAppProvide
   const base = createBrowserProviders({
     network,
     // v2 token engine: aggregator URL + trust base come from the network
-    // preset; the apiKey is the resolved per-wallet subscription key when
-    // provided, else the static env key (non-secret on testnet2, migration
-    // fallback).
-    oracle: { apiKey: apiKey ?? import.meta.env.VITE_AGGREGATOR_API_KEY },
+    // preset; `apiKey` is already fully resolved by getActiveOracleApiKey()
+    // (per-wallet subscription key when subscriptions are on, else the static
+    // env key when off). Do NOT add an `?? env` fallback here — that would
+    // resurrect VITE_AGGREGATOR_API_KEY while subscriptions are enabled, which
+    // must ignore it entirely (see src/sdk/oracleKey.ts).
+    oracle: { apiKey },
     price: { platform: 'coingecko', baseUrl: COINGECKO_BASE_URL, cacheTtlMs: 5 * 60_000 },
     groupChat: true,
     market: true,

--- a/src/sdk/oracleKey.ts
+++ b/src/sdk/oracleKey.ts
@@ -1,7 +1,14 @@
 /**
- * Resolves which aggregator API key the SDK oracle should use:
- * the per-wallet subscription key when the feature is enabled and one exists,
- * otherwise the static build-time env key (migration fallback).
+ * Resolves which aggregator API key the SDK oracle should use.
+ *
+ * The two modes are mutually exclusive — the static env key
+ * (VITE_AGGREGATOR_API_KEY) and the per-wallet subscription key are NEVER
+ * both in play:
+ * - Subscriptions ON: the per-wallet subscription key is the ONLY source. The
+ *   env key is completely ignored — even before a key is provisioned we return
+ *   undefined rather than fall back to it (provisioning runs before any send).
+ * - Subscriptions OFF: the static env key is the source (and is required at
+ *   deploy time — deploy/runtime-config.sh fails closed without it).
  */
 import { getStoredSubscriptionKey } from '../config/storageKeys';
 import { SUBSCRIPTION_ENABLED } from '../config/subscription';
@@ -11,7 +18,7 @@ export function resolveOracleApiKey(opts: {
   envKey: string | undefined;
   subscriptionEnabled: boolean;
 }): string | undefined {
-  if (opts.subscriptionEnabled && opts.storedKey) return opts.storedKey;
+  if (opts.subscriptionEnabled) return opts.storedKey ?? undefined;
   return opts.envKey ?? undefined;
 }
 

--- a/tests/unit/sdk/oracleKey.test.ts
+++ b/tests/unit/sdk/oracleKey.test.ts
@@ -5,13 +5,16 @@ describe('resolveOracleApiKey', () => {
   it('uses the per-wallet key when enabled and present', () => {
     expect(resolveOracleApiKey({ storedKey: 'key_sub', envKey: 'sk_env', subscriptionEnabled: true })).toBe('key_sub');
   });
-  it('falls back to the env key when no stored key', () => {
-    expect(resolveOracleApiKey({ storedKey: null, envKey: 'sk_env', subscriptionEnabled: true })).toBe('sk_env');
+  it('IGNORES the env key when subscriptions are on, even with no stored key', () => {
+    // The env key must be completely unused while subscriptions are enabled —
+    // return undefined (provisioning sets the key before any send), never fall
+    // back to VITE_AGGREGATOR_API_KEY.
+    expect(resolveOracleApiKey({ storedKey: null, envKey: 'sk_env', subscriptionEnabled: true })).toBeUndefined();
   });
-  it('ignores the stored key when the flag is off', () => {
+  it('uses the env key when the flag is off (ignoring any stored key)', () => {
     expect(resolveOracleApiKey({ storedKey: 'key_sub', envKey: 'sk_env', subscriptionEnabled: false })).toBe('sk_env');
   });
-  it('returns undefined when nothing is available', () => {
-    expect(resolveOracleApiKey({ storedKey: null, envKey: undefined, subscriptionEnabled: true })).toBeUndefined();
+  it('returns undefined when nothing is available (flag off, no env key)', () => {
+    expect(resolveOracleApiKey({ storedKey: null, envKey: undefined, subscriptionEnabled: false })).toBeUndefined();
   });
 });

--- a/tests/unit/sdk/oracleKey.test.ts
+++ b/tests/unit/sdk/oracleKey.test.ts
@@ -5,7 +5,7 @@ describe('resolveOracleApiKey', () => {
   it('uses the per-wallet key when enabled and present', () => {
     expect(resolveOracleApiKey({ storedKey: 'key_sub', envKey: 'sk_env', subscriptionEnabled: true })).toBe('key_sub');
   });
-  it('IGNORES the env key when subscriptions are on, even with no stored key', () => {
+  it('ignores the env key when subscriptions are on, even with no stored key', () => {
     // The env key must be completely unused while subscriptions are enabled —
     // return undefined (provisioning sets the key before any send), never fall
     // back to VITE_AGGREGATOR_API_KEY.


### PR DESCRIPTION
Makes the static aggregator key and the per-wallet subscription key **strictly mutually exclusive**, per the intended model.

Before this, `VITE_AGGREGATOR_API_KEY` was effectively required (Docker warned if unset) and was still used as a fallback even with subscriptions enabled — in two places: `resolveOracleApiKey` (when no key was provisioned yet) and, independently, `SphereProvider.buildProviders` (`apiKey ?? import.meta.env.VITE_AGGREGATOR_API_KEY`), which resurrected the env key unconditionally.

## New behavior

| `SUBSCRIPTION_ENABLED` | `AGGREGATOR_API_KEY` | Oracle key | Docker |
|---|---|---|---|
| `true` | (ignored) | per-wallet SGW key, or none until provisioned | not required; logs a NOTE if set |
| not `true` | **required** | the env key | **fail-closed** if missing |

- **App** (`oracleKey.ts`): when subscriptions are on, `resolveOracleApiKey` returns the stored subscription key or `undefined` — it never falls back to the env key. Removed the second, bypassing `?? env` fallback in `buildProviders`. `VITE_AGGREGATOR_API_KEY` is now read in exactly one place.
- **Docker** (`deploy/runtime-config.sh`): `AGGREGATOR_API_KEY` is required only when `SUBSCRIPTION_ENABLED != 'true'` — the container refuses to start without it (otherwise the app has no key to sign L3 state transitions). When subs are on it's ignored (NOTE logged if set). Dropped from the unconditional unset-warning loop. The #351 wallet-api check still fires first.

## Verification

- 228 unit tests (oracleKey cases updated: subs-on + no stored key now expects `undefined`); `tsc`, ESLint, shell syntax all clean.
- 8 sandbox cases of `runtime-config.sh` + **4 real container smokes**: fail-closed on subs-off/no-key, starts on subs-off/key, starts on subs-on/no-key, starts + ignored-NOTE on subs-on/key; plus #351 precedence confirmed in-container.
- `docker-validate.yml` extended: the substitution smoke now proves subs-on starts with no `AGGREGATOR_API_KEY`, and a new step asserts both required-when-off and ignored-when-on.