### PR TITLE
test: fix flaky pollOrder listener-leak test (real-timer race on loaded CI runners)

### DIFF
--- a/tests/unit/sdk/pollOrder.test.ts
+++ b/tests/unit/sdk/pollOrder.test.ts
@@ -60,12 +60,17 @@ it('does not leak abort listeners across intervals (default sleep cleans up on t
     if (type === 'abort') removed++;
     return (origRemove as (...a: unknown[]) => void)(type, ...rest);
   }) as typeof ac.signal.removeEventListener;
-  // Several pending polls on real (tiny) timers, never aborted → each interval's
-  // listener must be removed when its timer fires.
-  const res = await pollOrderStatus(async () => base, { intervalMs: 2, timeoutMs: 12, signal: ac.signal });
+  // Several pending polls, never aborted → each interval's listener must be
+  // removed when its timer fires. Keep the DEFAULT sleep (the real-timer path
+  // under test) but fake `now` so the iteration count is deterministic: with
+  // real elapsed time a loaded CI runner can stretch one 2ms sleep past the
+  // whole deadline and leave only a single interval (flaked with added === 1).
+  // now steps +10/call: deadline at 45, checks at 20/30/40 → exactly 3 sleeps.
+  const now = (() => { let t = 0; return () => (t += 10); })();
+  const res = await pollOrderStatus(async () => base, { intervalMs: 1, timeoutMs: 35, now, signal: ac.signal });
   expect(res.outcome).toBe('timeout');
-  expect(added).toBeGreaterThan(1); // multiple intervals actually elapsed
-  expect(removed).toBe(added);      // every listener cleaned up
+  expect(added).toBe(3);       // multiple intervals elapsed, deterministically
+  expect(removed).toBe(added); // every listener cleaned up
 });
 
 it('the default (real-timer) sleep unblocks immediately on abort', async () => {


### PR DESCRIPTION
Fixes the CI flake that failed the first attempt of main run [29209567892](https://github.com/unicity-sphere/sphere/actions/runs/29209567892) (`AssertionError: expected 1 to be greater than 1` in `tests/unit/sdk/pollOrder.test.ts`), unrelated to the #428 diff on that commit.

## Why it flaked

The test drove `pollOrderStatus` with **real timers** (`intervalMs: 2, timeoutMs: 12`) and asserted ≥2 intervals elapsed. `pollOrderStatus` re-checks `now()` against the deadline each loop, so on a loaded runner a single 2 ms `setTimeout` stretched past the 12 ms wall-clock deadline → exactly one interval → `added === 1`.

## Fix

The loop's iteration count is governed by `now()`, which the options let us fake independently of `sleep`. The test now keeps the **default real-timer sleep** (the abort-listener add/remove path is precisely what's under test) but pins iterations with a fake `now` stepping +10 per call against a 35 ms budget → deterministically 3 sleeps regardless of scheduler lag. Assertion tightened from `added > 1` to `added === 3`.

Verified: 30 consecutive runs green; determinism is structural (the count no longer depends on wall-clock at all).