### PR TITLE
feat(subscription): in-place key upgrade, ack-based key delivery, real renew

### DIFF
--- a/src/components/subscription/PlanCard.tsx
+++ b/src/components/subscription/PlanCard.tsx
@@ -15,16 +15,23 @@ interface PlanCardProps {
   popular: boolean;
   /** When provided (and the card is not the current plan) the card shows a CTA. */
   onSelect?: (plan: PlanInfo) => void;
+  /**
+   * Lapsed subscription: the CURRENT plan's store card becomes purchasable
+   * again ("Renew" — same key, fresh 30 days). Never applies to the synthetic
+   * free-priced current card, which is not a store product.
+   */
+  renewable?: boolean;
   loading?: boolean;
   disabled?: boolean;
   /** Mount variants (supplied by PlansGrid for the staggered reveal). */
   variants?: Variants;
 }
 
-export function PlanCard({ plan, current, popular, onSelect, loading, disabled, variants }: PlanCardProps) {
+export function PlanCard({ plan, current, popular, onSelect, renewable, loading, disabled, variants }: PlanCardProps) {
   const price = formatPlanPrice(plan);
   const features = planFeatures(plan);
-  const showCta = !!onSelect && !current;
+  const renewCta = current && !!renewable && plan.priceCents > 0;
+  const showCta = !!onSelect && (!current || renewCta);
 
   return (
     <motion.div
@@ -69,20 +76,20 @@ export function PlanCard({ plan, current, popular, onSelect, loading, disabled, 
 
       {/* CTA */}
       <div className="mt-5 min-h-10">
-        {current ? (
-          <div className="w-full rounded-xl border border-emerald-500/30 py-2 text-center text-sm font-medium text-emerald-500">
-            Your current plan
-          </div>
-        ) : showCta ? (
+        {showCta ? (
           <Button
-            variant={popular ? 'primary' : 'secondary'}
+            variant={renewCta || popular ? 'primary' : 'secondary'}
             fullWidth
             loading={loading}
             disabled={disabled}
             onClick={() => onSelect?.(plan)}
           >
-            {price === 'Free' ? 'Get started' : 'Choose plan'}
+            {renewCta ? 'Renew plan' : price === 'Free' ? 'Get started' : 'Choose plan'}
           </Button>
+        ) : current ? (
+          <div className="w-full rounded-xl border border-emerald-500/30 py-2 text-center text-sm font-medium text-emerald-500">
+            Your current plan
+          </div>
         ) : null}
       </div>
 

--- a/src/components/subscription/PlansGrid.tsx
+++ b/src/components/subscription/PlansGrid.tsx
@@ -20,13 +20,15 @@ interface PlansGridProps {
   currentPlanName: string | null;
   /** Provide to make cards selectable (upgrade flow). Omit for an info-only grid. */
   onSelect?: (plan: PlanInfo) => void;
+  /** Lapsed subscription: the current plan's store card offers a "Renew" CTA. */
+  renewableCurrent?: boolean;
   /** planId currently being processed (shows a spinner on that card's CTA). */
   loadingPlanId?: number | null;
   /** Disable all CTAs (e.g. while another checkout is pending). */
   disabled?: boolean;
 }
 
-export function PlansGrid({ plans, currentPlanName, onSelect, loadingPlanId, disabled }: PlansGridProps) {
+export function PlansGrid({ plans, currentPlanName, onSelect, renewableCurrent, loadingPlanId, disabled }: PlansGridProps) {
   const reduce = useReducedMotion();
 
   const container: Variants = {
@@ -69,6 +71,7 @@ export function PlansGrid({ plans, currentPlanName, onSelect, loadingPlanId, dis
               current={plan.name.toLowerCase() === (currentPlanName ?? '').toLowerCase()}
               popular={isPopularPlan(plan)}
               onSelect={onSelect}
+              renewable={renewableCurrent}
               loading={loadingPlanId === plan.planId}
               disabled={disabled}
               variants={item}

--- a/src/components/subscription/planFeatures.ts
+++ b/src/components/subscription/planFeatures.ts
@@ -33,6 +33,28 @@ export function planFeatures(plan: PlanInfo): string[] {
 }
 
 /**
+ * Whether a plan card is a valid purchase target right now. The synthetic
+ * current card (priceCents 0) is informational only. Re-buying the current
+ * plan is blocked while it's ACTIVE — the gateway resets the window to
+ * now+30d with no time carry-over, so an early re-buy only loses time — but
+ * allowed once the subscription lapses ('expired'/'inactive'/unknown): that
+ * is the renew path (same key, fresh 30 days).
+ */
+export function isPlanSelectable(
+  plan: PlanInfo,
+  opts: {
+    currentPlanName: string | null;
+    subscriptionStatus: 'active' | 'expired' | 'inactive' | null;
+    paidPlansEnabled: boolean;
+  },
+): boolean {
+  if (plan.priceCents <= 0) return false;
+  if (!opts.paidPlansEnabled) return false;
+  const isCurrent = plan.name.toLowerCase() === (opts.currentPlanName ?? '').toLowerCase();
+  return !(isCurrent && opts.subscriptionStatus === 'active');
+}
+
+/**
  * The store list excludes the free plan, so the user's current (free) plan card
  * is synthesized from utilization data. planId -1 is never a store id.
  */

--- a/src/components/upgrade/UpgradeModal.tsx
+++ b/src/components/upgrade/UpgradeModal.tsx
@@ -7,9 +7,14 @@ import { PlansGrid } from '../subscription/PlansGrid';
 import { CurrentPlanShowcase } from '../subscription/CurrentPlanShowcase';
 import { UpgradeSuccess } from './UpgradeSuccess';
 import { usePlans, useUtilization, useCheckout } from '../../sdk/hooks/subscription';
-import { pollOrderStatus } from '../../sdk/subscription/pollOrder';
-import { getOrderStatus, type PlanInfo } from '../../services/subscriptionApi';
-import { syntheticCurrentPlan, formatPlanPrice } from '../subscription/planFeatures';
+import { pollOrderStatus, type OrderPollResult } from '../../sdk/subscription/pollOrder';
+import { resolveCheckoutOutcome } from '../../sdk/subscription/checkoutOutcome';
+import { validatePastedKey } from '../../sdk/subscription/keyCheck';
+import { loadWalletKey } from '../../sdk/subscription/keyVault';
+import { rememberPlan } from '../../sdk/subscription/planMemory';
+import { getOrderStatus, ackOrderKeyDelivery, type PlanInfo } from '../../services/subscriptionApi';
+import { syntheticCurrentPlan, formatPlanPrice, isPlanSelectable } from '../subscription/planFeatures';
+import { getStoredSubscriptionKey } from '../../config/storageKeys';
 import { SUBSCRIPTION_MOCK, PAID_PLANS_ENABLED } from '../../config/subscription';
 import { showToast } from '../ui/toast-utils';
 import { useQueryClient } from '@tanstack/react-query';
@@ -17,6 +22,12 @@ import { SPHERE_KEYS } from '../../sdk/queryKeys';
 import { useSphereContext } from '../../sdk/hooks';
 import { getPublicKey } from '@unicitylabs/sphere-sdk';
 import type { UpgradeReason } from './UpgradeContext';
+
+/** Local mirror of the gateway's mask ("sk_...abcd") for keys we hold in full. */
+function maskKey(key: string): string {
+  if (key.length < 12) return '...';
+  return `${key.startsWith('sk_') ? 'sk_' : ''}...${key.slice(-4)}`;
+}
 
 type Step = 'plans' | 'email' | 'awaiting' | 'claim' | 'success' | 'error';
 
@@ -59,7 +70,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const util = useUtilization();
   const checkout = useCheckout();
   const queryClient = useQueryClient();
-  const { sphere, applySubscriptionKey } = useSphereContext();
+  const { sphere, applySubscriptionKey, network } = useSphereContext();
 
   const [step, setStep] = useState<Step>('plans');
   const [error, setError] = useState<string | null>(null);
@@ -67,9 +78,16 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
   const [selectedPlan, setSelectedPlan] = useState<PlanInfo | null>(null);
   const [email, setEmail] = useState('');
   const [claimKey, setClaimKey] = useState('');
+  const [claimError, setClaimError] = useState<string | null>(null);
   const [claiming, setClaiming] = useState(false);
   const [newApiKey, setNewApiKey] = useState<string | null>(null);
   const [walletWide, setWalletWide] = useState(false);
+  /** Key sent to checkout for an in-place upgrade (null = fresh-key purchase). */
+  const [upgradeTargetKey, setUpgradeTargetKey] = useState<string | null>(null);
+  /** Success came from an in-place upgrade — render the "same key" variant. */
+  const [upgradedMaskedKey, setUpgradedMaskedKey] = useState<string | null>(null);
+  /** Checkout failed while carrying an upgrade key — offer buying a new key instead. */
+  const [upgradeRejected, setUpgradeRejected] = useState(false);
 
   // Cancels the in-flight checkout poll when the modal closes (or a newer
   // checkout starts). Without this the poll outlives the modal and can
@@ -97,11 +115,12 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
     [plans.data, freePlan],
   );
 
+  const subscriptionStatus = util.data?.status ?? null;
+  // A lapsed plan's own store card becomes the renew path (same key, fresh 30 days).
+  const renewableCurrent = subscriptionStatus !== null && subscriptionStatus !== 'active';
+
   const handleSelect = (plan: PlanInfo) => {
-    if (plan.name.toLowerCase() === (currentPlanName ?? '').toLowerCase()) return;
-    // Paid plans aren't purchasable yet (testnet) — the card shows "Coming on
-    // Mainnet" and no CTA; this guards any other entry path.
-    if (!PAID_PLANS_ENABLED && plan.priceCents > 0) return;
+    if (!isPlanSelectable(plan, { currentPlanName, subscriptionStatus, paidPlansEnabled: PAID_PLANS_ENABLED })) return;
     setSelectedPlan(plan);
     setStep('email');
   };
@@ -117,13 +136,21 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
     showToast(`Upgraded to ${selectedPlan?.name ?? 'new plan'}`, 'success', 4000);
   };
 
-  // Claim-step activation: adoptKey can reject (e.g. storage blocked while
-  // persisting the key) — surface it on the error step instead of leaving the
-  // user stuck. claimKey is kept so "I have a key" lets them retry.
+  // Claim-step activation: the pasted key is first sanity-checked against the
+  // gateway (definitive unknown/revoked rejects inline; a failed lookup fails
+  // open). adoptKey can still reject (e.g. storage blocked while persisting) —
+  // surface that on the error step. claimKey is kept so "I have a key" lets
+  // them retry.
   const activateClaimKey = async () => {
     setClaiming(true);
     setError(null);
+    setClaimError(null);
     try {
+      const verdict = await validatePastedKey(claimKey);
+      if (!verdict.valid) {
+        setClaimError(verdict.message ?? 'This key is not valid.');
+        return;
+      }
       await adoptKey(claimKey);
     } catch (e) {
       setStep('error');
@@ -133,16 +160,43 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
     }
   };
 
-  const startCheckout = async () => {
+  /**
+   * The key this purchase should upgrade in place: the wallet key when the
+   * purchase is wallet-wide (root address or the checkbox), otherwise whatever
+   * key the active address currently uses. Null (no key yet, or the user chose
+   * "buy a new key instead") turns the checkout into a fresh-key purchase.
+   */
+  const resolveUpgradeKey = async (): Promise<string | null> => {
+    try {
+      if ((onRootAddress || walletWide) && sphere) {
+        return (await loadWalletKey(sphere, network)) ?? getStoredSubscriptionKey();
+      }
+    } catch {
+      // fall through to the boot cache
+    }
+    return getStoredSubscriptionKey();
+  };
+
+  const startCheckout = async (opts?: { forceNewKey?: boolean }) => {
     if (!selectedPlan) return;
     setError(null);
+    setUpgradeRejected(false);
     // Supersede any prior in-flight poll, then track this one so close/unmount
     // can abort it.
     checkoutAbortRef.current?.abort();
     const abort = new AbortController();
     checkoutAbortRef.current = abort;
+    // Always ask for an in-place upgrade of the existing key (same key, new
+    // plan, fresh 30 days). Pre-upgrade gateways ignore the field and mint a
+    // new key — the order's `upgrade` flag tells us which flow ran.
+    const upgradeApiKey = opts?.forceNewKey ? null : await resolveUpgradeKey();
+    setUpgradeTargetKey(upgradeApiKey);
     try {
-      const { orderId, redirectUrl } = await checkout.mutateAsync({ planId: selectedPlan.planId, email });
+      const { orderId, redirectUrl } = await checkout.mutateAsync({
+        planId: selectedPlan.planId,
+        email,
+        upgradeApiKey: upgradeApiKey ?? undefined,
+      });
       // Closed (or superseded) during order creation — don't pop a payment tab
       // or strand the modal on 'awaiting' after the user cancelled.
       if (abort.signal.aborted) return;
@@ -150,31 +204,59 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
       window.open(redirectUrl, '_blank', 'noopener,noreferrer');
       setStep('awaiting');
 
-      const result = SUBSCRIPTION_MOCK
-        ? { outcome: 'paid' as const, apiKey: 'sk_mock_upgraded' } // demoable without a backend
+      const result: OrderPollResult = SUBSCRIPTION_MOCK
+        ? upgradeApiKey // demoable without a backend — mirror the live gateway's two shapes
+          ? { outcome: 'paid', upgrade: true, maskedKey: maskKey(upgradeApiKey), planName: selectedPlan.name }
+          : { outcome: 'paid', upgrade: false, apiKey: 'sk_mock_upgraded' }
         : await pollOrderStatus(() => getOrderStatus(orderId), { signal: abort.signal });
 
       // Modal closed (or a newer checkout took over) while polling — do NOT
       // adopt a key or touch step/error state on a torn-down flow.
       if (abort.signal.aborted) return;
 
-      if (result.outcome === 'cancelled') return;
-
-      if (result.outcome === 'paid' && result.apiKey) {
-        await adoptKey(result.apiKey);
-      } else if (result.outcome === 'paid') {
-        setStep('claim'); // reveal consumed by the gateway return page — let the user paste it
-      } else if (result.outcome === 'failed') {
-        setStep('error');
-        setError('The payment was not completed. No charge was made — you can try again.');
-      } else {
-        setStep('error');
-        setError('Payment not detected yet. If you paid, open the payment return page — your API key is shown there once — then paste it via "I have a key".');
+      const action = resolveCheckoutOutcome(result);
+      switch (action.kind) {
+        case 'cancelled':
+          return;
+        case 'upgraded': {
+          // Same key, new plan — nothing to adopt or re-init; just refresh the
+          // subscription read models and remember the plan for the
+          // downgrade watcher.
+          await queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.subscription.all });
+          const planName = action.planName ?? selectedPlan.name;
+          if (upgradeApiKey) rememberPlan(upgradeApiKey, planName);
+          setUpgradedMaskedKey(action.maskedKey ?? (upgradeApiKey ? maskKey(upgradeApiKey) : null));
+          setStep('success');
+          showToast(`Upgraded to ${planName}`, 'success', 4000);
+          return;
+        }
+        case 'adopt':
+          await adoptKey(action.apiKey);
+          // Stop the gateway's key delivery only AFTER the key is persisted;
+          // fire-and-forget — an unsent ack just leaves the key deliverable.
+          void ackOrderKeyDelivery(orderId);
+          return;
+        case 'claim':
+          setStep('claim');
+          return;
+        case 'failed':
+          setStep('error');
+          setError('The payment was not completed. No charge was made — you can try again.');
+          return;
+        case 'timeout':
+          setStep('error');
+          setError(
+            'Payment not detected yet. It may still be confirming — keep the payment tab open and reopen this dialog in a minute.',
+          );
+          return;
       }
     } catch (e) {
       if (abort.signal.aborted) return; // torn down mid-checkout — stay silent
       setStep('error');
       setError(e instanceof Error ? e.message : 'Checkout failed');
+      // The gateway validates the upgrade key up front (unknown/revoked → 400):
+      // give the user a way to buy a fresh key instead of the upgrade.
+      setUpgradeRejected(!!upgradeApiKey);
     }
   };
 
@@ -187,9 +269,13 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
     setSelectedPlan(null);
     setEmail('');
     setClaimKey('');
+    setClaimError(null);
     setClaiming(false);
     setNewApiKey(null);
     setWalletWide(false);
+    setUpgradeTargetKey(null);
+    setUpgradedMaskedKey(null);
+    setUpgradeRejected(false);
     onClose();
   };
 
@@ -261,7 +347,12 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                   </div>
                 )}
                 {!plans.isLoading && !plans.isError && (
-                  <PlansGrid plans={gridPlans} currentPlanName={currentPlanName} onSelect={handleSelect} />
+                  <PlansGrid
+                    plans={gridPlans}
+                    currentPlanName={currentPlanName}
+                    renewableCurrent={renewableCurrent}
+                    onSelect={handleSelect}
+                  />
                 )}
               </>
             )}
@@ -276,6 +367,12 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                     Paymento will send the payment link and receipt to this email.
                   </p>
                 </div>
+                {subscriptionStatus === 'active' && util.data?.activeUntil && (
+                  <p className="rounded-xl border border-amber-500/20 bg-amber-500/10 p-3 text-xs text-neutral-600 dark:text-white/60">
+                    Your current plan is replaced as soon as the payment confirms — remaining time doesn't
+                    carry over. The new plan runs 30 days from payment.
+                  </p>
+                )}
                 <input
                   type="email"
                   value={email}
@@ -299,7 +396,7 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                   fullWidth
                   disabled={!/\S+@\S+\.\S+/.test(email)}
                   loading={checkout.isPending}
-                  onClick={startCheckout}
+                  onClick={() => void startCheckout()}
                 >
                   Continue to payment
                 </Button>
@@ -316,7 +413,11 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
             {step === 'awaiting' && (
               <div className="flex flex-col items-center gap-3 py-24 text-center">
                 <Loader2 className="h-8 w-8 animate-spin text-orange-500" />
-                <p className="text-sm">Complete the payment in the new tab — we'll pick up your new API key automatically.</p>
+                <p className="text-sm">
+                  {upgradeTargetKey
+                    ? `Complete the payment in the new tab — your key ${maskKey(upgradeTargetKey)} moves to the new plan automatically.`
+                    : "Complete the payment in the new tab — we'll pick up your new API key automatically."}
+                </p>
                 {paymentUrl && (
                   <a href={paymentUrl} target="_blank" rel="noopener noreferrer" className="text-sm text-orange-500 underline">
                     Payment page didn't open? Open it here
@@ -333,10 +434,14 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
                 </p>
                 <input
                   value={claimKey}
-                  onChange={(e) => setClaimKey(e.target.value.trim())}
+                  onChange={(e) => {
+                    setClaimKey(e.target.value.trim());
+                    setClaimError(null);
+                  }}
                   placeholder="sk_…"
                   className="w-full rounded-xl border border-neutral-200 bg-white px-4 py-2.5 font-mono text-sm outline-none focus:border-orange-500 dark:border-white/10 dark:bg-white/5"
                 />
+                {claimError && <p className="text-sm text-red-500">{claimError}</p>}
                 <Button
                   variant="primary"
                   fullWidth
@@ -349,16 +454,23 @@ export function UpgradeModal({ isOpen, reason, onClose }: UpgradeModalProps) {
               </div>
             )}
 
-            {step === 'success' && <UpgradeSuccess plan={selectedPlan} apiKey={newApiKey} onDone={handleClose} />}
+            {step === 'success' && (
+              <UpgradeSuccess plan={selectedPlan} apiKey={newApiKey} upgradedMaskedKey={upgradedMaskedKey} onDone={handleClose} />
+            )}
 
             {step === 'error' && (
               <div className="flex flex-col items-center gap-4 py-24 text-center">
                 <AlertTriangle className="h-8 w-8 text-yellow-500" />
                 <p className="max-w-md text-sm">{error}</p>
-                <div className="flex gap-3">
+                <div className="flex flex-wrap justify-center gap-3">
                   <Button variant="secondary" onClick={() => setStep('plans')}>
                     Back to plans
                   </Button>
+                  {upgradeRejected && (
+                    <Button variant="secondary" onClick={() => void startCheckout({ forceNewKey: true })}>
+                      Buy a new key instead
+                    </Button>
+                  )}
                   <Button variant="secondary" onClick={() => setStep('claim')}>
                     I have a key
                   </Button>

--- a/src/components/upgrade/UpgradeSuccess.tsx
+++ b/src/components/upgrade/UpgradeSuccess.tsx
@@ -47,12 +47,17 @@ function Confetti() {
 
 interface UpgradeSuccessProps {
   plan: PlanInfo | null;
-  /** One-time-revealed key from a fresh checkout (or pasted via the claim step) — renders the copy-me key box when set. */
+  /** Freshly issued key from a new-key checkout (or pasted via the claim step) — renders the copy-me key box when set. */
   apiKey?: string | null;
+  /**
+   * In-place upgrade: the existing key (masked, e.g. "sk_...abcd") that now
+   * carries the new plan — renders the "same key" note instead of a key box.
+   */
+  upgradedMaskedKey?: string | null;
   onDone: () => void;
 }
 
-export function UpgradeSuccess({ plan, apiKey, onDone }: UpgradeSuccessProps) {
+export function UpgradeSuccess({ plan, apiKey, upgradedMaskedKey, onDone }: UpgradeSuccessProps) {
   const [copied, setCopied] = useState(false);
   const copyKey = () => {
     if (!apiKey) return;
@@ -105,6 +110,12 @@ export function UpgradeSuccess({ plan, apiKey, onDone }: UpgradeSuccessProps) {
             {plan.requestsPerDay.toLocaleString()} commitments/day · up to {plan.requestsPerMinute.toLocaleString()}/minute
           </p>
         )}
+        {upgradedMaskedKey && (
+          <p className="text-sm text-neutral-500 dark:text-white/50">
+            Your key <code className="font-mono">{upgradedMaskedKey}</code> stays the same — the new limits
+            apply within a minute.
+          </p>
+        )}
       </motion.div>
 
       {/* What it unlocked */}
@@ -140,7 +151,8 @@ export function UpgradeSuccess({ plan, apiKey, onDone }: UpgradeSuccessProps) {
           <code className="block break-all font-mono text-xs">{apiKey}</code>
           <p className="mt-2 text-[11px] leading-snug text-yellow-700/80 dark:text-yellow-300/70">
             Save this key — it's tied to this purchase, not your wallet identity. Restoring the wallet
-            recovers only the free key; paste this one again in Settings if you switch devices.
+            recovers only your wallet's own identity-bound key, not this one; paste this key again in
+            Settings if you switch devices.
           </p>
         </div>
       )}

--- a/src/components/wallet/L3/modals/SubscriptionModal.tsx
+++ b/src/components/wallet/L3/modals/SubscriptionModal.tsx
@@ -8,6 +8,7 @@ import { usagePercent, formatExpiry, msUntil, formatCountdown } from '../../../.
 import { getStoredSubscriptionKey } from '../../../../config/storageKeys';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
 import { provisionOrRecoverKey } from '../../../../services/subscriptionApi';
+import { validatePastedKey } from '../../../../sdk/subscription/keyCheck';
 import { SPHERE_KEYS } from '../../../../sdk/queryKeys';
 
 interface SubscriptionModalProps {
@@ -212,7 +213,8 @@ function ApiKeyRow({ apiKey }: { apiKey: string }) {
         </span>
       </div>
       <p className="mt-1.5 text-[11px] text-neutral-500 dark:text-white/40">
-        Purchased keys aren't tied to your wallet identity — keep a copy. Restore recovers only the free key.
+        Your wallet's own key — including any plan bought for it — is recovered when you restore the
+        wallet. Keys pasted from elsewhere aren't; keep a copy of those.
       </p>
     </div>
   );
@@ -238,7 +240,15 @@ function EnterKeyRow() {
     setBusy(true);
     setError(null);
     try {
-      await applySubscriptionKey(value.trim());
+      const key = value.trim();
+      // Definitive unknown/revoked keys reject inline; a failed lookup fails
+      // open (the gateway still gates real usage).
+      const verdict = await validatePastedKey(key);
+      if (!verdict.valid) {
+        setError(verdict.message ?? 'This key is not valid.');
+        return;
+      }
+      await applySubscriptionKey(key);
       await queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.subscription.all });
       setOpen(false);
       setValue('');

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -28,6 +28,7 @@ import {
 import { getActiveOracleApiKey } from './oracleKey';
 import { SUBSCRIPTION_ENABLED } from '../config/subscription';
 import { resolveActiveKey, saveWalletKey, saveAddressKey, loadWalletKey } from './subscription/keyVault';
+import { validatePastedKey } from './subscription/keyCheck';
 import { isPaidPlan } from './subscription/usage';
 import type { SubscriptionKeyStatus } from './subscription/keyStatus';
 import { provisionOrRecoverKey, getUtilization } from '../services/subscriptionApi';
@@ -258,13 +259,26 @@ export function SphereProvider({
       // then mark the gate ready — but only while this reconcile is still the
       // latest (gen guard) and only once the engine actually carries THIS key
       // (appliedOracleKeyRef), never off the boot-cache slot alone.
-      const applyResolved = async (key: string, gen: number) => {
+      const applyResolved = async (key: string, gen: number, source: 'wallet' | 'own') => {
         if (gen !== subKeyGenRef.current) return;
         setStoredSubscriptionKey(key);
         await applyOracleKey(instance, key, gen);
         if (gen !== subKeyGenRef.current) return;
         if (appliedOracleKeyRef.current === key) {
           setSubscriptionKeyStatus('ready');
+          // Background sanity check of the resolved key against the gateway —
+          // without it a revoked/foreign vault key surfaces only as 401s at
+          // send time. Only a DEFINITIVE unknown/revoked verdict acts
+          // (validatePastedKey fails open on lookup errors / pre-key-info
+          // gateways); recovery re-provisions the identity's free key for the
+          // same scope, and a revoked identity key (which the gateway refuses
+          // to re-mint) lands on the existing terminal 'failed' + Settings
+          // recovery UX.
+          void validatePastedKey(key).then((verdict) => {
+            if (verdict.valid || gen !== subKeyGenRef.current) return;
+            console.warn('stored subscription key is unknown/revoked on the gateway — re-provisioning');
+            void provisionOwn(source === 'wallet' ? 'wallet' : 'address', gen);
+          });
         } else if (appliedOracleKeyRef.current === null) {
           // The engine rebuild did not land and the oracle is still keyless →
           // block the send gate (terminal 'failed') rather than leave it stuck
@@ -313,7 +327,7 @@ export function SphereProvider({
         const resolved = await resolveActiveKey(instance, network);
         if (gen !== subKeyGenRef.current) return;
         if (resolved.key) {
-          await applyResolved(resolved.key, gen);
+          await applyResolved(resolved.key, gen, resolved.source === 'wallet' ? 'wallet' : 'own');
           return;
         }
         // needs-own: index 0 → wallet key; else this address's own key.

--- a/src/sdk/hooks/subscription/useCheckout.ts
+++ b/src/sdk/hooks/subscription/useCheckout.ts
@@ -3,6 +3,7 @@ import { createStoreCheckout } from '../../../services/subscriptionApi';
 
 export function useCheckout() {
   return useMutation({
-    mutationFn: ({ planId, email }: { planId: number; email: string }) => createStoreCheckout(planId, email),
+    mutationFn: ({ planId, email, upgradeApiKey }: { planId: number; email: string; upgradeApiKey?: string }) =>
+      createStoreCheckout(planId, email, upgradeApiKey),
   });
 }

--- a/src/sdk/subscription/checkoutOutcome.ts
+++ b/src/sdk/subscription/checkoutOutcome.ts
@@ -1,0 +1,26 @@
+/**
+ * Maps a settled checkout poll onto the single UI action it warrants. Kept
+ * pure (UpgradeModal only executes the action) so the branching — the part the
+ * gateway contract change actually altered — is unit-testable without
+ * mounting the modal.
+ */
+import type { OrderPollResult } from './pollOrder';
+
+export type CheckoutOutcomeAction =
+  | { kind: 'upgraded'; maskedKey?: string; planName?: string }
+  | { kind: 'adopt'; apiKey: string }
+  | { kind: 'claim' }
+  | { kind: 'failed' }
+  | { kind: 'timeout' }
+  | { kind: 'cancelled' };
+
+export function resolveCheckoutOutcome(result: OrderPollResult): CheckoutOutcomeAction {
+  if (result.outcome !== 'paid') return { kind: result.outcome };
+  // Upgrade orders never deliver a key — the buyer already holds it; the plan
+  // change is entirely server-side.
+  if (result.upgrade) return { kind: 'upgraded', maskedKey: result.maskedKey, planName: result.planName };
+  if (result.apiKey) return { kind: 'adopt', apiKey: result.apiKey };
+  // Paid but keyless non-upgrade order: a pre-ack gateway whose one-time
+  // reveal was consumed by the payment return page — fall back to pasting it.
+  return { kind: 'claim' };
+}

--- a/src/sdk/subscription/keyCheck.ts
+++ b/src/sdk/subscription/keyCheck.ts
@@ -1,0 +1,25 @@
+/**
+ * Server-side sanity check for keys the user pastes by hand (Settings'
+ * "Use a different key", the upgrade claim step). Only a DEFINITIVE
+ * unknown/revoked verdict rejects; a failed lookup (pre-key-info gateway,
+ * network hiccup) fails open — the gateway still gates actual usage, so a
+ * transient error must not lock the user out of adopting a valid key.
+ */
+import { getKeyInfo } from '../../services/subscriptionApi';
+
+export interface PastedKeyVerdict {
+  valid: boolean;
+  message?: string;
+}
+
+export async function validatePastedKey(apiKey: string): Promise<PastedKeyVerdict> {
+  try {
+    const info = await getKeyInfo(apiKey);
+    if (info === null) {
+      return { valid: false, message: "This key wasn't found or has been revoked — check it for typos." };
+    }
+    return { valid: true };
+  } catch {
+    return { valid: true };
+  }
+}

--- a/src/sdk/subscription/pollOrder.ts
+++ b/src/sdk/subscription/pollOrder.ts
@@ -1,11 +1,22 @@
 /**
- * Polls a Paymento order until it settles. On 'paid' the response may carry the
- * one-time revealed apiKey — absent when the gateway return page consumed the
- * reveal first (the UI then falls back to a paste-key claim step).
+ * Polls a Paymento order until it settles. On 'paid':
+ * - `upgrade` true means the buyer's existing key was upgraded IN PLACE — no
+ *   key is ever delivered (only `maskedKey`/`planName`);
+ * - otherwise `apiKey` carries the freshly issued key, which current gateways
+ *   keep delivering until the caller acks receipt (ackOrderKeyDelivery). It is
+ *   absent only on a pre-ack gateway whose one-time reveal was consumed by the
+ *   payment return page (the UI then falls back to a paste-key claim step).
  */
 import type { OrderStatusInfo } from '../../services/subscriptionApi';
 
-export interface OrderPollResult { outcome: 'paid' | 'failed' | 'timeout' | 'cancelled'; apiKey?: string }
+export interface OrderPollResult {
+  outcome: 'paid' | 'failed' | 'timeout' | 'cancelled';
+  apiKey?: string;
+  /** Set on 'paid' only: whether the order upgraded an existing key in place. */
+  upgrade?: boolean;
+  maskedKey?: string;
+  planName?: string;
+}
 
 export async function pollOrderStatus(
   fetchStatus: () => Promise<OrderStatusInfo>,
@@ -45,7 +56,15 @@ export async function pollOrderStatus(
     if (signal?.aborted) return { outcome: 'cancelled' };
     try {
       const order = await fetchStatus();
-      if (order.status === 'paid') return { outcome: 'paid', apiKey: order.apiKey };
+      if (order.status === 'paid') {
+        return {
+          outcome: 'paid',
+          apiKey: order.apiKey,
+          upgrade: order.upgrade === true,
+          maskedKey: order.maskedKey,
+          planName: order.planName,
+        };
+      }
       if (order.status === 'failed') return { outcome: 'failed' };
     } catch {
       // transient — keep polling

--- a/src/services/subscriptionApi.mock.ts
+++ b/src/services/subscriptionApi.mock.ts
@@ -3,7 +3,7 @@
  * subscription UI (Phases 2–4) be built and visually verified without a
  * live backend. Shapes must match the real client's types exactly.
  */
-import type { PlanInfo, UtilizationInfo, ProvisionResult, CheckoutResult, OrderStatusInfo } from './subscriptionApi';
+import type { PlanInfo, UtilizationInfo, ProvisionResult, CheckoutResult, OrderStatusInfo, KeyInfo } from './subscriptionApi';
 
 // Per-minute values are the seeded gateway plans (V25 = old rps × 60; V23 cents).
 export const mockPlans: PlanInfo[] = [
@@ -36,12 +36,32 @@ export const mockCheckout: CheckoutResult = {
   redirectUrl: 'https://pay.example.test/gateway?token=mock',
 };
 
+// A fulfilled NEW-key order: the key stays deliverable on every poll until acked.
 export const mockOrderStatus: OrderStatusInfo = {
   orderId: 'ssc-mock',
   status: 'paid',
   statusName: 'Confirmed',
   fulfilled: true,
   confirming: false,
+  upgrade: false,
   apiKey: 'sk_mock_upgraded',
-  keyShownOnce: true,
+};
+
+// A fulfilled IN-PLACE upgrade order: no key is ever delivered, only its mask.
+export const mockOrderStatusUpgrade: OrderStatusInfo = {
+  orderId: 'ssc-mock-upgrade',
+  status: 'paid',
+  statusName: 'Approve',
+  fulfilled: true,
+  confirming: false,
+  upgrade: true,
+  maskedKey: 'sk_...free',
+  planName: 'premium',
+};
+
+export const mockKeyInfo: KeyInfo = {
+  maskedKey: 'sk_...free',
+  planName: 'free',
+  subscriptionState: 'active',
+  activeUntil: null, // free keys never expire
 };

--- a/src/services/subscriptionApi.ts
+++ b/src/services/subscriptionApi.ts
@@ -53,8 +53,25 @@ export interface OrderStatusInfo {
   statusName: string;
   fulfilled: boolean;
   confirming: boolean;
-  apiKey?: string; // revealed exactly once, when fulfilled
-  keyShownOnce?: boolean;
+  /**
+   * Fresh key of a non-upgrade order. Current gateways deliver it on EVERY
+   * poll until receipt is confirmed via order-key-ack; pre-ack gateways
+   * revealed it exactly once (first poll after fulfilment consumed it).
+   */
+  apiKey?: string;
+  /** True when this order upgrades an existing key in place (absent on pre-ack gateways). */
+  upgrade?: boolean;
+  /** Masked upgraded key, e.g. "sk_...abcd" — upgrade orders only. */
+  maskedKey?: string;
+  /** Purchased plan name — fulfilled upgrade orders only. */
+  planName?: string;
+}
+
+export interface KeyInfo {
+  maskedKey: string;
+  planName: string | null;
+  subscriptionState: 'active' | 'expired' | 'inactive';
+  activeUntil: string | null;
 }
 
 interface StorePlanWire {
@@ -148,14 +165,69 @@ export async function getStorePlans(): Promise<PlanInfo[]> {
   return data.availablePlans.map(({ id, ...rest }) => ({ planId: id, ...rest }));
 }
 
-/** Starts a Paymento checkout session for the given plan; redirect the user to `redirectUrl`. */
-export function createStoreCheckout(planId: number, email: string): Promise<CheckoutResult> {
+/**
+ * Starts a Paymento checkout session for the given plan; redirect the user to
+ * `redirectUrl`. Passing `upgradeApiKey` asks the gateway to upgrade that
+ * existing key IN PLACE (same key string, purchased plan, fresh 30-day window)
+ * instead of minting a new one; the gateway rejects unknown/revoked keys with
+ * a 400 up front. Pre-upgrade gateways ignore the extra field and mint a new
+ * key — callers detect which happened via order-status's `upgrade` flag.
+ */
+export function createStoreCheckout(planId: number, email: string, upgradeApiKey?: string): Promise<CheckoutResult> {
   if (SUBSCRIPTION_MOCK) return Promise.resolve(mock.mockCheckout);
-  return postJson<CheckoutResult>('/api/paymento/checkout', { planId, email });
+  const apiKey = upgradeApiKey?.trim();
+  return postJson<CheckoutResult>('/api/paymento/checkout', apiKey ? { planId, email, apiKey } : { planId, email });
 }
 
-/** Polls the fulfillment status of a checkout order; apiKey is surfaced exactly once, when fulfilled. */
+/** Polls the fulfillment status of a checkout order (see OrderStatusInfo for key-delivery semantics). */
 export function getOrderStatus(orderId: string): Promise<OrderStatusInfo> {
   if (SUBSCRIPTION_MOCK) return Promise.resolve(mock.mockOrderStatus);
   return request<OrderStatusInfo>(`/api/paymento/order-status?orderId=${encodeURIComponent(orderId)}`);
+}
+
+/**
+ * Confirms the freshly issued key was received and durably stored, ending its
+ * delivery in order-status responses — call ONLY after the key is persisted,
+ * since a premature ack makes a lost key unrecoverable. Never throws: true
+ * when acknowledged, false on a definitive refusal (404 = unknown order or a
+ * pre-ack gateway without the route; 409 = upgrade/unfulfilled order) or after
+ * the retry budget for transient failures is exhausted.
+ */
+export async function ackOrderKeyDelivery(
+  orderId: string,
+  opts: { attempts?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<boolean> {
+  if (SUBSCRIPTION_MOCK) return true;
+  const attempts = opts.attempts ?? 3;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const res = await fetch(
+        `${SUBSCRIPTION_API_URL}/api/paymento/order-key-ack?orderId=${encodeURIComponent(orderId)}`,
+        { method: 'POST' },
+      );
+      if (res.ok) return true;
+      if (res.status === 404 || res.status === 409) return false; // definitive — retrying can't change it
+    } catch {
+      // transient (network) — retry below
+    }
+    if (attempt < attempts) await sleep(1000 * attempt);
+  }
+  return false;
+}
+
+/**
+ * Read-only lookup of a key — the key itself is the credential. Returns null
+ * ONLY on the gateway's definitive "Unknown API key." 404 (unknown or revoked
+ * key); any other failure throws, including the route-missing 404 of pre-ack
+ * gateways ("Not found") — a missing endpoint must never read as a dead key.
+ */
+export async function getKeyInfo(apiKey: string): Promise<KeyInfo | null> {
+  if (SUBSCRIPTION_MOCK) return mock.mockKeyInfo;
+  const res = await fetch(`${SUBSCRIPTION_API_URL}/api/paymento/key-info`, { headers: { 'x-api-key': apiKey } });
+  if (res.ok) return res.json() as Promise<KeyInfo>;
+  const body = (await res.json().catch(() => null)) as { error?: unknown } | null;
+  const detail = typeof body?.error === 'string' && body.error !== '' ? body.error : null;
+  if (res.status === 404 && detail === 'Unknown API key.') return null;
+  throw new Error(detail ?? `subscription /api/paymento/key-info failed: ${res.status}`);
 }

--- a/tests/unit/components/planFeatures.test.ts
+++ b/tests/unit/components/planFeatures.test.ts
@@ -3,6 +3,7 @@ import {
   formatPlanPrice,
   isFreePlan,
   isPopularPlan,
+  isPlanSelectable,
   planFeatures,
   syntheticCurrentPlan,
 } from '@/components/subscription/planFeatures';
@@ -49,6 +50,33 @@ describe('planFeatures', () => {
 
   it('marks the free plan with a no-payment bullet', () => {
     expect(planFeatures({ ...basic, priceCents: 0 })[2]).toBe('Free — no payment required');
+  });
+});
+
+describe('isPlanSelectable', () => {
+  const active = { currentPlanName: 'basic', subscriptionStatus: 'active' as const, paidPlansEnabled: true };
+
+  it('allows buying a different paid plan', () => {
+    expect(isPlanSelectable({ ...basic, name: 'premium' }, active)).toBe(true);
+  });
+
+  it('blocks re-buying the ACTIVE current plan (nothing to gain — no time carry-over)', () => {
+    expect(isPlanSelectable(basic, active)).toBe(false);
+    expect(isPlanSelectable({ ...basic, name: 'Basic' }, active)).toBe(false); // case-insensitive
+  });
+
+  it('allows renewing the current plan once it is no longer active', () => {
+    expect(isPlanSelectable(basic, { ...active, subscriptionStatus: 'expired' })).toBe(true);
+    expect(isPlanSelectable(basic, { ...active, subscriptionStatus: 'inactive' })).toBe(true);
+    expect(isPlanSelectable(basic, { ...active, subscriptionStatus: null })).toBe(true);
+  });
+
+  it('never selects the synthetic/free card (it is not a store product)', () => {
+    expect(isPlanSelectable({ ...basic, priceCents: 0 }, { ...active, subscriptionStatus: 'expired' })).toBe(false);
+  });
+
+  it('blocks paid plans while purchases are disabled', () => {
+    expect(isPlanSelectable({ ...basic, name: 'premium' }, { ...active, paidPlansEnabled: false })).toBe(false);
   });
 });
 

--- a/tests/unit/sdk/checkoutOutcome.test.ts
+++ b/tests/unit/sdk/checkoutOutcome.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCheckoutOutcome } from '@/sdk/subscription/checkoutOutcome';
+
+describe('resolveCheckoutOutcome', () => {
+  it('maps an in-place upgrade to "upgraded" (never adopts, even if a key sneaks in)', () => {
+    expect(
+      resolveCheckoutOutcome({ outcome: 'paid', upgrade: true, maskedKey: 'sk_...abcd', planName: 'premium' }),
+    ).toEqual({ kind: 'upgraded', maskedKey: 'sk_...abcd', planName: 'premium' });
+  });
+
+  it('maps a fresh-key purchase to "adopt"', () => {
+    expect(resolveCheckoutOutcome({ outcome: 'paid', apiKey: 'sk_new', upgrade: false })).toEqual({
+      kind: 'adopt',
+      apiKey: 'sk_new',
+    });
+  });
+
+  it('maps paid-without-key (pre-ack gateway consumed the reveal) to the claim fallback', () => {
+    expect(resolveCheckoutOutcome({ outcome: 'paid', upgrade: false })).toEqual({ kind: 'claim' });
+  });
+
+  it('passes terminal outcomes through', () => {
+    expect(resolveCheckoutOutcome({ outcome: 'failed' })).toEqual({ kind: 'failed' });
+    expect(resolveCheckoutOutcome({ outcome: 'timeout' })).toEqual({ kind: 'timeout' });
+    expect(resolveCheckoutOutcome({ outcome: 'cancelled' })).toEqual({ kind: 'cancelled' });
+  });
+});

--- a/tests/unit/sdk/keyCheck.test.ts
+++ b/tests/unit/sdk/keyCheck.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/subscriptionApi', () => ({
+  getKeyInfo: vi.fn(),
+}));
+
+import { validatePastedKey } from '@/sdk/subscription/keyCheck';
+import { getKeyInfo } from '@/services/subscriptionApi';
+
+describe('validatePastedKey', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('accepts a key the gateway knows', async () => {
+    vi.mocked(getKeyInfo).mockResolvedValue({
+      maskedKey: 'sk_...abcd',
+      planName: 'basic',
+      subscriptionState: 'active',
+      activeUntil: null,
+    });
+    await expect(validatePastedKey('sk_' + 'a'.repeat(32))).resolves.toEqual({ valid: true });
+  });
+
+  it('rejects a definitively unknown/revoked key with a message', async () => {
+    vi.mocked(getKeyInfo).mockResolvedValue(null);
+    const res = await validatePastedKey('sk_' + 'b'.repeat(32));
+    expect(res.valid).toBe(false);
+    expect(res.message).toMatch(/wasn't found|revoked/i);
+  });
+
+  it('fails open when the lookup itself fails (old gateway / network hiccup)', async () => {
+    vi.mocked(getKeyInfo).mockRejectedValue(new Error('Not found'));
+    await expect(validatePastedKey('sk_' + 'c'.repeat(32))).resolves.toEqual({ valid: true });
+  });
+});

--- a/tests/unit/sdk/pollOrder.test.ts
+++ b/tests/unit/sdk/pollOrder.test.ts
@@ -10,12 +10,22 @@ it('resolves paid with the revealed key', async () => {
   // enumerable props) so intervalMs/timeoutMs/sleep fall back to prod defaults
   // and the test silently runs on a real 3s timer.
   const res = await pollOrderStatus(async () => seq.shift() ?? seq[0], instant());
-  expect(res).toEqual({ outcome: 'paid', apiKey: 'sk_new' });
+  expect(res).toEqual({ outcome: 'paid', apiKey: 'sk_new', upgrade: false });
 });
 
-it('resolves paid without a key when the reveal was consumed elsewhere', async () => {
+it('resolves paid without a key when the reveal was consumed elsewhere (pre-ack gateway)', async () => {
   const res = await pollOrderStatus(async () => ({ ...base, status: 'paid', fulfilled: true }), instant());
-  expect(res).toEqual({ outcome: 'paid', apiKey: undefined });
+  expect(res.outcome).toBe('paid');
+  expect(res.apiKey).toBeUndefined();
+  expect(res.upgrade).toBe(false);
+});
+
+it('passes through the in-place upgrade fields on paid', async () => {
+  const res = await pollOrderStatus(
+    async () => ({ ...base, status: 'paid', fulfilled: true, upgrade: true, maskedKey: 'sk_...abcd', planName: 'premium' }),
+    instant(),
+  );
+  expect(res).toEqual({ outcome: 'paid', apiKey: undefined, upgrade: true, maskedKey: 'sk_...abcd', planName: 'premium' });
 });
 
 it('resolves failed on a failed order', async () => {

--- a/tests/unit/sdk/subscriptionHooks.test.tsx
+++ b/tests/unit/sdk/subscriptionHooks.test.tsx
@@ -75,10 +75,17 @@ describe('subscription hooks', () => {
     expect(result.current.data?.utilization.consumedPerDay).toBe(10);
   });
 
-  it('useCheckout posts {planId, email}', async () => {
+  it('useCheckout posts {planId, email} without an upgrade key', async () => {
     const { result } = renderHook(() => useCheckout(), { wrapper });
     result.current.mutate({ planId: 3, email: 'a@b.com' });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(createStoreCheckout).toHaveBeenCalledWith(3, 'a@b.com');
+    expect(createStoreCheckout).toHaveBeenCalledWith(3, 'a@b.com', undefined);
+  });
+
+  it('useCheckout forwards the upgrade key for in-place upgrades', async () => {
+    const { result } = renderHook(() => useCheckout(), { wrapper });
+    result.current.mutate({ planId: 3, email: 'a@b.com', upgradeApiKey: 'sk_current' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(createStoreCheckout).toHaveBeenCalledWith(3, 'a@b.com', 'sk_current');
   });
 });

--- a/tests/unit/services/subscriptionApi.mock.test.ts
+++ b/tests/unit/services/subscriptionApi.mock.test.ts
@@ -11,6 +11,8 @@ import {
   getStorePlans,
   createStoreCheckout,
   getOrderStatus,
+  ackOrderKeyDelivery,
+  getKeyInfo,
 } from '@/services/subscriptionApi';
 
 describe('subscriptionApi mock mode', () => {
@@ -69,7 +71,7 @@ describe('subscriptionApi mock mode', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('returns a canned order status without calling fetch', async () => {
+  it('returns a canned order status without calling fetch (new ack contract — no keyShownOnce)', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
@@ -77,6 +79,27 @@ describe('subscriptionApi mock mode', () => {
 
     expect(status.status).toBe('paid');
     expect(status.fulfilled).toBe(true);
+    expect(status).not.toHaveProperty('keyShownOnce');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('acks key delivery without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(ackOrderKeyDelivery('ssc-mock')).resolves.toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns canned key info without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const info = await getKeyInfo('sk_mock_free');
+
+    expect(info).not.toBeNull();
+    expect(info?.maskedKey).toMatch(/^sk_\.\.\./);
+    expect(['active', 'expired', 'inactive']).toContain(info?.subscriptionState);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/subscriptionApi.test.ts
+++ b/tests/unit/services/subscriptionApi.test.ts
@@ -14,6 +14,8 @@ import {
   getStorePlans,
   createStoreCheckout,
   getOrderStatus,
+  ackOrderKeyDelivery,
+  getKeyInfo,
 } from '@/services/subscriptionApi';
 
 // The subscription identity is the wallet's INDEX-0 keypair (stable across
@@ -165,13 +167,106 @@ describe('subscriptionApi', () => {
     expect(res.orderId).toBe('ssc-1');
   });
 
-  it('getOrderStatus passes orderId and surfaces the one-time apiKey', async () => {
+  it('createStoreCheckout includes the upgrade apiKey in the body when provided', async () => {
+    const fetchSpy = mockFetchOnce({ json: { orderId: 'ssc-2', redirectUrl: 'https://app.paymento.io/gateway?token=u' } });
+    await createStoreCheckout(3, 'a@b.c', 'sk_' + 'e'.repeat(32));
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/paymento/checkout'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ planId: 3, email: 'a@b.c', apiKey: 'sk_' + 'e'.repeat(32) }),
+      }),
+    );
+  });
+
+  it('createStoreCheckout omits the apiKey field for blank upgrade keys', async () => {
+    const fetchSpy = mockFetchOnce({ json: { orderId: 'ssc-3', redirectUrl: 'https://x' } });
+    await createStoreCheckout(2, 'a@b.c', '  ');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ body: JSON.stringify({ planId: 2, email: 'a@b.c' }) }),
+    );
+  });
+
+  it('getOrderStatus passes through the ack-contract fields (apiKey on every poll, upgrade/maskedKey/planName)', async () => {
     mockFetchOnce({
-      json: { orderId: 'ssc-1', status: 'paid', statusName: 'Confirmed', fulfilled: true, confirming: false, apiKey: 'sk_new', keyShownOnce: true },
+      json: {
+        orderId: 'ssc-1', status: 'paid', statusName: 'Approve', fulfilled: true, confirming: false,
+        upgrade: true, maskedKey: 'sk_...abcd', planName: 'premium',
+      },
     });
     const res = await getOrderStatus('ssc-1');
     expect(res.status).toBe('paid');
-    expect(res.apiKey).toBe('sk_new');
+    expect(res.upgrade).toBe(true);
+    expect(res.maskedKey).toBe('sk_...abcd');
+    expect(res.planName).toBe('premium');
+    expect(res.apiKey).toBeUndefined();
+  });
+
+  describe('ackOrderKeyDelivery', () => {
+    it('POSTs to order-key-ack and resolves true on 200', async () => {
+      const fetchSpy = mockFetchOnce({ json: { acknowledged: true } });
+      await expect(ackOrderKeyDelivery('ssc-1')).resolves.toBe(true);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/paymento/order-key-ack?orderId=ssc-1'),
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('resolves false without retrying on 409 (upgrade order) and 404 (old gateway / unknown order)', async () => {
+      const on409 = mockFetchOnce({ ok: false, status: 409, json: { error: 'Upgrade orders have no key to acknowledge.' } });
+      await expect(ackOrderKeyDelivery('ssc-upg')).resolves.toBe(false);
+      expect(on409).toHaveBeenCalledTimes(1);
+
+      const on404 = mockFetchOnce({ ok: false, status: 404, json: { error: 'Not found' } });
+      await expect(ackOrderKeyDelivery('ssc-x')).resolves.toBe(false);
+      expect(on404).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries transient failures and never throws', async () => {
+      const fn = vi.fn()
+        .mockRejectedValueOnce(new Error('net'))
+        .mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) })
+        .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ acknowledged: true }) });
+      vi.stubGlobal('fetch', fn);
+      await expect(ackOrderKeyDelivery('ssc-1', { sleep: async () => {} })).resolves.toBe(true);
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('gives up after the attempt budget on persistent failures', async () => {
+      const fn = vi.fn().mockRejectedValue(new Error('net'));
+      vi.stubGlobal('fetch', fn);
+      await expect(ackOrderKeyDelivery('ssc-1', { attempts: 2, sleep: async () => {} })).resolves.toBe(false);
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getKeyInfo', () => {
+    it('GETs key-info with the key as X-API-Key credential and returns the info', async () => {
+      const body = { maskedKey: 'sk_...abcd', planName: 'basic', subscriptionState: 'active', activeUntil: '2026-08-12T00:00:00Z' };
+      const fetchSpy = mockFetchOnce({ json: body });
+      const res = await getKeyInfo('sk_' + 'a'.repeat(32));
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/paymento/key-info'),
+        expect.objectContaining({ headers: { 'x-api-key': 'sk_' + 'a'.repeat(32) } }),
+      );
+      expect(res).toEqual(body);
+    });
+
+    it('returns null on the definitive unknown/revoked 404', async () => {
+      mockFetchOnce({ ok: false, status: 404, json: { error: 'Unknown API key.' } });
+      await expect(getKeyInfo('sk_dead')).resolves.toBeNull();
+    });
+
+    it("throws on an old gateway's route-missing 404 (must not read as a dead key)", async () => {
+      mockFetchOnce({ ok: false, status: 404, json: { error: 'Not found' } });
+      await expect(getKeyInfo('sk_abc')).rejects.toThrow(/Not found/);
+    });
+
+    it('throws on server errors', async () => {
+      mockFetchOnce({ ok: false, status: 503, json: { error: 'nope' } });
+      await expect(getKeyInfo('sk_abc')).rejects.toThrow();
+    });
   });
 
   it('throws on non-ok responses', async () => {


### PR DESCRIPTION
## Summary

Aligns the wallet with the SGW `api-key-upgrade` contract ([aggregator-subscription#59](https://github.com/unicitynetwork/aggregator-subscription/pull/59), which includes #61 `api-key-ack`):

- **In-place key upgrade.** Checkout now always sends the existing key (`apiKey` in the body): the wallet key when the purchase is wallet-wide (root address or the checkbox), otherwise the active address key. The new gateway upgrades that key in place — same `sk_` string, purchased plan, fresh 30-day window — so the success screen shows no key box at all ("Your key sk_...abcd stays the same"). No adopt, no re-key, no engine rebuild.
- **Ack-based key delivery.** For fresh-key purchases the gateway now delivers the key on **every** `order-status` poll until the wallet POSTs `/api/paymento/order-key-ack`. The ack is sent only **after** the key is durably persisted (boot cache + vault), so a crash before persist keeps the key recoverable. `keyShownOnce` is gone from the wire type.
- **Real renew.** A lapsed plan's own store card now shows a "Renew plan" CTA (same key, fresh 30 days). Re-buying the **active** current plan stays blocked — the gateway resets the window to now+30d with no time carry-over — and the email step warns about that when upgrading away from an active paid plan.
- **Pasted-key validation.** The claim step and Settings → "Use a different key" validate pasted keys via the new `GET /api/paymento/key-info` (the key itself is the credential). A definitive unknown/revoked verdict rejects inline; lookup failures fail open.
- **Startup sanity check.** After the vault key is applied, a background key-info check re-provisions the identity's free key when the stored key is definitively dead (revoked identity keys can't re-mint → the existing terminal `failed` + Settings recovery UX).
- **Copy fixes.** All "shown only once" language removed; "restore recovers only the free key" reworded — an in-place-upgraded identity-bound key IS recovered with its plan.

### Adaptive client — deploy-order independent

Pre-upgrade gateways ignore the extra `apiKey` checkout field and mint a new key; the wallet branches on `order-status.upgrade` (absent → legacy adopt/claim path, ack POST 404s and is swallowed). This PR is therefore safe to merge and deploy **before** aggregator-subscription#59 lands. `getKeyInfo` treats only the 404 with `"Unknown API key."` as a dead key — the old gateway's route-missing 404 (`"Not found"`) throws instead, so a missing endpoint can never read as a dead key.

The branching lives in pure, unit-tested helpers: `resolveCheckoutOutcome` (upgraded / adopt / claim / failed / timeout / cancelled), `isPlanSelectable` (renew rules), `validatePastedKey` (fail-open).

## Test plan

- [x] 311/311 unit tests (`npm run test:run`) — new coverage: checkout body with/without `apiKey`, ack retry/definitive-refusal semantics, key-info 404 disambiguation, pollOrder upgrade pass-through, outcome branching, renew selectability, mock parity
- [x] `tsc` clean, `eslint` 0 errors, production build green
- [x] Mock-mode walkthrough (`VITE_SUBSCRIPTION_ENABLED=true VITE_SUBSCRIPTION_MOCK=true VITE_PAID_PLANS_ENABLED=true`): upgrade flow plays the in-place scenario (masked-key success, no key box)
- [ ] e2e against a local SGW built from `api-key-upgrade` (upgrade paid plan, renew after expiry, revoked-key 400, old-gateway compat) — pending SGW-side merge/stand
