### PR TITLE
feat(payments): bump sphere-sdk 0.11.9 + present SEND_SYNC_PENDING as pending-success (#665)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.8",
+        "@unicitylabs/sphere-sdk": "0.11.9",
         "@unicitylabs/sphere-ui": "^0.1.30",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -629,7 +629,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -646,7 +645,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,7 +661,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -680,7 +677,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,7 +693,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -714,7 +709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,7 +725,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -748,7 +741,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,7 +757,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,7 +773,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -799,7 +789,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -816,7 +805,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,7 +821,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -850,7 +837,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -867,7 +853,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -884,7 +869,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,7 +885,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,7 +901,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,7 +917,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,7 +933,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,7 +949,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,7 +965,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,7 +981,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,7 +997,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,7 +1013,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,7 +1029,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1611,7 +1585,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1625,7 +1598,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1639,7 +1611,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1653,7 +1624,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1667,7 +1637,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1681,7 +1650,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1695,7 +1663,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1709,7 +1676,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1723,7 +1689,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,7 +1702,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1751,7 +1715,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1765,7 +1728,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1779,7 +1741,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1793,7 +1754,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1807,7 +1767,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1821,7 +1780,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1835,7 +1793,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1849,7 +1806,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1863,7 +1819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1877,7 +1832,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1891,7 +1845,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1905,7 +1858,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1919,7 +1871,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1933,7 +1884,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,7 +1897,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,7 +2487,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2558,7 +2506,7 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2946,9 +2894,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.8.tgz",
-      "integrity": "sha512-Wsfpl7hBz4DEddYuvfTZirb8PZEueDtetVgtZBlfvkS6msG0ElifOLoB16jZfIYDgY+n/VZzpxJqYcfHqy+Ugg==",
+      "version": "0.11.9",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.9.tgz",
+      "integrity": "sha512-n7waCh07SDiQ5EnB9W86bdhZ01gs/5ZriFx6Cb0cnezGK9QwStPzThICzjJmqaFJBJZ76CR2eWGarN7CKzgQ9w==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
@@ -4341,7 +4289,6 @@
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4649,7 +4596,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4773,7 +4719,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5969,7 +5914,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6350,14 +6294,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6440,7 +6382,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6875,7 +6816,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -7308,7 +7248,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -7526,7 +7465,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -7636,7 +7575,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -7963,7 +7901,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.8",
+    "@unicitylabs/sphere-sdk": "0.11.9",
     "@unicitylabs/sphere-ui": "^0.1.30",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -110,13 +110,12 @@ export function useTransfer(): UseTransferReturn {
           memo: params.memo,
         });
       } catch (e) {
-        // #665: a POST-COMMIT mirror-sync failure rejects with SEND_SYNC_PENDING —
-        // the spend already committed on-chain, the SDK keeps the intent OPEN, and
-        // resume converges the server mirror (idempotent apply). Present it as a
-        // pending SUCCESS, never a re-sendable failure (re-sending would double-pay),
-        // exactly like CERTIFICATION_UNCONFIRMED below. String-compare: the code
-        // ships in a newer sphere-sdk than the app's current SphereErrorCode type.
-        if ((getErrorCode(e) as string | null) === 'SEND_SYNC_PENDING') {
+        // #665: a POST-COMMIT wallet-api mirror-sync failure rejects with
+        // SEND_SYNC_PENDING — the spend already committed on-chain, the SDK keeps
+        // the intent OPEN, and resume converges the server mirror (idempotent
+        // apply). Present it as a pending SUCCESS, never a re-sendable failure
+        // (re-sending would double-pay), exactly like CERTIFICATION_UNCONFIRMED.
+        if (getErrorCode(e) === 'SEND_SYNC_PENDING') {
           return { id: '', status: 'pending', tokens: [], tokenTransfers: [], deliveryPending: true };
         }
         // #631/#633: a POSSIBLY-CERTIFIED send rejects with ProofUnconfirmedError

--- a/src/sdk/hooks/payments/useTransfer.ts
+++ b/src/sdk/hooks/payments/useTransfer.ts
@@ -110,6 +110,15 @@ export function useTransfer(): UseTransferReturn {
           memo: params.memo,
         });
       } catch (e) {
+        // #665: a POST-COMMIT mirror-sync failure rejects with SEND_SYNC_PENDING —
+        // the spend already committed on-chain, the SDK keeps the intent OPEN, and
+        // resume converges the server mirror (idempotent apply). Present it as a
+        // pending SUCCESS, never a re-sendable failure (re-sending would double-pay),
+        // exactly like CERTIFICATION_UNCONFIRMED below. String-compare: the code
+        // ships in a newer sphere-sdk than the app's current SphereErrorCode type.
+        if ((getErrorCode(e) as string | null) === 'SEND_SYNC_PENDING') {
+          return { id: '', status: 'pending', tokens: [], tokenTransfers: [], deliveryPending: true };
+        }
         // #631/#633: a POSSIBLY-CERTIFIED send rejects with ProofUnconfirmedError
         // (code CERTIFICATION_UNCONFIRMED) — the spend may already be final on-chain and
         // the SDK keeps the intent OPEN, so resume completes it under the same transferId.

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -126,6 +126,25 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
+  it('converts a SEND_SYNC_PENDING reject into a pending SUCCESS (post-commit mirror-sync — no re-send) (#665)', async () => {
+    // The code ships in a newer sphere-sdk than the app's type — build it via override.
+    const syncPending = new SphereError('Your payment was sent. Your wallet is syncing.', 'STORAGE_ERROR');
+    (syncPending as unknown as { code: string }).code = 'SEND_SYNC_PENDING';
+    const send = vi.fn().mockRejectedValue(syncPending);
+    fakeSphere = { payments: { send } };
+    const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
+
+    let res: { deliveryPending?: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.transfer(PARAMS);
+    });
+
+    // Resolved (NOT rejected) as pending success — the money is on-chain, resume converges.
+    expect(res?.deliveryPending).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
   it('still rejects a genuine failure so the user is told (and can retry safely)', async () => {
     const send = vi.fn().mockRejectedValue(new SphereError('not enough balance', 'INSUFFICIENT_BALANCE'));
     fakeSphere = { payments: { send } };

--- a/tests/unit/hooks/useTransfer.test.tsx
+++ b/tests/unit/hooks/useTransfer.test.tsx
@@ -127,10 +127,9 @@ describe('useTransfer — #631/#633 possibly-certified send', () => {
   });
 
   it('converts a SEND_SYNC_PENDING reject into a pending SUCCESS (post-commit mirror-sync — no re-send) (#665)', async () => {
-    // The code ships in a newer sphere-sdk than the app's type — build it via override.
-    const syncPending = new SphereError('Your payment was sent. Your wallet is syncing.', 'STORAGE_ERROR');
-    (syncPending as unknown as { code: string }).code = 'SEND_SYNC_PENDING';
-    const send = vi.fn().mockRejectedValue(syncPending);
+    const send = vi.fn().mockRejectedValue(
+      new SphereError('Your payment was sent. Your wallet is syncing.', 'SEND_SYNC_PENDING'),
+    );
     fakeSphere = { payments: { send } };
     const { result } = renderHook(() => useTransfer(), { wrapper: Wrapper });
 


### PR DESCRIPTION
The app half of sphere-sdk#665 (SDK PR unicity-sphere/sphere-sdk#669).

The SDK now tags a **post-commit** wallet-api mirror-sync failure with a distinct `SEND_SYNC_PENDING` code — the spend already committed on-chain, the intent stays open, and resume converges the server mirror. `useTransfer` now catches it and returns the **same synthetic pending-success** it already returns for `CERTIFICATION_UNCONFIRMED` (a resolved `{ status: 'pending', deliveryPending: true }`), never a re-sendable failure (re-sending would double-pay). So the user sees "sent — pending" instead of a scary "storage error", and the send screen never returns to a re-sendable confirm step.

Forward-compatible: the code ships in a newer sphere-sdk than the app's current `SphereErrorCode` type, so the check string-matches; it activates once the app bumps to the SDK release carrying #665.

## Verification
tsc, ESLint, production build clean; `useTransfer.test.tsx` — a `SEND_SYNC_PENDING` reject resolves as a pending success (not rejected, `send()` called once), mirroring the `CERTIFICATION_UNCONFIRMED` test; full app suite green (248).