### PR TITLE
fix(sentry): drop unhandled EIP-1193 provider rejections from injected wallet extensions

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -10,7 +10,7 @@
  */
 import * as Sentry from '@sentry/react';
 import { SENTRY_DSN, detectEnvironment } from './config/sentry';
-import { scrubBreadcrumb, scrubEvent, scrubTransactionEvent } from './utils/sentryScrub';
+import { isInjectedProviderNoise, scrubBreadcrumb, scrubEvent, scrubTransactionEvent } from './utils/sentryScrub';
 
 if (SENTRY_DSN) {
   Sentry.init({
@@ -35,7 +35,9 @@ if (SENTRY_DSN) {
       genAI: { inputs: false, outputs: false },
       stackFrameVariables: false,
     },
-    beforeSend: scrubEvent,
+    // denyUrls can't catch extension-origin PLAIN-OBJECT rejections (no stack
+    // frames on the synthetic event) — isInjectedProviderNoise drops those.
+    beforeSend: (event) => (isInjectedProviderNoise(event) ? null : scrubEvent(event)),
     beforeBreadcrumb: scrubBreadcrumb,
     // No tracesSampleRate is set, so no transactions are ever sent — this
     // guard exists so that if tracing is enabled later, fetch/XHR span

--- a/src/utils/sentryScrub.ts
+++ b/src/utils/sentryScrub.ts
@@ -104,6 +104,32 @@ export function scrubTransactionEvent<E extends TransactionEvent>(event: E): E {
   return event;
 }
 
+// EIP-1193 ProviderRpcError codes (userRejected, unauthorized,
+// unsupportedMethod, disconnected, chainDisconnected). Positive 4xxx codes are
+// wallet-provider-specific — our own JSON-RPC surfaces (aggregator, wallet-api)
+// use -32xxx — so a rejection carrying one cannot have come from our code.
+const EIP1193_CODES = new Set([4001, 4100, 4200, 4900, 4901]);
+const EXTENSION_URL_RE = /\b(?:chrome|moz|safari-web)-extension:\/\//;
+
+/**
+ * Unhandled promise rejections thrown by injected wallet-extension provider
+ * scripts (EIP-1193). This app never calls `window.ethereum` — these originate
+ * wholly inside extensions whose inpage scripts run in our page context. They
+ * reject with PLAIN OBJECTS, so Sentry builds a synthetic event with no stack
+ * frames and `denyUrls` (which matches frame URLs) never sees the extension
+ * origin — it survives only as a string inside `extra.__serialized__.stack`.
+ * SPHERE-9 / SPHERE-A: ~1.4k events (~27% of monthly quota) in 5 days.
+ */
+export function isInjectedProviderNoise(event: ErrorEvent): boolean {
+  const mechanism = event.exception?.values?.[0]?.mechanism?.type ?? '';
+  if (!mechanism.includes('onunhandledrejection')) return false;
+  const serialized = (event.extra as Record<string, unknown> | undefined)?.['__serialized__'];
+  if (typeof serialized !== 'object' || serialized === null) return false;
+  const { code, stack } = serialized as { code?: unknown; stack?: unknown };
+  if (typeof code === 'number' && EIP1193_CODES.has(code)) return true;
+  return typeof stack === 'string' && EXTENSION_URL_RE.test(stack);
+}
+
 export function scrubEvent<E extends ErrorEvent>(event: E): E {
   if (event.message) event.message = scrubText(event.message);
   for (const exception of event.exception?.values ?? []) {

--- a/tests/unit/utils/sentryScrub.test.ts
+++ b/tests/unit/utils/sentryScrub.test.ts
@@ -4,6 +4,7 @@ import {
   scrubBreadcrumb,
   scrubEvent,
   scrubTransactionEvent,
+  isInjectedProviderNoise,
 } from '@/utils/sentryScrub';
 import type { Breadcrumb, ErrorEvent } from '@sentry/react';
 
@@ -186,5 +187,53 @@ describe('scrubEvent', () => {
     expect(scrubbed.breadcrumbs).toHaveLength(1);
     // sensitive key names in extra are filtered wholesale
     expect(scrubbed.extra?.seed).toBe('[Filtered]');
+  });
+});
+
+describe('isInjectedProviderNoise', () => {
+  const rejection = (serialized: unknown, mechanism = 'auto.browser.global_handlers.onunhandledrejection'): ErrorEvent =>
+    ({
+      exception: { values: [{ type: 'UnhandledRejection', mechanism: { type: mechanism } }] },
+      extra: { __serialized__: serialized },
+    }) as unknown as ErrorEvent;
+
+  it('drops an EIP-1193 disconnect rejection without a stack (SPHERE-A shape)', () => {
+    expect(
+      isInjectedProviderNoise(
+        rejection({ code: 4900, message: 'The provider is disconnected from all chains.' })
+      )
+    ).toBe(true);
+  });
+
+  it('drops an object rejection whose stack string points into an extension (SPHERE-9 shape)', () => {
+    expect(
+      isInjectedProviderNoise(
+        rejection({
+          code: 4900,
+          message: 'The provider is disconnected from all chains.',
+          stack: 'Error: ...\n    at s (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:4:1)',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('keeps our JSON-RPC-style rejections (negative codes)', () => {
+    expect(isInjectedProviderNoise(rejection({ code: -32000, message: 'aggregator busy' }))).toBe(false);
+  });
+
+  it('keeps object rejections with non-EIP-1193 codes and app-origin stacks', () => {
+    expect(
+      isInjectedProviderNoise(
+        rejection({ code: 500, message: 'x', stack: 'Error at https://sphere.unicity.network/assets/index.js:1:1' })
+      )
+    ).toBe(false);
+  });
+
+  it('ignores events from other mechanisms even with a 4900 code', () => {
+    expect(isInjectedProviderNoise(rejection({ code: 4900, message: 'x' }, 'generic'))).toBe(false);
+  });
+
+  it('ignores events without a serialized rejection object', () => {
+    expect(isInjectedProviderNoise({ exception: { values: [] } } as unknown as ErrorEvent)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes the SPHERE-9 (668 events) / SPHERE-A (697 events) Sentry noise pair — together ~27% of the monthly free-tier quota since Jul 8.

## What these actually are

Both issues are the SAME event, captured twice per occurrence by `onunhandledrejection`: an injected wallet extension's provider script rejecting internal promises with the standard EIP-1193 error object `{code: 4900, message: "The provider is disconnected from all chains."}` (SPHERE-9's copy carries a `stack` string pointing entirely into `chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js`). Code 4900 is the EIP-1193 "provider disconnected" code — the classic MV3 service-worker-suspension symptom. **Sphere never calls `window.ethereum`** (verified: zero references in `src/` and in the SDK dist) — the extension's inpage script simply runs in our page context, so its unhandled rejections surface in our Sentry.

Trend (SPHERE-A daily): 3 → 186 → 202 → 175 → 61 → 70. Not escalating — but steady, unactionable, and expensive.

## Why the existing filter misses them

`denyUrls: [/^chrome-extension:\/\//]` already expresses exactly this intent, but it matches **stack-frame URLs** — and a plain-object rejection produces a frameless synthetic event (`Object captured as promise rejection with keys: …`, culprit empty). The extension origin survives only as a *string property* inside `extra.__serialized__.stack`, which denyUrls never inspects. `ignoreErrors` can't be used either: the exception value is the generic "Object captured…" text, and matching it would also drop *our* object rejections (aggregator JSON-RPC errors share the `{code, message}` shape).

## Fix

`isInjectedProviderNoise(event)` in `sentryScrub.ts`, checked in `beforeSend` before scrubbing. Drops only unhandled-rejection events whose serialized object carries a **positive EIP-1193 code** (4001/4100/4200/4900/4901 — our JSON-RPC surfaces use `-32xxx`, so these cannot come from our code) or whose serialized `stack` string points into a `chrome|moz|safari-web-extension://` origin. Everything else — including negative-code JSON-RPC rejections — still flows.

Tests: 6 new cases pinning both production shapes (drop) and the keep-cases (negative codes, non-EIP codes with app-origin stacks, other mechanisms, no serialized object). Full suite 254/254, `tsc --noEmit` clean, lint clean (pre-existing warnings only).

After merge + deploy, SPHERE-9/SPHERE-A can be resolved in Sentry — any recurrence would mean a genuinely new shape worth seeing.