### PR TITLE
fix(sentry): filter v2 — drop remaining extension noise (~49% of events), pin release, stabilize grouping

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,12 +43,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # No build-args: the image is environment-AGNOSTIC. The Dockerfile
-          # bakes __RUNTIME_*__ placeholders (its ARG defaults); the real
-          # per-env public config (SPHERE_API_URL, WALLET_API_URL, ...) is
-          # injected at container start by deploy/runtime-config.sh from the
-          # ECS task definition's env vars. This is what lets the SAME image
-          # auto-deploy to staging and be promoted, unchanged, to prod.
+          # The ONLY build-arg is the git sha for the Sentry release tag —
+          # env-AGNOSTIC (identical for staging and prod), so it preserves
+          # build-once, promote-many. Everything per-environment stays out:
+          # the Dockerfile bakes __RUNTIME_*__ placeholders (its ARG
+          # defaults); the real per-env public config (SPHERE_API_URL,
+          # WALLET_API_URL, ...) is injected at container start by
+          # deploy/runtime-config.sh from the ECS task definition's env vars.
+          # This is what lets the SAME image auto-deploy to staging and be
+          # promoted, unchanged, to prod.
+          build-args: |
+            VITE_BUILD_SHA=${{ github.sha }}
 
       # Auto-deploy the just-published image to AWS staging. Fires a
       # repository_dispatch into sphere-infra, whose deploy-sphere-site-staging

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,16 @@ ARG VITE_DEV_PORTAL_URL=__RUNTIME_DEV_PORTAL_URL__
 # BASE_PATH is a true build-time concern (Vite rewrites asset URLs + router
 # basename); both AWS envs serve at root, so it stays baked as `/`.
 ARG BASE_PATH=/
+# Sentry release tag. Baked (not a placeholder) because it is env-AGNOSTIC:
+# the same sha ships to staging and prod, so it never breaks build-once,
+# promote-many. Empty (release unset) in docker-validate and local builds.
+ARG VITE_BUILD_SHA=
 ENV VITE_SPHERE_API_URL=$VITE_SPHERE_API_URL \
     VITE_WALLET_API_URL=$VITE_WALLET_API_URL \
     VITE_REQUIRE_WALLET_API=$VITE_REQUIRE_WALLET_API \
     VITE_AGGREGATOR_API_KEY=$VITE_AGGREGATOR_API_KEY \
     VITE_DEV_PORTAL_URL=$VITE_DEV_PORTAL_URL \
+    VITE_BUILD_SHA=$VITE_BUILD_SHA \
     BASE_PATH=$BASE_PATH
 RUN npm run build
 

--- a/Dockerfile.ssl
+++ b/Dockerfile.ssl
@@ -23,11 +23,14 @@ ARG VITE_DEV_PORTAL_URL=__RUNTIME_DEV_PORTAL_URL__
 # via window.__SPHERE_RUNTIME_CONFIG__ (/runtime-config.js, written at container
 # start by sphere-runtime-config). See the note in the main Dockerfile.
 ARG BASE_PATH=/
+# Sentry release tag — env-agnostic (same sha every env); see main Dockerfile.
+ARG VITE_BUILD_SHA=
 ENV VITE_SPHERE_API_URL=$VITE_SPHERE_API_URL \
     VITE_WALLET_API_URL=$VITE_WALLET_API_URL \
     VITE_REQUIRE_WALLET_API=$VITE_REQUIRE_WALLET_API \
     VITE_AGGREGATOR_API_KEY=$VITE_AGGREGATOR_API_KEY \
     VITE_DEV_PORTAL_URL=$VITE_DEV_PORTAL_URL \
+    VITE_BUILD_SHA=$VITE_BUILD_SHA \
     BASE_PATH=$BASE_PATH
 RUN npm run build
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -12,10 +12,23 @@ import * as Sentry from '@sentry/react';
 import { SENTRY_DSN, detectEnvironment } from './config/sentry';
 import { isInjectedProviderNoise, scrubBreadcrumb, scrubEvent, scrubTransactionEvent } from './utils/sentryScrub';
 
+// Baked at build time (Dockerfile ARG from GITHUB_SHA; absent in local dev and
+// docker-validate builds). Without an explicit release, extension-injected
+// window.SENTRY_RELEASE wins — production events were tagged with Phantom's
+// "26.15.2", a VPN extension's version, etc., corrupting release-based
+// filtering and regression detection. Env-agnostic: the same sha ships to
+// staging and prod (build-once, promote-many).
+const BUILD_SHA: string | undefined = import.meta.env.VITE_BUILD_SHA || undefined;
+
 if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
     environment: detectEnvironment(),
+    // The explicit `undefined` is load-bearing: applyDefaultOptions spreads
+    // user options OVER the window.SENTRY_RELEASE fallback, so even sha-less
+    // builds are protected from extension-injected releases. Do NOT "clean up"
+    // to a conditional spread.
+    release: BUILD_SHA ? `sphere@${BUILD_SHA.slice(0, 12)}` : undefined,
     integrations: [
       // Console breadcrumbs are how Slope Wallet leaked seed phrases to
       // Sentry — and this app console.errors raw SDK errors in 20+ places.
@@ -46,9 +59,31 @@ if (SENTRY_DSN) {
     ignoreErrors: [
       'ResizeObserver loop limit exceeded',
       'ResizeObserver loop completed with undelivered notifications',
+      // Extension / in-app-browser / webview noise: none of these strings
+      // exist anywhere in our bundle or the SDK (verified per-issue in the
+      // 2026-07 Sentry triage — SPHERE-G/K/1M/1T/16/1B/13).
+      'Failed to connect to MetaMask',
+      'Could not establish connection. Receiving end does not exist',
+      /A listener indicated an asynchronous response by returning true/,
+      'not found rainbowkit',
+      /Error invoking postEvent/, // Telegram in-app WebApp bridge
+      /zaloJSV2/, // Zalo in-app browser injection
+      'WKWebView API client did not respond to this postMessage',
+      // TODO(sphere-sdk IDB InvalidStateError retry): remove once the SDK
+      // reopens-and-retries on pagehide/bfcache connection teardown
+      // (SPHERE-M/1G) — until then these are unactionable lifecycle noise.
+      'The database connection is closing',
     ],
     // Errors thrown by injected extension scripts (other wallets) and the GA
-    // tag are not ours
-    denyUrls: [/^chrome-extension:\/\//, /^moz-extension:\/\//, /googletagmanager\.com/],
+    // tag are not ours. blob: is safe to deny wholesale — first-party code
+    // never executes from blob: URLs (createObjectURL is only used for backup
+    // file downloads); extensions injecting code via blob: do (SPHERE-1F).
+    denyUrls: [
+      /^chrome-extension:\/\//,
+      /^moz-extension:\/\//,
+      /^safari-(?:web-)?extension:\/\//,
+      /^blob:/,
+      /googletagmanager\.com/,
+    ],
   });
 }

--- a/src/utils/sentryScrub.ts
+++ b/src/utils/sentryScrub.ts
@@ -35,12 +35,27 @@ const NAMETAG_RE = /@[a-z0-9_-]{2,64}(?![a-z0-9_/-])/gi;
 // Key names whose values must never ride along in extra/contexts/tags
 const SENSITIVE_KEY_RE = /mnemonic|seed|phrase|private|secret|password|passphrase|entropy|token|key/i;
 
+// Grouping normalization: SDK messages interpolate per-occurrence identifiers,
+// so Sentry fingerprints diverge and the SAME defect mints a new issue per
+// occurrence (SPHERE-25 split off SPHERE-R over an intent UUID; SPHERE-1Z off
+// SPHERE-Y over an agent name). Normalizing here is also privacy-positive.
+// Deliberately NOT normalized: HTTP status codes in messages — they carry the
+// only diagnostic signal those events have.
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const SINCE_CURSOR_RE = /([?&]since=)\d+/g;
+const QUOTED_RECIPIENT_RE = /(transport pubkey for )"[^"]{1,64}"/g;
+const RECIPIENT_IDENTITY_RE = /(Recipient )\S{1,64}( has no published identity)/g;
+
 export function scrubText(text: string): string {
   return text
     .replace(EMAIL_RE, '[email]')
     .replace(LONG_HEX_RE, '[hex]')
     .replace(MNEMONIC_RE, '[possible mnemonic]')
-    .replace(NAMETAG_RE, '@[nametag]');
+    .replace(NAMETAG_RE, '@[nametag]')
+    .replace(UUID_RE, ':id')
+    .replace(SINCE_CURSOR_RE, '$1:n')
+    .replace(QUOTED_RECIPIENT_RE, '$1"[nametag]"')
+    .replace(RECIPIENT_IDENTITY_RE, '$1[nametag]$2');
 }
 
 /**
@@ -108,26 +123,57 @@ export function scrubTransactionEvent<E extends TransactionEvent>(event: E): E {
 // unsupportedMethod, disconnected, chainDisconnected). Positive 4xxx codes are
 // wallet-provider-specific — our own JSON-RPC surfaces (aggregator, wallet-api)
 // use -32xxx — so a rejection carrying one cannot have come from our code.
+// LATENT COLLISION (documented, currently safe): sphere-sdk's Connect protocol
+// reuses 4001/4100/4200 in its own ERROR_CODES — but ConnectClient/ConnectHost
+// always reject ConnectError, a real Error, which never produces the
+// `__serialized__` plain-object shape this filter requires. If a connect
+// surface ever rejects a bare `{code: 4001, ...}` object, this filter would
+// eat it — the regression test pins the Error-instance path staying captured.
 const EIP1193_CODES = new Set([4001, 4100, 4200, 4900, 4901]);
 const EXTENSION_URL_RE = /\b(?:chrome|moz|safari-web)-extension:\/\//;
+// chrome.tabs.* error strings relayed by extension background scripts — these
+// cannot originate from web-page code (SPHERE-H).
+const CHROME_TABS_MSG_RE = /^No tab with id: -?\d+\.?$/;
 
 /**
  * Unhandled promise rejections thrown by injected wallet-extension provider
- * scripts (EIP-1193). This app never calls `window.ethereum` — these originate
- * wholly inside extensions whose inpage scripts run in our page context. They
- * reject with PLAIN OBJECTS, so Sentry builds a synthetic event with no stack
- * frames and `denyUrls` (which matches frame URLs) never sees the extension
- * origin — it survives only as a string inside `extra.__serialized__.stack`.
- * SPHERE-9 / SPHERE-A: ~1.4k events (~27% of monthly quota) in 5 days.
+ * scripts. This app never calls `window.ethereum` — these originate wholly
+ * inside extensions whose inpage scripts run in our page context. They reject
+ * with PLAIN OBJECTS, so Sentry builds a synthetic event with no stack frames
+ * and `denyUrls` (which matches frame URLs) never sees the extension origin.
+ * Shapes seen in production, ~49% of all events (SPHERE-9/A/D/H/E):
+ *   {code: 4900, message, stack?}                       — EIP-1193 provider
+ *   {code: -32603, message, data: {originalError}}      — @metamask/rpc-errors
+ *   {message: 'No tab with id: N.'}                     — chrome.tabs relay
+ *   {}                                                  — keyless, stripped
+ *                                                          crossing the
+ *                                                          content-script
+ *                                                          boundary
+ * Every app/SDK error surface rejects real Error subclasses (SphereError,
+ * ConnectError, WalletApiError, JsonRpcNetworkError), which Sentry captures
+ * with a real exception and NO `__serialized__` extra — so matching on the
+ * serialized plain object is collision-free by construction.
  */
 export function isInjectedProviderNoise(event: ErrorEvent): boolean {
   const mechanism = event.exception?.values?.[0]?.mechanism?.type ?? '';
   if (!mechanism.includes('onunhandledrejection')) return false;
   const serialized = (event.extra as Record<string, unknown> | undefined)?.['__serialized__'];
   if (typeof serialized !== 'object' || serialized === null) return false;
-  const { code, stack } = serialized as { code?: unknown; stack?: unknown };
+  const { code, stack, message, data } = serialized as {
+    code?: unknown; stack?: unknown; message?: unknown; data?: unknown;
+  };
   if (typeof code === 'number' && EIP1193_CODES.has(code)) return true;
-  return typeof stack === 'string' && EXTENSION_URL_RE.test(stack);
+  if (typeof stack === 'string' && EXTENSION_URL_RE.test(stack)) return true;
+  // @metamask/rpc-errors serializeError: our surfaces never wrap a rejection
+  // in {code: -32603, data: {originalError}} (SPHERE-D, 353 events).
+  if (code === -32603 && typeof data === 'object' && data !== null && 'originalError' in data) {
+    return true;
+  }
+  if (typeof message === 'string' && (CHROME_TABS_MSG_RE.test(message) || message === 'Cannot verify request origin')) {
+    return true;
+  }
+  // A keyless object carries zero diagnostic value by construction (SPHERE-E).
+  return Object.keys(serialized).length === 0;
 }
 
 export function scrubEvent<E extends ErrorEvent>(event: E): E {

--- a/tests/unit/utils/sentryScrub.test.ts
+++ b/tests/unit/utils/sentryScrub.test.ts
@@ -237,3 +237,77 @@ describe('isInjectedProviderNoise', () => {
     expect(isInjectedProviderNoise({ exception: { values: [] } } as unknown as ErrorEvent)).toBe(false);
   });
 });
+
+describe('isInjectedProviderNoise v2 (SPHERE-D/H/E shapes)', () => {
+  const rejection2 = (serialized: unknown): ErrorEvent =>
+    ({
+      exception: { values: [{ type: 'UnhandledRejection', mechanism: { type: 'auto.browser.global_handlers.onunhandledrejection' } }] },
+      extra: { __serialized__: serialized },
+    }) as unknown as ErrorEvent;
+
+  it('drops the @metamask/rpc-errors serializeError shape (SPHERE-D)', () => {
+    expect(
+      isInjectedProviderNoise(
+        rejection2({ code: -32603, message: 'Internal JSON-RPC error.', data: { originalError: '[Object]' } })
+      )
+    ).toBe(true);
+  });
+
+  it('keeps -32603 WITHOUT data.originalError — our JSON-RPC surfaces can produce plain -32xxx', () => {
+    expect(isInjectedProviderNoise(rejection2({ code: -32603, message: 'Internal JSON-RPC error.' }))).toBe(false);
+    expect(isInjectedProviderNoise(rejection2({ code: -32603, message: 'x', data: { cause: 'y' } }))).toBe(false);
+  });
+
+  it('drops chrome.tabs relay strings (SPHERE-H)', () => {
+    expect(isInjectedProviderNoise(rejection2({ message: 'No tab with id: 1926953339.' }))).toBe(true);
+    expect(isInjectedProviderNoise(rejection2({ message: 'No tab with id: -1' }))).toBe(true);
+    expect(isInjectedProviderNoise(rejection2({ message: 'Cannot verify request origin' }))).toBe(true);
+  });
+
+  it('keeps ordinary message-bearing object rejections', () => {
+    expect(isInjectedProviderNoise(rejection2({ message: 'No tab with id: abc' }))).toBe(false);
+    expect(isInjectedProviderNoise(rejection2({ message: 'something else entirely' }))).toBe(false);
+  });
+
+  it('drops keyless objects (SPHERE-E) — zero diagnostic value by construction', () => {
+    expect(isInjectedProviderNoise(rejection2({}))).toBe(true);
+  });
+
+  it('regression guard: an Error-instance rejection (no __serialized__) with a connect ERROR_CODE is never dropped', () => {
+    // sphere-sdk connect reuses 4001/4100/4200 — safe only because ConnectError
+    // is a real Error, which Sentry captures WITHOUT extra.__serialized__.
+    const event = {
+      exception: { values: [{ type: 'ConnectError', value: 'not connected', mechanism: { type: 'auto.browser.global_handlers.onunhandledrejection' } }] },
+      extra: {},
+    } as unknown as ErrorEvent;
+    expect(isInjectedProviderNoise(event)).toBe(false);
+  });
+});
+
+describe('scrubText grouping normalization', () => {
+  it('normalizes UUIDs so per-occurrence ids stop splitting Sentry issues (SPHERE-R vs 25)', () => {
+    expect(scrubText('PUT /v1/intents/c3cef661-2d0c-4d04-8295-492f0343496b: VALIDATION_FAILED')).toBe(
+      'PUT /v1/intents/:id: VALIDATION_FAILED'
+    );
+  });
+
+  it('normalizes since-cursors', () => {
+    expect(scrubText('GET /v1/history?since=1752349000123 failed')).toBe('GET /v1/history?since=:n failed');
+  });
+
+  it('normalizes quoted transport-pubkey recipients (SPHERE-Y vs 1Z)', () => {
+    expect(scrubText('Cannot resolve transport pubkey for "sphere-swap". No binding event found.')).toBe(
+      'Cannot resolve transport pubkey for "[nametag]". No binding event found.'
+    );
+  });
+
+  it('normalizes recipient-identity messages', () => {
+    expect(scrubText('Recipient vlad has no published identity (chain pubkey)')).toBe(
+      'Recipient [nametag] has no published identity (chain pubkey)'
+    );
+  });
+
+  it('leaves HTTP status codes intact — the only diagnostic signal those messages carry', () => {
+    expect(scrubText('blob upload failed with status 503')).toBe('blob upload failed with status 503');
+  });
+});


### PR DESCRIPTION
Quota protection: ~49% of all Sentry events are injected-extension noise, and the free tier is 5k events/month. The built-in browser-extensions inbound filter is already ON and can't catch these (frameless plain-object rejections; the extension origin never appears in stack frames), and message-based custom inbound filters are a paid feature — so client-side `beforeSend` is the only lever.

## Filter v2 (extends #428)

Three new discriminators in `isInjectedProviderNoise`, each verified collision-free — every app/SDK error surface rejects real `Error` subclasses, which Sentry captures **without** `extra.__serialized__` (the shape this filter requires); greps over app src, SDK source **and the shipped SDK bundle incl. transitive deps** found zero plain-object rejections:

| Shape dropped | Sentry issue | Events |
|---|---|---|
| `{code:-32603, data:{originalError}}` (@metamask/rpc-errors `serializeError`) | SPHERE-D | 353 |
| `"No tab with id: N."` / `"Cannot verify request origin"` (chrome.tabs relay — impossible from web-page code) | SPHERE-H | 68 |
| keyless `{}` (stripped crossing the content-script boundary; zero diagnostic value by construction) | SPHERE-E | 28 |

Kept deliberately: `-32603` **without** `data.originalError` (our JSON-RPC surfaces use `-32xxx`), and a regression test pins that an Error-instance rejection carrying a connect `ERROR_CODE` (4001/4100/4200 overlap EIP-1193) is never dropped.

## ignoreErrors / denyUrls additions

MetaMask/RainbowKit content-script probes, orphaned `chrome.runtime` channels, Telegram `postEvent`, Zalo `zaloJSV2`, WKWebView bridge (SPHERE-G/K/1M/1T/16/1B/13 — none of these strings exist in our bundle or the SDK), plus `denyUrls` for `blob:` (verified: first-party code never executes from blob: — `createObjectURL` is download-anchors only, no Workers anywhere) and safari-extension parity. Interim entry for `'The database connection is closing'` (SPHERE-M/1G) with a TODO tied to the planned SDK IndexedDB reopen-retry fix — **known tradeoff**: this also mutes a persistent-failure loop after browser force-close (no event fires), so the SDK fix should not slip.

## Release pinning

Production events currently carry whatever `window.SENTRY_RELEASE` the last-loaded extension injected (Phantom's "26.15.2", VPN extensions, …) because we never set `release` — corrupting release-based regression detection. Now baked from `VITE_BUILD_SHA` (new **env-agnostic** Dockerfile ARG — identical for staging and prod, so build-once-promote-many is preserved; docker-validate builds without args and gets `release: undefined`, which *also* deliberately defeats the `window.SENTRY_RELEASE` fallback — commented as load-bearing). Both `Dockerfile` and `Dockerfile.ssl` get the ARG; `deploy/runtime-config.sh` only seds `__RUNTIME_*__` so it can't touch the sha.

## Grouping normalization (scrubText)

Interpolated identifiers were minting duplicate issues: intent UUIDs (SPHERE-25 split off SPHERE-R), transport recipient names (SPHERE-1Z off SPHERE-Y), since-cursors. Now normalized to `:id` / `[nametag]` / `:n` — privacy-positive too. HTTP status codes deliberately **kept** (only diagnostic signal those messages carry).

## Verification

38/38 scrub tests (16 new), full suite 265/265, tsc/lint clean, prod build OK. Adversarial review: ship — confirmed no false-positive path, regex complexity linear (200KB adversarial inputs ≤107ms), docker-validate/pages/runtime-config plumbing unaffected.

After merge + deploy: set SPHERE-D/H/E/G/K/1M/1T/16/1B/13/1F/17 to **Ignored** in Sentry (their residual events from cached old bundles still count against quota until clients refresh, so expect the drop to phase in over a day or two).