### PR TITLE
fix(subscription): close the keyless L3-send window (gate sends until the key is on the oracle)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.5",
+        "@unicitylabs/sphere-sdk": "0.11.6",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -1344,13 +1344,13 @@
       "optional": true
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.20.tgz",
-      "integrity": "sha512-sPz+CvDWPDb+O8xYsueXDdrV6Kf7PciNEYvcCjOR/VqM0iHwzC7aaM0xPiQqrUDj1nggswbY/E/vNZYJ4aCQaA==",
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
+      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.2.4",
+        "@libp2p/interface": "^3.2.5",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "multiformats": "^14.0.0",
@@ -1360,16 +1360,16 @@
       }
     },
     "node_modules/@libp2p/crypto/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
     "node_modules/@libp2p/interface": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.4.tgz",
-      "integrity": "sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.5.tgz",
+      "integrity": "sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
@@ -1382,20 +1382,20 @@
       }
     },
     "node_modules/@libp2p/interface/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
     "node_modules/@libp2p/logger": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.9.tgz",
-      "integrity": "sha512-hjuF81KSt9dWNPJZcdJ4SHEuygMLHrPZVTGNzCWu+2jxpJqOHWy9CJS8llLH7pgbDtlq4jJ4uuqihCR5Gjo4gA==",
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
+      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/interface": "^3.2.4",
+        "@libp2p/interface": "^3.2.5",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "multiformats": "^14.0.0",
@@ -1425,36 +1425,36 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.11.tgz",
-      "integrity": "sha512-p2Sw8y12gcrmDYGTrbvGQzMhM7ypquCfQX5WdhitI0+ArTSRHHXt7ozdpUWzcq7CNaK5r2q6FIbpz9Yxywg9Hw==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
+      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
-        "@libp2p/crypto": "^5.1.20",
-        "@libp2p/interface": "^3.2.4",
+        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/peer-id/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
     "node_modules/@multiformats/dns": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.13.tgz",
-      "integrity": "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "dependencies": {
@@ -1463,17 +1463,7 @@
         "hashlru": "^2.3.0",
         "p-queue": "^9.0.0",
         "progress-events": "^1.0.0",
-        "uint8arrays": "^5.0.2"
-      }
-    },
-    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
-      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
-      "license": "Apache-2.0 OR MIT",
-      "optional": true,
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@multiformats/multiaddr": {
@@ -1490,9 +1480,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },
@@ -2946,9 +2936,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.5.tgz",
-      "integrity": "sha512-RNh7VW5NcIS7ra6H3gRZCJpNQroURwJWP+QTO9tdSypnO2VDQTMBTnZPCKu7kn4fMKhUdDEsHAT7gpvA9CMXUg==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.6.tgz",
+      "integrity": "sha512-clnoYTH79/z2m6YYU5MRBbnBr1n4Y+FUxNJH2sVv1pEZ0mpktyz5l8lJyQBr2n7GuZxglDQioK7BIsrW6HkZdw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
@@ -3811,9 +3801,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
-      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
+      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -5534,9 +5524,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.7.tgz",
-      "integrity": "sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.8.tgz",
+      "integrity": "sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==",
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -6208,9 +6198,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
+      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7516,9 +7506,9 @@
       }
     },
     "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.0.tgz",
-      "integrity": "sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
       "license": "Apache-2.0 OR MIT",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.5",
+    "@unicitylabs/sphere-sdk": "0.11.6",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -9,6 +9,7 @@ import { useConnectContext } from './ConnectContext';
 import { useSendDM } from '../../sdk/hooks/comms/useSendDM';
 import { getErrorMessage } from '../../sdk/errors';
 import { useSphereContext } from '../../sdk';
+import { useSubscriptionKeyGuard } from '../../sdk/hooks/subscription';
 
 /** Intents this wallet actually implements. Anything else is rejected cleanly. */
 const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint', 'receive']);
@@ -69,6 +70,7 @@ function validateIntent(action: string, params: Record<string, unknown>): Intent
 export function ConnectIntentHandler() {
   const { pendingIntent, resolveIntent, rejectIntent, registerAutoIntent } = useConnectContext();
   const { sphere } = useSphereContext();
+  const { ready: subscriptionKeyReady } = useSubscriptionKeyGuard();
   const { sendDM, isLoading: isSendingDM } = useSendDM();
   const [dmError, setDmError] = useState<string | null>(null);
   const [autoApproveDM, setAutoApproveDM] = useState(false);
@@ -308,6 +310,12 @@ export function ConnectIntentHandler() {
       }
       if (amountBig <= 0n) {
         rejectIntent(ERROR_CODES.INVALID_PARAMS, 'amount must be greater than zero');
+        return;
+      }
+      // Mint is a certification_request — refuse until the subscription key is on
+      // the oracle (else it 401s in the provisioning window). Reject gracefully.
+      if (!subscriptionKeyReady) {
+        rejectIntent(ERROR_CODES.INTERNAL_ERROR, 'Subscription is still being set up — try again in a moment');
         return;
       }
 

--- a/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
+++ b/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
-import { isSubscriptionKeyReady, SubscriptionNotReadyError } from '../../../../sdk/subscription/keyStatus';
-import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
+import { useSubscriptionKeyGuard } from '../../../../sdk/hooks/subscription';
 import type { IncomingPaymentRequest as SDKPaymentRequest } from '@unicitylabs/sphere-sdk';
 
 export const PaymentRequestStatus = {
@@ -71,7 +70,8 @@ function bridgeRequest(sdk: SDKPaymentRequest): IncomingPaymentRequest {
  *   send is logged by the SDK, never reported as a payment failure.
  */
 export const useIncomingPaymentRequests = () => {
-    const { sphere, subscriptionKeyStatus } = useSphereContext();
+    const { sphere } = useSphereContext();
+    const { assertReady: requireSubscriptionKey } = useSubscriptionKeyGuard();
     const [requests, setRequests] = useState<IncomingPaymentRequest[]>([]);
 
     const refresh = useCallback(() => {
@@ -134,18 +134,15 @@ export const useIncomingPaymentRequests = () => {
     const pay = useCallback(async (request: IncomingPaymentRequest) => {
         if (!sphere) return;
         // Paying a request routes through payments.send() (certification) — same
-        // keyless-send window as a normal send. Refuse until the subscription key
-        // is on the oracle, or this bypasses the gate and 401s. handleAction in
-        // PaymentRequestModal surfaces the thrown message per-request.
-        if (SUBSCRIPTION_ENABLED && !isSubscriptionKeyReady(subscriptionKeyStatus)) {
-            throw new SubscriptionNotReadyError(subscriptionKeyStatus === 'failed' ? 'failed' : 'provisioning');
-        }
+        // keyless-send window as a normal send, so it uses the shared readiness
+        // guard. handleAction in PaymentRequestModal surfaces the thrown message.
+        requireSubscriptionKey();
         try {
             await sphere.payments.payPaymentRequest(request.id);
         } finally {
             refresh();
         }
-    }, [sphere, subscriptionKeyStatus, refresh]);
+    }, [sphere, requireSubscriptionKey, refresh]);
 
     const clearProcessed = useCallback(() => {
         if (!sphere) return;

--- a/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
+++ b/src/components/wallet/L3/hooks/useIncomingPaymentRequests.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
+import { isSubscriptionKeyReady, SubscriptionNotReadyError } from '../../../../sdk/subscription/keyStatus';
+import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
 import type { IncomingPaymentRequest as SDKPaymentRequest } from '@unicitylabs/sphere-sdk';
 
 export const PaymentRequestStatus = {
@@ -69,7 +71,7 @@ function bridgeRequest(sdk: SDKPaymentRequest): IncomingPaymentRequest {
  *   send is logged by the SDK, never reported as a payment failure.
  */
 export const useIncomingPaymentRequests = () => {
-    const { sphere } = useSphereContext();
+    const { sphere, subscriptionKeyStatus } = useSphereContext();
     const [requests, setRequests] = useState<IncomingPaymentRequest[]>([]);
 
     const refresh = useCallback(() => {
@@ -131,12 +133,19 @@ export const useIncomingPaymentRequests = () => {
 
     const pay = useCallback(async (request: IncomingPaymentRequest) => {
         if (!sphere) return;
+        // Paying a request routes through payments.send() (certification) — same
+        // keyless-send window as a normal send. Refuse until the subscription key
+        // is on the oracle, or this bypasses the gate and 401s. handleAction in
+        // PaymentRequestModal surfaces the thrown message per-request.
+        if (SUBSCRIPTION_ENABLED && !isSubscriptionKeyReady(subscriptionKeyStatus)) {
+            throw new SubscriptionNotReadyError(subscriptionKeyStatus === 'failed' ? 'failed' : 'provisioning');
+        }
         try {
             await sphere.payments.payPaymentRequest(request.id);
         } finally {
             refresh();
         }
-    }, [sphere, refresh]);
+    }, [sphere, subscriptionKeyStatus, refresh]);
 
     const clearProcessed = useCallback(() => {
         if (!sphere) return;

--- a/src/components/wallet/L3/modals/SendModal.tsx
+++ b/src/components/wallet/L3/modals/SendModal.tsx
@@ -8,6 +8,7 @@ import { getErrorMessage } from '../../../../sdk/errors';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
 import { useUtilization } from '../../../../sdk/hooks/subscription';
 import { QuotaBlockedError, SEND_OPS_HEADROOM } from '../../../../sdk/quotaGate';
+import { isSubscriptionKeyReady } from '../../../../sdk/subscription/keyStatus';
 import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
 import { useUpgrade } from '../../../upgrade';
 import { WalletScreen } from '../../ui/WalletScreen';
@@ -23,9 +24,13 @@ interface SendModalProps {
 export function SendModal({ isOpen, onClose }: SendModalProps) {
   const { assets: sdkAssets } = useAssets();
   const { transfer, isLoading: isTransferring } = useTransfer();
-  const { sphere } = useSphereContext();
+  const { sphere, subscriptionKeyStatus } = useSphereContext();
   const { openUpgrade } = useUpgrade();
   const utilization = useUtilization();
+
+  // Subscriptions on but the per-wallet key isn't on the oracle yet — a send
+  // now would go out keyless (→ 401). Disable Send until it's ready.
+  const subsNotReady = SUBSCRIPTION_ENABLED && !isSubscriptionKeyReady(subscriptionKeyStatus);
 
   const assets = sdkAssets;
 
@@ -442,6 +447,14 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
 
               {recipientError && !quotaBlocked && <p className="text-red-500 text-sm mb-4 text-center">{recipientError}</p>}
 
+              {subsNotReady && !quotaBlocked && (
+                <p className="text-neutral-500 dark:text-white/45 text-xs mb-4 text-center">
+                  {subscriptionKeyStatus === 'failed'
+                    ? "Couldn't set up your subscription. Reload the app to retry."
+                    : 'Setting up your subscription — one moment…'}
+                </p>
+              )}
+
               <div className="flex gap-3">
                 <button
                   onClick={handleClose}
@@ -451,7 +464,7 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
                 </button>
                 <button
                   onClick={handleSend}
-                  disabled={isTransferring}
+                  disabled={isTransferring || subsNotReady}
                   className="flex-1 py-4 bg-orange-500 hover:bg-orange-600 dark:bg-brand-orange dark:hover:bg-brand-orange-dark text-white font-bold font-mono rounded-full transition-colors disabled:opacity-50"
                 >
                   Send

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -626,11 +626,12 @@ export function useOnboardingFlow(): UseOnboardingFlowReturn {
         // Persist ONLY — do NOT re-init here. Re-initializing now (like
         // applySubscriptionKey does) would flip walletExists to true and
         // unmount CreateWalletFlow before the capabilities screen renders.
-        // The stored key becomes the ACTIVE oracle key on the SDK's next
-        // initialize() (which the finalize flow triggers before any send). With
-        // subscriptions on the env key is NOT a fallback (oracleKey.ts ignores
-        // it), so the pre-reinit oracle simply carries no key — fine, because
-        // no L3 send happens on the onboarding screens.
+        // The stored key becomes the ACTIVE oracle key when finalizeWallet()
+        // re-inits on wallet entry (SphereProvider) — which happens before any
+        // send. With subscriptions on the env key is NOT a fallback
+        // (oracleKey.ts ignores it), so until that re-init the oracle carries no
+        // key; that's fine because the send gate blocks sends until it lands and
+        // no L3 send happens on the onboarding screens anyway.
         setStoredSubscriptionKey(result.apiKey);
         // Durable per-identity copy; non-fatal if it fails (cache still set).
         await saveWalletKey(active, network, result.apiKey).catch(() => {});

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -2,6 +2,7 @@ import { createContext } from 'react';
 import type { Sphere, PeerInfo, InitProgress } from '@unicitylabs/sphere-sdk';
 import type { BrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 import type { WalletApiProviderExtras } from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
+import type { SubscriptionKeyStatus } from './subscription/keyStatus';
 
 /**
  * The app's provider bundle: the browser base, plus — when the asset path
@@ -51,6 +52,14 @@ export interface SphereContextValue {
 
   /** Persist a per-wallet subscription API key and re-init the SDK oracle with it. */
   applySubscriptionKey: (apiKey: string, opts?: { walletWide?: boolean }) => Promise<void>;
+
+  /**
+   * Readiness of the subscription key on the LIVE oracle. When subscriptions
+   * are on, the send path must refuse until this is `'ready'` — otherwise a
+   * send races the async provisioning and goes out with no aggregator key
+   * (→ 401). `'not-required'` when subscriptions are disabled.
+   */
+  subscriptionKeyStatus: SubscriptionKeyStatus;
 
   /**
    * True when the asset path rides the wallet-api backend (S4 composition).

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -29,6 +29,7 @@ import { getActiveOracleApiKey } from './oracleKey';
 import { SUBSCRIPTION_ENABLED } from '../config/subscription';
 import { resolveActiveKey, saveWalletKey, saveAddressKey, loadWalletKey } from './subscription/keyVault';
 import { isPaidPlan } from './subscription/usage';
+import type { SubscriptionKeyStatus } from './subscription/keyStatus';
 import { provisionOrRecoverKey, getUtilization } from '../services/subscriptionApi';
 
 const COINGECKO_BASE_URL = import.meta.env.DEV
@@ -192,6 +193,11 @@ export function SphereProvider({
   const [ipfsEnabled, setIpfsEnabled] = useState(isIpfsEnabled);
   const [isDiscoveringAddresses, setIsDiscoveringAddresses] = useState(false);
   const [initProgress, setInitProgress] = useState<InitProgress | null>(null);
+  // Readiness of the subscription key on the live oracle — gates the send path
+  // so a send can't race async provisioning and go out keyless (→ 401).
+  const [subscriptionKeyStatus, setSubscriptionKeyStatus] = useState<SubscriptionKeyStatus>(
+    SUBSCRIPTION_ENABLED ? 'provisioning' : 'not-required',
+  );
   const sphereRef = useRef<Sphere | null>(null);
 
   const initialize = useCallback(async (attempt = 0, skipLoading = false) => {
@@ -205,7 +211,11 @@ export function SphereProvider({
       if (!skipLoading) setIsLoading(true);
       setError(null);
 
-      const browserProviders = buildProviders(network, getActiveOracleApiKey());
+      // Snapshot the resolved oracle key: when subscriptions are on it is the
+      // stored per-wallet key (or undefined if not provisioned yet), and it
+      // decides whether the live oracle is 'ready' vs still 'provisioning'.
+      const oracleApiKey = getActiveOracleApiKey();
+      const browserProviders = buildProviders(network, oracleApiKey);
       // Debug logging is off by default; enable at runtime via: logger.configure({ debug: true })
       setProviders(browserProviders);
 
@@ -234,6 +244,15 @@ export function SphereProvider({
         sphereRef.current = instance;
         setSphere(instance);
 
+        // Readiness for the send gate: 'ready' iff this oracle was built WITH a
+        // subscription key. With no key yet we provision below and stay
+        // 'provisioning' until the keyed re-init lands (covers the re-init gap,
+        // not just "no key in storage"). Subs off → the env key is the oracle
+        // credential, so sends are always allowed ('not-required').
+        setSubscriptionKeyStatus(
+          !SUBSCRIPTION_ENABLED ? 'not-required' : oracleApiKey ? 'ready' : 'provisioning',
+        );
+
         // Subscription key resolution (INDIVIDUAL per address by default;
         // inherit is opt-in — see sdk/subscription/keyVault.ts). Reconciles
         // the boot cache (a single global slot — config/storageKeys.ts);
@@ -243,7 +262,10 @@ export function SphereProvider({
         // - any other address with no key → give it its OWN free key, EXCEPT
         //   when index 0 is on a PAID plan and no choice was made yet, where a
         //   one-time prompt first offers to share that paid plan (inherit).
-        // The env-key fallback keeps the wallet working if provisioning fails.
+        // NOTE: there is NO env-key fallback while subscriptions are on (#418
+        // removed it) — if provisioning fails on the initial load the oracle has
+        // no key, so the send gate blocks (status → 'failed') rather than let a
+        // send go out keyless (→ 401).
         if (SUBSCRIPTION_ENABLED) {
           // `reinit` is only allowed on the initial load — NEVER on a live
           // address switch: initialize(0, true) destroys+rebuilds the whole
@@ -267,7 +289,11 @@ export function SphereProvider({
                 : saveAddressKey(instance, network, result.apiKey)); // both set the boot cache
               if (reinit) void initialize(0, true);
             } catch (err) {
-              console.warn('subscription auto-provisioning failed; using fallback key', err);
+              // On the initial load (reinit) a failure means the oracle has no
+              // key at all — mark it so the send gate blocks. On a live switch a
+              // bearer key is already loaded, so leave the status untouched.
+              if (reinit) setSubscriptionKeyStatus('failed');
+              console.warn('subscription auto-provisioning failed; sends are gated until it recovers', err);
             }
           };
           const reconcileSubscriptionKey = async (initialLoad: boolean) => {
@@ -572,7 +598,15 @@ export function SphereProvider({
       sendWelcomeDM(importedSphere);
     }
     setWalletExists(true);
-  }, [providers]);
+    // The onboarding oracle was built KEYLESS — the per-wallet subscription key
+    // is provisioned only after the wallet/identity exists, so the created
+    // instance never carried it. Re-init once here (the "next initialize()" the
+    // onboarding flow always relied on) so the oracle picks up the stored key
+    // and the send gate resolves 'provisioning' → 'ready' (or retries + 'failed'
+    // if provisioning never succeeded). Without this the send gate would stay
+    // blocked until a manual reload. skipLoading: the wallet UI is already up.
+    if (SUBSCRIPTION_ENABLED) void initialize(0, true);
+  }, [providers, initialize]);
 
   const toggleIpfs = useCallback(() => {
     const next = !isIpfsEnabled();
@@ -623,6 +657,7 @@ export function SphereProvider({
     ipfsEnabled,
     toggleIpfs,
     applySubscriptionKey,
+    subscriptionKeyStatus,
     walletApiEnabled: isWalletApiEnabled(),
   };
 

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -45,7 +45,6 @@ import type {
 import {
   clearAllSphereData,
   getOrCreateWalletApiDeviceId,
-  getStoredSubscriptionKey,
   setStoredSubscriptionKey,
   STORAGE_KEYS,
 } from '../config/storageKeys';
@@ -199,6 +198,153 @@ export function SphereProvider({
     SUBSCRIPTION_ENABLED ? 'provisioning' : 'not-required',
   );
   const sphereRef = useRef<Sphere | null>(null);
+  // Subscription-key reconcile bookkeeping (SUBSCRIPTION_ENABLED only):
+  // - subKeyGenRef: monotonic generation so only the LATEST reconcile (initial
+  //   load or a live address switch) may apply its key + flip status; stale
+  //   overlapping reconciles abort at their generation check (no last-writer-wins
+  //   drift when the user switches addresses quickly).
+  // - appliedOracleKeyRef: the key the LIVE token engine actually carries. The
+  //   send gate flips 'ready' off THIS — never the boot-cache slot, which is
+  //   written ahead of the async engine rebuild — so 'ready' can't race an
+  //   in-flight re-key and open a keyless-send window.
+  const subKeyGenRef = useRef(0);
+  const appliedOracleKeyRef = useRef<string | null>(null);
+  // Serialize live oracle re-keys so overlapping engine rebuilds from rapid
+  // address switches COMMIT in order — the live engine ends on the latest
+  // requested key, matching appliedOracleKeyRef (no wrong-key drift). A key whose
+  // generation was already superseded is skipped. This chain holds ONLY the fast,
+  // local setOracleApiKey rebuild; the (possibly hanging) network provisioning
+  // stays outside it, so an SGW stall can never block re-keying.
+  const applyChainRef = useRef<Promise<void>>(Promise.resolve());
+  const applyOracleKey = useCallback(
+    (instance: Sphere, key: string, gen: number): Promise<void> => {
+      const next = applyChainRef.current
+        .then(async () => {
+          if (gen !== subKeyGenRef.current) return; // superseded before we ran
+          if (key === appliedOracleKeyRef.current) return; // engine already carries it
+          await instance.setOracleApiKey(key);
+          if (gen !== subKeyGenRef.current) return; // superseded during the rebuild
+          appliedOracleKeyRef.current = key;
+        })
+        .catch(() => {});
+      applyChainRef.current = next;
+      return next;
+    },
+    [],
+  );
+
+  // Wire the per-wallet subscription (oracle) key onto a LIVE Sphere instance
+  // WITHOUT a full re-init: resolve/provision the key, apply it to the live
+  // oracle via setOracleApiKey, drive the send-gate status, and attach the
+  // identity:changed listener that re-keys on a live address switch. Shared by
+  // initialize() (existing wallet) AND finalizeWallet() (freshly onboarded
+  // wallet) so BOTH get per-address reconcile + provisioning retry + terminal
+  // status — not just a one-shot re-key. `builtWithKey` is the key the instance's
+  // oracle was constructed with (undefined for the keyless onboarding oracle);
+  // it seeds appliedOracleKeyRef so an unchanged key skips a needless rebuild.
+  const setupSubscriptionKey = useCallback(
+    (instance: Sphere, builtWithKey: string | undefined) => {
+      if (!SUBSCRIPTION_ENABLED) return;
+      appliedOracleKeyRef.current = builtWithKey ?? null;
+
+      // Apply a resolved key to the live oracle (via the serialized apply chain),
+      // then mark the gate ready — but only while this reconcile is still the
+      // latest (gen guard) and only once the engine actually carries THIS key
+      // (appliedOracleKeyRef), never off the boot-cache slot alone.
+      const applyResolved = async (key: string, gen: number) => {
+        if (gen !== subKeyGenRef.current) return;
+        setStoredSubscriptionKey(key);
+        await applyOracleKey(instance, key, gen);
+        if (gen !== subKeyGenRef.current) return;
+        if (appliedOracleKeyRef.current === key) {
+          setSubscriptionKeyStatus('ready');
+        } else if (appliedOracleKeyRef.current === null) {
+          // The engine rebuild did not land and the oracle is still keyless →
+          // block the send gate (terminal 'failed') rather than leave it stuck
+          // 'provisioning'. A non-null ref means a valid bearer key is loaded, so
+          // leave the status untouched.
+          setSubscriptionKeyStatus('failed');
+        }
+      };
+
+      const provisionOwn = async (scope: 'wallet' | 'address', gen: number) => {
+        try {
+          const result = await provisionOrRecoverKey(instance, { scope });
+          if (gen !== subKeyGenRef.current) return;
+          await (scope === 'wallet'
+            ? saveWalletKey(instance, network, result.apiKey)
+            : saveAddressKey(instance, network, result.apiKey)); // both set the boot cache
+          await applyOracleKey(instance, result.apiKey, gen);
+          if (gen !== subKeyGenRef.current) return;
+          if (appliedOracleKeyRef.current === result.apiKey) {
+            setSubscriptionKeyStatus('ready');
+          } else if (appliedOracleKeyRef.current === null) {
+            // Applying the key to the engine did not land and it is still keyless →
+            // block the send gate (terminal 'failed') rather than leave it stuck.
+            setSubscriptionKeyStatus('failed');
+          }
+        } catch (err) {
+          if (gen !== subKeyGenRef.current) return;
+          // Provisioning failed. Block the send gate ('failed') while the oracle is
+          // still keyless (initial load, OR a live switch that superseded an initial
+          // reconcile which never keyed the engine). A non-null ref means a valid
+          // bearer key is already loaded, so leave the status untouched (still 'ready').
+          if (appliedOracleKeyRef.current === null) setSubscriptionKeyStatus('failed');
+          console.warn('subscription auto-provisioning failed; sends are gated until it recovers', err);
+        }
+      };
+
+      // Reconciles the boot cache (a single global slot — config/storageKeys.ts)
+      // against the active address's resolved key:
+      // - resolved 'own'/'wallet' with a key → use it;
+      // - index 0 with no key yet → provision the wallet (index-0) free key;
+      // - any other address with no key → give it its OWN free key, EXCEPT when
+      //   index 0 is on a PAID plan and undecided, where a one-time prompt first
+      //   offers to share that paid plan (inherit).
+      const reconcileSubscriptionKey = async (initialLoad: boolean) => {
+        const gen = ++subKeyGenRef.current;
+        const resolved = await resolveActiveKey(instance, network);
+        if (gen !== subKeyGenRef.current) return;
+        if (resolved.key) {
+          await applyResolved(resolved.key, gen);
+          return;
+        }
+        // needs-own: index 0 → wallet key; else this address's own key.
+        const isRoot = instance.identity?.chainPubkey === getPublicKey(instance.deriveAddress(0).privateKey);
+        if (isRoot) {
+          await provisionOwn('wallet', gen);
+          return;
+        }
+        // Offer inheriting index 0's plan only when it's PAID and undecided
+        // (only on a live switch — never during the initial load).
+        if (!initialLoad && resolved.undecided) {
+          const walletKey = await loadWalletKey(instance, network);
+          if (gen !== subKeyGenRef.current) return;
+          if (walletKey) {
+            try {
+              if (isPaidPlan((await getUtilization(walletKey)).activeUntil)) {
+                if (gen !== subKeyGenRef.current) return;
+                window.dispatchEvent(new Event('subscription-address-prompt'));
+                return; // wait for the user's choice
+              }
+            } catch {
+              // metering unavailable → fall through to an own free key
+            }
+          }
+        }
+        await provisionOwn('address', gen);
+      };
+
+      void reconcileSubscriptionKey(true).catch(() => {});
+      // Re-resolve on a live address switch — the per-address key applies
+      // immediately via setOracleApiKey (no re-init, no reconnect). The listener
+      // dies with the instance on the next full re-init (instance.destroy()).
+      instance.on('identity:changed', () => {
+        void reconcileSubscriptionKey(false).catch(() => {});
+      });
+    },
+    [network, applyOracleKey],
+  );
 
   const initialize = useCallback(async (attempt = 0, skipLoading = false) => {
     try {
@@ -246,93 +392,19 @@ export function SphereProvider({
 
         // Readiness for the send gate: 'ready' iff this oracle was built WITH a
         // subscription key. With no key yet we provision below and stay
-        // 'provisioning' until the keyed re-init lands (covers the re-init gap,
-        // not just "no key in storage"). Subs off → the env key is the oracle
-        // credential, so sends are always allowed ('not-required').
+        // 'provisioning' until setupSubscriptionKey applies one (covers the whole
+        // provisioning gap, not just "no key in storage"). Subs off → the env key
+        // is the oracle credential, so sends are always allowed ('not-required').
         setSubscriptionKeyStatus(
           !SUBSCRIPTION_ENABLED ? 'not-required' : oracleApiKey ? 'ready' : 'provisioning',
         );
 
-        // Subscription key resolution (INDIVIDUAL per address by default;
-        // inherit is opt-in — see sdk/subscription/keyVault.ts). Reconciles
-        // the boot cache (a single global slot — config/storageKeys.ts);
-        // guarded so it only re-inits on a real difference, never in a loop.
-        // - resolved 'own'/'wallet' with a key → use it;
-        // - index 0 with no key yet → provision the wallet (index-0) free key;
-        // - any other address with no key → give it its OWN free key, EXCEPT
-        //   when index 0 is on a PAID plan and no choice was made yet, where a
-        //   one-time prompt first offers to share that paid plan (inherit).
-        // NOTE: there is NO env-key fallback while subscriptions are on (#418
-        // removed it) — if provisioning fails on the initial load the oracle has
-        // no key, so the send gate blocks (status → 'failed') rather than let a
-        // send go out keyless (→ 401).
-        if (SUBSCRIPTION_ENABLED) {
-          // `reinit` is only allowed on the initial load — NEVER on a live
-          // address switch: initialize(0, true) destroys+rebuilds the whole
-          // Sphere (transport + wallet-api realtime socket), which would flash
-          // "Reconnecting" on every switch. Keys are bearer tokens, so the
-          // active session sends fine on whatever key is loaded; the resolved
-          // per-address key is written to the vault + boot cache and takes
-          // effect on the next natural init (reload / network switch). Proper
-          // fix is a runtime oracle-key setter in the SDK (follow-up).
-          const applyResolved = async (key: string, reinit: boolean) => {
-            if (key !== getStoredSubscriptionKey()) {
-              setStoredSubscriptionKey(key);
-              if (reinit) void initialize(0, true);
-            }
-          };
-          const provisionOwn = async (scope: 'wallet' | 'address', reinit: boolean) => {
-            try {
-              const result = await provisionOrRecoverKey(instance, { scope });
-              await (scope === 'wallet'
-                ? saveWalletKey(instance, network, result.apiKey)
-                : saveAddressKey(instance, network, result.apiKey)); // both set the boot cache
-              if (reinit) void initialize(0, true);
-            } catch (err) {
-              // On the initial load (reinit) a failure means the oracle has no
-              // key at all — mark it so the send gate blocks. On a live switch a
-              // bearer key is already loaded, so leave the status untouched.
-              if (reinit) setSubscriptionKeyStatus('failed');
-              console.warn('subscription auto-provisioning failed; sends are gated until it recovers', err);
-            }
-          };
-          const reconcileSubscriptionKey = async (initialLoad: boolean) => {
-            const resolved = await resolveActiveKey(instance, network);
-            if (resolved.key) {
-              await applyResolved(resolved.key, initialLoad);
-              return;
-            }
-            // needs-own: index 0 → wallet key; else this address's own key.
-            const isRoot = instance.identity?.chainPubkey === getPublicKey(instance.deriveAddress(0).privateKey);
-            if (isRoot) {
-              await provisionOwn('wallet', initialLoad);
-              return;
-            }
-            // Offer inheriting index 0's plan only when it's PAID and undecided
-            // (only on a live switch — never during the initial load).
-            if (!initialLoad && resolved.undecided) {
-              const walletKey = await loadWalletKey(instance, network);
-              if (walletKey) {
-                try {
-                  if (isPaidPlan((await getUtilization(walletKey)).activeUntil)) {
-                    window.dispatchEvent(new Event('subscription-address-prompt'));
-                    return; // wait for the user's choice
-                  }
-                } catch {
-                  // metering unavailable → fall through to an own free key
-                }
-              }
-            }
-            await provisionOwn('address', initialLoad);
-          };
-          void reconcileSubscriptionKey(true).catch(() => {});
-          // Re-resolve on a live address switch (initialLoad=false → NO
-          // re-init, so no transport/realtime reconnect). The listener dies
-          // with the instance on the next re-init (instance.destroy()).
-          instance.on('identity:changed', () => {
-            void reconcileSubscriptionKey(false).catch(() => {});
-          });
-        }
+        // Wire the per-wallet subscription key onto this live instance: resolve /
+        // provision it, apply via setOracleApiKey (no re-init), drive the send-gate
+        // status, and attach the identity:changed re-key listener. Shared with
+        // finalizeWallet so onboarded wallets get the same reconcile + provisioning
+        // retry. Full algorithm in setupSubscriptionKey (defined above).
+        setupSubscriptionKey(instance, oracleApiKey);
         // Send welcome DMs after relay delivers historical messages (EOSE)
         {
           let welcomed = false;
@@ -381,7 +453,7 @@ export function SphereProvider({
       setInitProgress(null);
       setIsLoading(false);
     }
-  }, [network]);
+  }, [network, setupSubscriptionKey]);
 
   useEffect(() => {
     initialize();
@@ -598,15 +670,15 @@ export function SphereProvider({
       sendWelcomeDM(importedSphere);
     }
     setWalletExists(true);
-    // The onboarding oracle was built KEYLESS — the per-wallet subscription key
-    // is provisioned only after the wallet/identity exists, so the created
-    // instance never carried it. Re-init once here (the "next initialize()" the
-    // onboarding flow always relied on) so the oracle picks up the stored key
-    // and the send gate resolves 'provisioning' → 'ready' (or retries + 'failed'
-    // if provisioning never succeeded). Without this the send gate would stay
-    // blocked until a manual reload. skipLoading: the wallet UI is already up.
-    if (SUBSCRIPTION_ENABLED) void initialize(0, true);
-  }, [providers, initialize]);
+    // The onboarding oracle was built KEYLESS. Wire the subscription key onto this
+    // live instance exactly like initialize() does for an existing wallet: resolve
+    // / provision it + apply via setOracleApiKey (no full re-init), attach the
+    // identity:changed re-key listener, and drive the send gate to a terminal
+    // 'ready'/'failed'. (A bare setOracleApiKey here would skip the per-address
+    // re-key listener AND the provisioning retry — see #420 review.)
+    const inst = importedSphere ?? sphereRef.current;
+    if (inst) setupSubscriptionKey(inst, undefined);
+  }, [providers, setupSubscriptionKey]);
 
   const toggleIpfs = useCallback(() => {
     const next = !isIpfsEnabled();
@@ -620,6 +692,9 @@ export function SphereProvider({
     setStoredSubscriptionKey(apiKey);
     const instance = sphereRef.current;
     if (instance) {
+      // Supersede any in-flight reconcile (bump the generation) so a stale
+      // reconcile can't clobber this explicit, user-chosen key.
+      const gen = ++subKeyGenRef.current;
       // Bookkeeping (best-effort — the vault entry is a durability upgrade,
       // not a gate): while on the root address (or when explicitly asked) the
       // key becomes WALLET-wide; on any other address it becomes that
@@ -632,10 +707,14 @@ export function SphereProvider({
         ? saveWalletKey(instance, network, apiKey)
         : saveAddressKey(instance, network, apiKey)
       ).catch(() => {});
+      // Apply the new key to the LIVE oracle (serialized apply chain — no full
+      // re-init, rebuilds only the token engine). Flip 'ready' only once the
+      // engine actually carries it.
+      await applyOracleKey(instance, apiKey, gen);
+      if (gen !== subKeyGenRef.current) return; // a newer reconcile/apply superseded us
+      if (appliedOracleKeyRef.current === apiKey) setSubscriptionKeyStatus('ready');
     }
-    // Rebuild providers (oracle) with the new key and re-init the SDK.
-    await initialize(0, true);
-  }, [initialize, network]);
+  }, [network, applyOracleKey]);
 
   const value: SphereContextValue = {
     sphere,

--- a/src/sdk/hooks/payments/useTopUp.ts
+++ b/src/sdk/hooks/payments/useTopUp.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSphereContext } from '../core/useSphere';
+import { useSubscriptionKeyGuard } from '../subscription';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { TokenRegistry, parseTokenAmount } from '@unicitylabs/sphere-sdk';
 
@@ -42,11 +43,15 @@ const AMOUNTS: Record<string, number> = {
  */
 export function useTopUp(): UseTopUpReturn {
   const { sphere } = useSphereContext();
+  const { assertReady: requireSubscriptionKey } = useSubscriptionKeyGuard();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (): Promise<TopUpResult[]> => {
       if (!sphere) throw new Error('Wallet not initialized');
+      // Self-mint is a certification_request — gate it on the subscription key
+      // like a send, so it can't go out keyless in the provisioning window.
+      requireSubscriptionKey();
 
       const fungible = TokenRegistry.getInstance().getFungibleTokens();
       if (fungible.length === 0) {

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -3,6 +3,7 @@ import { useSphereContext } from '../core/useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { getErrorCode, isQuotaRateLimit, isGatewayAuthError } from '../../errors';
 import { checkSendQuota, QuotaBlockedError } from '../../quotaGate';
+import { isSubscriptionKeyReady, SubscriptionNotReadyError } from '../../subscription/keyStatus';
 import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
 import { useUpgrade, type UpgradeReason } from '../../../components/upgrade';
 import { getUtilization } from '../../../services/subscriptionApi';
@@ -61,7 +62,7 @@ export interface UseTransferReturn {
 }
 
 export function useTransfer(): UseTransferReturn {
-  const { sphere } = useSphereContext();
+  const { sphere, subscriptionKeyStatus } = useSphereContext();
   const queryClient = useQueryClient();
   // Rules of hooks: must be called unconditionally at the top level. This
   // requires UpgradeProvider to stay mounted ABOVE ConnectProvider in
@@ -75,6 +76,17 @@ export function useTransfer(): UseTransferReturn {
   const mutation = useMutation({
     mutationFn: async (params: TransferParams): Promise<TransferResult> => {
       if (!sphere) throw new Error('Wallet not initialized');
+
+      // Subscription-key readiness gate: with subscriptions on and no env-key
+      // fallback (#418), a send issued before the per-wallet key is provisioned
+      // would hit the aggregator unauthenticated (→ 401) and surface as a false
+      // "delivery pending". Refuse until the live oracle actually holds the key.
+      // This fires BEFORE checkSendQuota (which needs a key to meter anyway).
+      if (SUBSCRIPTION_ENABLED && !isSubscriptionKeyReady(subscriptionKeyStatus)) {
+        throw new SubscriptionNotReadyError(
+          subscriptionKeyStatus === 'failed' ? 'failed' : 'provisioning',
+        );
+      }
 
       // Proactive quota gate (spec §2): a hard block must land BEFORE the
       // first submit leaves — after that, #631/#633 keep-open semantics own

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -3,7 +3,7 @@ import { useSphereContext } from '../core/useSphere';
 import { SPHERE_KEYS } from '../../queryKeys';
 import { getErrorCode, isQuotaRateLimit, isGatewayAuthError } from '../../errors';
 import { checkSendQuota, QuotaBlockedError } from '../../quotaGate';
-import { isSubscriptionKeyReady, SubscriptionNotReadyError } from '../../subscription/keyStatus';
+import { useSubscriptionKeyGuard } from '../subscription';
 import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
 import { useUpgrade, type UpgradeReason } from '../../../components/upgrade';
 import { getUtilization } from '../../../services/subscriptionApi';
@@ -62,7 +62,8 @@ export interface UseTransferReturn {
 }
 
 export function useTransfer(): UseTransferReturn {
-  const { sphere, subscriptionKeyStatus } = useSphereContext();
+  const { sphere } = useSphereContext();
+  const { assertReady: requireSubscriptionKey } = useSubscriptionKeyGuard();
   const queryClient = useQueryClient();
   // Rules of hooks: must be called unconditionally at the top level. This
   // requires UpgradeProvider to stay mounted ABOVE ConnectProvider in
@@ -77,16 +78,11 @@ export function useTransfer(): UseTransferReturn {
     mutationFn: async (params: TransferParams): Promise<TransferResult> => {
       if (!sphere) throw new Error('Wallet not initialized');
 
-      // Subscription-key readiness gate: with subscriptions on and no env-key
-      // fallback (#418), a send issued before the per-wallet key is provisioned
-      // would hit the aggregator unauthenticated (→ 401) and surface as a false
-      // "delivery pending". Refuse until the live oracle actually holds the key.
-      // This fires BEFORE checkSendQuota (which needs a key to meter anyway).
-      if (SUBSCRIPTION_ENABLED && !isSubscriptionKeyReady(subscriptionKeyStatus)) {
-        throw new SubscriptionNotReadyError(
-          subscriptionKeyStatus === 'failed' ? 'failed' : 'provisioning',
-        );
-      }
+      // Subscription-key readiness gate: refuse the send until the live oracle
+      // holds the per-wallet key, else it hits the aggregator unauthenticated
+      // (→ 401, false "delivery pending"). Fires BEFORE checkSendQuota (which
+      // needs a key to meter anyway). Shared with pay/mint via the guard hook.
+      requireSubscriptionKey();
 
       // Proactive quota gate (spec §2): a hard block must land BEFORE the
       // first submit leaves — after that, #631/#633 keep-open semantics own

--- a/src/sdk/hooks/subscription/index.ts
+++ b/src/sdk/hooks/subscription/index.ts
@@ -1,3 +1,4 @@
 export { usePlans } from './usePlans';
 export { useUtilization } from './useUtilization';
 export { useCheckout } from './useCheckout';
+export { useSubscriptionKeyGuard } from './useSubscriptionKeyGuard';

--- a/src/sdk/hooks/subscription/useSubscriptionKeyGuard.ts
+++ b/src/sdk/hooks/subscription/useSubscriptionKeyGuard.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { useSphereContext } from '../core/useSphere';
+import { isSubscriptionKeyReady, SubscriptionNotReadyError } from '../../subscription/keyStatus';
+import { SUBSCRIPTION_ENABLED } from '../../../config/subscription';
+
+export interface SubscriptionKeyGuard {
+  /** True when a money op may proceed (subscriptions off, or the key is on the oracle). */
+  readonly ready: boolean;
+  /** Throws `SubscriptionNotReadyError` when not `ready` — for throw-style callers. */
+  readonly assertReady: () => void;
+}
+
+/**
+ * Single readiness guard for every L3 money operation (send / pay / mint) while
+ * subscriptions are on: until the per-wallet key is on the LIVE oracle, a
+ * `certification_request` would go out keyless (→ 401, surfacing as a false
+ * "delivery pending"). One source of truth for every certification entry point
+ * (see issue #419).
+ *
+ * Two consumption modes so each caller stays idiomatic:
+ * - `assertReady()` throws (useTransfer / payPaymentRequest / self-mint — the
+ *   surrounding error UI surfaces the message);
+ * - `ready` for callers that reject gracefully instead of throwing (a dApp
+ *   Connect intent replies with `rejectIntent`).
+ */
+export function useSubscriptionKeyGuard(): SubscriptionKeyGuard {
+  const { subscriptionKeyStatus } = useSphereContext();
+  const ready = !SUBSCRIPTION_ENABLED || isSubscriptionKeyReady(subscriptionKeyStatus);
+  const assertReady = useCallback(() => {
+    if (!ready) {
+      throw new SubscriptionNotReadyError(
+        subscriptionKeyStatus === 'failed' ? 'failed' : 'provisioning',
+      );
+    }
+  }, [ready, subscriptionKeyStatus]);
+  return { ready, assertReady };
+}

--- a/src/sdk/subscription/keyStatus.ts
+++ b/src/sdk/subscription/keyStatus.ts
@@ -1,0 +1,46 @@
+/**
+ * Subscription-key readiness for the send path.
+ *
+ * With subscriptions ON and no env-key fallback (#418), the SDK oracle carries
+ * NO aggregator credential until the per-wallet key is provisioned — and
+ * provisioning is an async, fire-and-forget step that runs AFTER the wallet
+ * becomes interactive (see SphereProvider `reconcileSubscriptionKey`). A send
+ * issued in that window would hit `certification_request` unauthenticated
+ * (→ 401). This module lets the send path refuse until the oracle actually
+ * holds the key, closing the window (see issue: keyless L3-send window).
+ *
+ * `ready` means the CURRENT oracle instance was built WITH the key — not merely
+ * that a key exists in storage — so it also covers the brief re-init gap
+ * between "key persisted" and "SDK re-initialized with it".
+ */
+
+export type SubscriptionKeyStatus =
+  | 'not-required' // subscriptions disabled — the static env key is the oracle credential
+  | 'provisioning' // subscriptions on, the per-wallet key is being fetched/recovered
+  | 'ready' //        the live oracle holds the subscription key
+  | 'failed'; //      provisioning failed on the initial load — no key to send with
+
+/** A send is safe to attempt only when the oracle has a credential. */
+export function isSubscriptionKeyReady(status: SubscriptionKeyStatus): boolean {
+  return status === 'ready' || status === 'not-required';
+}
+
+/**
+ * Thrown by the send path when subscriptions are on but the oracle has no key
+ * yet. Distinct from `QuotaBlockedError` (which is an upgrade/quota signal) —
+ * this is a transient "not set up yet" state, surfaced as a plain error so the
+ * existing generic error UI shows the message without an Upgrade CTA.
+ */
+export class SubscriptionNotReadyError extends Error {
+  readonly status: 'provisioning' | 'failed';
+
+  constructor(status: 'provisioning' | 'failed') {
+    super(
+      status === 'failed'
+        ? "Couldn't set up your subscription. Reload the app to retry."
+        : 'Setting up your subscription — try again in a moment.',
+    );
+    this.name = 'SubscriptionNotReadyError';
+    this.status = status;
+  }
+}

--- a/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
+++ b/tests/unit/hooks/useIncomingPaymentRequests.test.tsx
@@ -4,6 +4,8 @@ import {
   useIncomingPaymentRequests,
   PaymentRequestStatus,
 } from "../../../src/components/wallet/L3/hooks/useIncomingPaymentRequests";
+import { SubscriptionNotReadyError, type SubscriptionKeyStatus } from "../../../src/sdk/subscription/keyStatus";
+import * as subscriptionConfig from "../../../src/config/subscription";
 
 // ============================================================================
 // Fake sphere: implements exactly the PaymentsModule surface the hook is
@@ -95,13 +97,22 @@ function makeFakeSphere(initial: FakeSdkRequest[] = []) {
 }
 
 let fakeSphere: ReturnType<typeof makeFakeSphere> | null = null;
+let subscriptionKeyStatus: SubscriptionKeyStatus = "ready";
 
 vi.mock("../../../src/sdk/hooks/core/useSphere", () => ({
-  useSphereContext: () => ({ sphere: fakeSphere }),
+  useSphereContext: () => ({ sphere: fakeSphere, subscriptionKeyStatus }),
+}));
+// SUBSCRIPTION_ENABLED defaults false here (gate inert for the existing tests);
+// the readiness-gate tests flip it on. Rest of the module stays real.
+vi.mock("../../../src/config/subscription", async (orig) => ({
+  ...(await orig<typeof import("../../../src/config/subscription")>()),
+  SUBSCRIPTION_ENABLED: false,
 }));
 
 beforeEach(() => {
   fakeSphere = null;
+  subscriptionKeyStatus = "ready";
+  (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
 });
 
 describe("useIncomingPaymentRequests", () => {
@@ -204,6 +215,33 @@ describe("useIncomingPaymentRequests", () => {
     ).rejects.toThrow(/INSUFFICIENT_FUNDS/);
 
     expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+  });
+
+  it("refuses to pay while the subscription key is not ready (same keyless-send guard as a normal send)", async () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
+    subscriptionKeyStatus = "provisioning";
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await expect(
+      act(() => result.current.pay(result.current.requests[0])),
+    ).rejects.toBeInstanceOf(SubscriptionNotReadyError);
+
+    // The keyless send never left, and the request stays actionable.
+    expect(fakeSphere.payments.payPaymentRequest).not.toHaveBeenCalled();
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PENDING);
+  });
+
+  it("pays once the subscription key is ready (gate is transparent)", async () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
+    subscriptionKeyStatus = "ready";
+    fakeSphere = makeFakeSphere([makeRequest("a")]);
+    const { result } = renderHook(() => useIncomingPaymentRequests());
+
+    await act(() => result.current.pay(result.current.requests[0]));
+
+    expect(fakeSphere.payments.payPaymentRequest).toHaveBeenCalledWith("a");
+    expect(result.current.requests[0].status).toBe(PaymentRequestStatus.PAID);
   });
 
   it("clearProcessed delegates to the module and keeps pending requests", async () => {

--- a/tests/unit/hooks/useSubscriptionKeyGuard.test.tsx
+++ b/tests/unit/hooks/useSubscriptionKeyGuard.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { SubscriptionKeyStatus } from '@/sdk/subscription/keyStatus';
+
+// The guard reads subscriptionKeyStatus from context and SUBSCRIPTION_ENABLED
+// from config — both swappable per test.
+let subscriptionKeyStatus: SubscriptionKeyStatus = 'ready';
+vi.mock('@/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ subscriptionKeyStatus }),
+}));
+vi.mock('@/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('@/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: true,
+}));
+
+import { useSubscriptionKeyGuard } from '@/sdk/hooks/subscription/useSubscriptionKeyGuard';
+import { SubscriptionNotReadyError } from '@/sdk/subscription/keyStatus';
+import * as subscriptionConfig from '@/config/subscription';
+
+beforeEach(() => {
+  subscriptionKeyStatus = 'ready';
+  (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
+});
+
+describe('useSubscriptionKeyGuard — the single money-op readiness gate', () => {
+  it('ready + assertReady is a no-op when the key is on the oracle', () => {
+    subscriptionKeyStatus = 'ready';
+    const { result } = renderHook(() => useSubscriptionKeyGuard());
+    expect(result.current.ready).toBe(true);
+    expect(() => result.current.assertReady()).not.toThrow();
+  });
+
+  it('blocks while provisioning: ready=false, assertReady throws SubscriptionNotReadyError', () => {
+    subscriptionKeyStatus = 'provisioning';
+    const { result } = renderHook(() => useSubscriptionKeyGuard());
+    expect(result.current.ready).toBe(false);
+    expect(() => result.current.assertReady()).toThrow(SubscriptionNotReadyError);
+  });
+
+  it('failed provisioning → assertReady throws with status "failed" (reload hint)', () => {
+    subscriptionKeyStatus = 'failed';
+    const { result } = renderHook(() => useSubscriptionKeyGuard());
+    let err: unknown;
+    try {
+      result.current.assertReady();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(SubscriptionNotReadyError);
+    expect((err as SubscriptionNotReadyError).status).toBe('failed');
+    expect(result.current.ready).toBe(false);
+  });
+
+  it('subscriptions off → always ready, never gates (env-key mode)', () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
+    subscriptionKeyStatus = 'provisioning';
+    const { result } = renderHook(() => useSubscriptionKeyGuard());
+    expect(result.current.ready).toBe(true);
+    expect(() => result.current.assertReady()).not.toThrow();
+  });
+});

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -5,13 +5,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SphereError } from '@unicitylabs/sphere-sdk';
 import type { UtilizationInfo } from '../../../src/services/subscriptionApi';
 import { useTransfer } from '../../../src/sdk/hooks/payments/useTransfer';
+import { SubscriptionNotReadyError, type SubscriptionKeyStatus } from '../../../src/sdk/subscription/keyStatus';
 
-// The hook reads the wallet from useSphereContext — swap in a fake with just
-// payments.send. The SDK throws a ProofUnconfirmedError (extends SphereError,
-// code CERTIFICATION_UNCONFIRMED) for a possibly-certified send (#631/#633).
+// The hook reads the wallet + subscription-key readiness from useSphereContext —
+// swap in a fake with just payments.send. The SDK throws a ProofUnconfirmedError
+// (extends SphereError, code CERTIFICATION_UNCONFIRMED) for a possibly-certified
+// send (#631/#633). `subscriptionKeyStatus` defaults to 'ready' so the readiness
+// gate is transparent to the quota/send tests; the gate tests flip it.
 let fakeSphere: { payments: { send: ReturnType<typeof vi.fn> } } | null = null;
+let subscriptionKeyStatus: SubscriptionKeyStatus = 'ready';
 vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
-  useSphereContext: () => ({ sphere: fakeSphere }),
+  useSphereContext: () => ({ sphere: fakeSphere, subscriptionKeyStatus }),
 }));
 
 // Task 3: proactive quota gate. Mock checkSendQuota (keep the real
@@ -91,6 +95,7 @@ let openUpgradeMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   fakeSphere = null;
+  subscriptionKeyStatus = 'ready';
   vi.mocked(checkSendQuota).mockReset().mockResolvedValue({ verdict: 'allow' });
   (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = true;
 
@@ -144,6 +149,67 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
       res = await result.current.transfer(PARAMS);
     });
     expect(res).toEqual(ok);
+  });
+});
+
+describe('useTransfer — subscription-key readiness gate (keyless-send window)', () => {
+  it('refuses the send while the key is still provisioning (never reaches quota/send → no keyless 401)', async () => {
+    subscriptionKeyStatus = 'provisioning';
+    const send = vi.fn();
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    await expect(
+      act(async () => {
+        await result.current.transfer(PARAMS);
+      }),
+    ).rejects.toBeInstanceOf(SubscriptionNotReadyError);
+
+    // The send never left, and the gate fired BEFORE the quota check.
+    expect(send).not.toHaveBeenCalled();
+    expect(checkSendQuota).not.toHaveBeenCalled();
+  });
+
+  it('refuses with a reload hint when provisioning has failed', async () => {
+    subscriptionKeyStatus = 'failed';
+    const send = vi.fn();
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let caught: unknown;
+    await act(async () => {
+      caught = await result.current.transfer(PARAMS).catch((e) => e);
+    });
+    expect(caught).toBeInstanceOf(SubscriptionNotReadyError);
+    expect((caught as SubscriptionNotReadyError).status).toBe('failed');
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('allows the send once the key is ready', async () => {
+    subscriptionKeyStatus = 'ready';
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.transfer(PARAMS);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not gate when SUBSCRIPTION_ENABLED is false (env-key mode), even if status is not ready', async () => {
+    (subscriptionConfig as { SUBSCRIPTION_ENABLED: boolean }).SUBSCRIPTION_ENABLED = false;
+    subscriptionKeyStatus = 'provisioning';
+    const ok = { id: 't1', status: 'completed', tokens: [], tokenTransfers: [] };
+    const send = vi.fn().mockResolvedValue(ok);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.transfer(PARAMS);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/sdk/keyStatus.test.ts
+++ b/tests/unit/sdk/keyStatus.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSubscriptionKeyReady,
+  SubscriptionNotReadyError,
+  type SubscriptionKeyStatus,
+} from '@/sdk/subscription/keyStatus';
+
+describe('isSubscriptionKeyReady', () => {
+  it('is true only when the oracle has a credential', () => {
+    expect(isSubscriptionKeyReady('ready')).toBe(true);
+    expect(isSubscriptionKeyReady('not-required')).toBe(true);
+  });
+
+  it('is false while there is no key on the oracle (the keyless-send window)', () => {
+    expect(isSubscriptionKeyReady('provisioning')).toBe(false);
+    expect(isSubscriptionKeyReady('failed')).toBe(false);
+  });
+
+  it('covers every status in the union (exhaustive)', () => {
+    const all: SubscriptionKeyStatus[] = ['not-required', 'provisioning', 'ready', 'failed'];
+    // ready + not-required allowed → exactly 2 of 4 are "ready"
+    expect(all.filter(isSubscriptionKeyReady)).toEqual(['not-required', 'ready']);
+  });
+});
+
+describe('SubscriptionNotReadyError', () => {
+  it('carries a transient "provisioning" message', () => {
+    const err = new SubscriptionNotReadyError('provisioning');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('SubscriptionNotReadyError');
+    expect(err.status).toBe('provisioning');
+    expect(err.message).toMatch(/setting up/i);
+  });
+
+  it('carries a reload hint when provisioning failed', () => {
+    const err = new SubscriptionNotReadyError('failed');
+    expect(err.status).toBe('failed');
+    expect(err.message).toMatch(/reload/i);
+  });
+});


### PR DESCRIPTION
Closes #419.

## Problem

With subscriptions on and no env-key fallback (#418), the SDK oracle carries **no aggregator key** until the per-wallet key is provisioned — an async, fire-and-forget step that runs *after* the wallet becomes interactive. A send/mint issued in that window hit `certification_request` unauthenticated → **401**, surfacing as a false **"delivery pending"**.

Verified by adversarial code-trace (both the window and money-safety): money was never lost (a keyless 401 → `CERTIFICATION_UNCONFIRMED` → intent kept open, source restored, never re-sent), but the UX was a confusing stuck/false-pending state.

## Fix — readiness gate

- **Readiness signal** — `SphereProvider` tracks `subscriptionKeyStatus` (`not-required` | `provisioning` | `ready` | `failed`). `ready` means the **live oracle/token-engine actually holds a usable key** — never merely "key in storage".
- **Single centralized gate** — `useSubscriptionKeyGuard()` (`{ ready, assertReady }`) is the one readiness check. All money choke points use it: `useTransfer` (normal send + `SwapModal` + dApp `SendIntentModal`), `useIncomingPaymentRequests.pay()`, **and mints** (`useTopUp` self-mint, dApp mint intent). Leaf module `src/sdk/subscription/keyStatus.ts` (`isSubscriptionKeyReady` + `SubscriptionNotReadyError`).
- **Send button** — `SendModal` disables Send with a "Setting up your subscription…" hint while not ready.

## Fix — live re-keying via SDK `setOracleApiKey` (the "proper fix" from #419 layer 5)

Consumes **@unicitylabs/sphere-sdk 0.11.6** (adds `Sphere.setOracleApiKey`). Applying the per-wallet key now re-keys the **live** oracle/token-engine in place — no full `initialize(0, true)` re-init, so provisioning/switching a key no longer tears down the transport + wallet-api realtime socket ("Reconnecting" flash gone).

- The reconcile logic (resolve/provision the key → apply it → drive the gate status → attach the `identity:changed` re-key listener) is extracted into a shared **`setupSubscriptionKey(instance, builtWithKey)`**, called from **both** `initialize()` (existing wallet) and `finalizeWallet()` (freshly onboarded/imported wallet). Previously only the exists-branch wired the listener + provisioning retry, so an onboarded wallet silently lost per-address key isolation and the retry for the whole session.

### Money-safety design (adversarially reviewed)
- `appliedOracleKeyRef` tracks the key the live engine **actually** carries; status flips `ready` only when it matches the intended key — never off the boot-cache slot (written ahead of the async engine rebuild), so `ready` can't race an in-flight re-key.
- `applyOracleKey` **serializes** live re-keys through a promise chain so overlapping rebuilds from rapid address switches commit in order (no wrong-key drift); the hang-prone network provisioning stays **outside** the chain (SGW stall can't block re-keying).
- `subKeyGenRef` (monotonic generation) makes only the **latest** reconcile apply its key + flip status; superseded reconciles abort.
- On a failed apply/provision while the engine is still keyless → terminal `failed` (not stuck `provisioning`); a valid loaded key is left `ready`.

## Not a money-safety change

All changes are gated behind `SUBSCRIPTION_ENABLED` — non-subscription builds are byte-unchanged. Three rounds of multi-agent adversarial review found **no** path where the gate reports `ready` while the engine is keyless (no keyless-send window); residual findings were billing-attribution / liveness only (fail-closed).

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run test:run` — **243 passed** (adds `keyStatus` + `useSubscriptionKeyGuard` unit tests + readiness-gate tests)
- `npm run build` — OK