### PR TITLE
chore(deps): bump @unicitylabs/sphere-sdk 0.11.7 -> 0.11.8 (idempotent apply retry)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.7",
+        "@unicitylabs/sphere-sdk": "0.11.8",
         "@unicitylabs/sphere-ui": "^0.1.23",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.7.tgz",
-      "integrity": "sha512-sU+mxUl/i1uRy1GoiuQUZViEmRN0vseRnogMrNoN+quRoMOeztPdSD3pVZ0mOK5k8lMV0Mi71WtBwo80Io4/uw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.8.tgz",
+      "integrity": "sha512-Wsfpl7hBz4DEddYuvfTZirb8PZEueDtetVgtZBlfvkS6msG0ElifOLoB16jZfIYDgY+n/VZzpxJqYcfHqy+Ugg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.7",
+    "@unicitylabs/sphere-sdk": "0.11.8",
     "@unicitylabs/sphere-ui": "^0.1.23",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Brings **sphere-sdk#664** to the app: the wallet-api client now retries `POST /v1/inventory/apply` on a transient network drop/timeout, scoped to that one write (idempotent by `transferId` — the backend replays a re-applied transferId to the same cursor; contract tracked in wallet-api#100). Previously the send-path write was single-attempt, so a dropped connection on a slow/flaky link hard-failed the send — the dominant "cannot send" failure in production.

Completes the wallet-api robustness series:
- 0.11.7 (#421): challenge clock-skew fix (#662) + benign CONFLICT (#663) + `requestTimeoutMs`/retry config.
- **0.11.8 (this): idempotent apply retry (#664)** — the last slow-connection send-blocker.

## Verification
tsc, 243 unit tests, and production build all green; #664's `idempotentWrite` retry path confirmed present in the installed 0.11.8 bundle.