### PR TITLE
chore(deps): bump sphere-sdk 0.11.9 -> 0.11.10 (intent-validation hardening)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.9",
+        "@unicitylabs/sphere-sdk": "0.11.10",
         "@unicitylabs/sphere-ui": "^0.1.30",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.9.tgz",
-      "integrity": "sha512-n7waCh07SDiQ5EnB9W86bdhZ01gs/5ZriFx6Cb0cnezGK9QwStPzThICzjJmqaFJBJZ76CR2eWGarN7CKzgQ9w==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.10.tgz",
+      "integrity": "sha512-ytq8pdPhf1MxQQN+GaEX8TyEL+28mZHxG0IDWP74FOYjwZEUYA4qNGWcX++qARz5P1mXNPoJnlr3Zp1FVu38pg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.9",
+    "@unicitylabs/sphere-sdk": "0.11.10",
     "@unicitylabs/sphere-ui": "^0.1.30",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Picks up [sphere-sdk 0.11.10](https://github.com/unicity-sphere/sphere-sdk/pull/671) (closes the client side of the SPHERE-R Sentry issue — `PUT /v1/intents: VALIDATION_FAILED envelope exceeds 4096 bytes (§8.3)`):

- A wallet-api 422 `VALIDATION` on the intent PUT now reaches the app as a typed `SphereError('VALIDATION_ERROR')` with a human message — the red toast shows "The payment could not be registered with the wallet service because it exceeds the service's size limit. Try sending a smaller amount." instead of the raw wire text, and Sentry captures tag `sphereErrorCode=VALIDATION_ERROR` instead of `unknown`. No app code changes needed — `getErrorMessage`/`getErrorCode` pick this up as-is.
- The failed send no longer poisons the local intent store: no recurring background 422 replay on every sync epoch, and one bad entry no longer blocks replay of later intents. Wallets already wedged by the old behavior self-heal on their next sync.

Server-side companion (raises the cap itself so fragmented-wallet sends succeed): unicity-sphere/wallet-api#102 / PR unicity-sphere/wallet-api#103 — still open; this bump is safe to ship independently and improves behavior against the current 4 KiB cap.

Verified: `npx tsc --noEmit` clean, `npm run test:run` 248/248, `npm run build` succeeds.