### PR TITLE
fix: surface delivery-pending and undeliverable states (connect intents + event bridge)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.10",
+        "@unicitylabs/sphere-sdk": "0.11.11",
         "@unicitylabs/sphere-ui": "^0.1.30",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.10.tgz",
-      "integrity": "sha512-ytq8pdPhf1MxQQN+GaEX8TyEL+28mZHxG0IDWP74FOYjwZEUYA4qNGWcX++qARz5P1mXNPoJnlr3Zp1FVu38pg==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.11.tgz",
+      "integrity": "sha512-Fh/aKulXLlThG4/MeCuhRPcGR8tC73s5nhnydr4gfy73/IBPBhtLqnlOJXhLPk2UzJla1bKLrdASNlxOJMFqjw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.10",
+    "@unicitylabs/sphere-sdk": "0.11.11",
     "@unicitylabs/sphere-ui": "^0.1.30",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -110,7 +110,18 @@ export function ConnectIntentHandler() {
         amount={String(params.amount)}
         coinId={params.coinId as string}
         memo={params.memo as string | undefined}
-        onResolve={() => resolveIntent({ success: true })}
+        // #433: additive result fields so the dApp can distinguish "delivered"
+        // from "certified on-chain, delivery journaled for retry" and correlate
+        // the send with wallet history. transferId is omitted on the synthetic
+        // pending results (#631/#665) — those carry an empty id by design.
+        onResolve={(result) =>
+          resolveIntent({
+            success: true,
+            ...(result.id ? { transferId: result.id } : {}),
+            status: result.status,
+            deliveryPending: result.deliveryPending ?? false,
+          })
+        }
         onReject={(message) => rejectIntent(ERROR_CODES.TRANSFER_FAILED, message)}
         onCancel={handleClose}
       />

--- a/src/components/connect/SendIntentModal.tsx
+++ b/src/components/connect/SendIntentModal.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { Send } from 'lucide-react';
 import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
+import type { TransferResult } from '@unicitylabs/sphere-sdk';
 import { useAssets, useTransfer } from '../../sdk';
 import { getErrorMessage } from '../../sdk/errors';
 import { QuotaBlockedError } from '../../sdk/quotaGate';
 import { useUpgrade } from '../upgrade';
+import { showToast } from '../ui/toast-utils';
 import { IntentConfirmModal } from './IntentConfirmModal';
 
 interface SendIntentModalProps {
@@ -15,8 +17,8 @@ interface SendIntentModalProps {
   /** Token coinId (lowercase even-length hex). */
   coinId: string;
   memo?: string;
-  /** Called after the transfer succeeds (resolves the intent). */
-  onResolve: () => void;
+  /** Called after the transfer succeeds (resolves the intent with the result). */
+  onResolve: (result: TransferResult) => void;
   /** Called when the transfer fails (rejects the intent with the message). */
   onReject: (message: string) => void;
   /** Called when the user cancels (rejects the intent). */
@@ -57,8 +59,19 @@ export function SendIntentModal({ to, amount, coinId, memo, onResolve, onReject,
     setBusy(true);
     try {
       const recipient = to.startsWith('DIRECT://') ? to : to.replace(/^@/, '');
-      await transfer({ coinId, amount, recipient, ...(memo ? { memo } : {}) });
-      onResolve();
+      const result = await transfer({ coinId, amount, recipient, ...(memo ? { memo } : {}) });
+      // #433: a deliveryPending result means the spend certified on-chain but the
+      // recipient-side delivery is journaled for retry (§3.1). The dApp learns it
+      // via the intent result; this modal unmounts on resolve, so the wallet-side
+      // signal has to be a toast (SendModal's equivalent is its pending screen).
+      if (result.deliveryPending) {
+        showToast(
+          'Sent — delivery to the recipient is pending and will retry automatically.',
+          'info',
+          8000,
+        );
+      }
+      onResolve(result);
     } catch (err) {
       // Proactive quota block (useTransfer's mutationFn, Task 3) does NOT open
       // the Upgrade modal itself — that only happens on the reactive

--- a/src/pages/DocsPage.tsx
+++ b/src/pages/DocsPage.tsx
@@ -1373,8 +1373,18 @@ const { client, connection, disconnect } = await autoConnect({
 const identity = await client.query('sphere_getIdentity');
 const balance = await client.query('sphere_getBalance');
 
-// Send tokens (requires user confirmation in wallet)
-await client.intent('send', { to: '@alice', amount: '100' });
+// Send tokens (requires user confirmation in wallet).
+// amount is in BASE UNITS (smallest indivisible unit) and coinId is
+// required — the wallet rejects the intent with INVALID_PARAMS otherwise.
+const result = await client.intent('send', {
+  to: '@alice',                    // Unicity ID or DIRECT:// address
+  amount: '1000000000000000000',   // base units, positive integer string
+  coinId: '<lowercase hex coin id>', // e.g. from sphere_getAssets
+});
+// result: { success: true, transferId?: string, status: string,
+//           deliveryPending: boolean }
+// deliveryPending=true means the spend is FINAL on-chain but the recipient's
+// delivery is queued and retries automatically — never re-send it.
 
 // Handle wallet logout — user signed out or switched wallets
 client.on(WALLET_EVENTS.LOCKED, () => {

--- a/src/sdk/hooks/core/useSphereEvents.ts
+++ b/src/sdk/hooks/core/useSphereEvents.ts
@@ -25,6 +25,9 @@ export function useSphereEvents(): void {
   const invalidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track seen transfer IDs to prevent duplicate toasts from Nostr re-deliveries
   const seenTransferIdsRef = useRef<Set<string>>(new Set());
+  // One deferred-delivery toast per transfer — the SDK re-emits delivery:deferred
+  // on every replay pass that hits the recipient's full mailbox again.
+  const deferredToastIdsRef = useRef<Set<string>>(new Set());
   // Last storage:degraded toast per providerId — cooldown against toast storms
   const degradedToastAtRef = useRef<Map<string, number>>(new Map());
 
@@ -105,9 +108,10 @@ export function useSphereEvents(): void {
 
     const handleIdentityChange = () => {
       // New identity = new transfer stream (wallet-api sessions are
-      // per-identity): clear the toast dedup set so the new address's
+      // per-identity): clear the toast dedup sets so the new address's
       // transfers are never swallowed by ids seen under the old one.
       seenTransferIdsRef.current.clear();
+      deferredToastIdsRef.current.clear();
       refreshIdentityCache();
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.identity.all });
       queryClient.invalidateQueries({ queryKey: SPHERE_KEYS.payments.all });
@@ -210,6 +214,38 @@ export function useSphereEvents(): void {
       );
     };
 
+    // sphere-sdk#517 item 1 (#434): a journaled post-commit delivery exhausted its
+    // bounded replay budget and is marked POISON — kept journaled, NEVER auto-retried
+    // again. The spend is final on-chain and the recipient has NOT received it, so
+    // without a loud signal the transfer is stranded silently until support steps in.
+    const handleDeliveryUndeliverable = (data: {
+      transferId: string;
+      recipientPubkey: string;
+      attempts: number;
+      error: string;
+    }) => {
+      showToast(
+        `A sent transfer could not be delivered after ${data.attempts} attempts — the funds are ` +
+          `committed to the recipient but undelivered. Contact support with reference ` +
+          `${data.transferId.slice(0, 8)}.`,
+        'error',
+        15000,
+      );
+    };
+
+    // §3.1 / sphere-sdk#621 (#434): recipient's mailbox is full (429) — the delivery
+    // stays journaled and retries after the deferral window. Not a failure; toast once
+    // per transfer so periodic replay passes don't re-announce the same deferral.
+    const handleDeliveryDeferred = (data: { transferId: string }) => {
+      if (deferredToastIdsRef.current.has(data.transferId)) return;
+      deferredToastIdsRef.current.add(data.transferId);
+      showToast(
+        "Recipient can't receive yet (inbox full) — delivery will retry automatically.",
+        'info',
+        8000,
+      );
+    };
+
     sphere.on('transfer:incoming', handleIncomingTransfer);
     sphere.on('transfer:confirmed', handleTransferConfirmed);
     // sphere-sdk 0.10.6 (#621/#622): a send whose recipient delivery is deferred (full mailbox / 429,
@@ -229,6 +265,8 @@ export function useSphereEvents(): void {
     sphere.on('payment_request:incoming', handlePaymentRequestIncoming);
     sphere.on('storage:degraded', handleStorageDegraded);
     sphere.on('split:checkpoint-stuck', handleSplitCheckpointStuck);
+    sphere.on('delivery:undeliverable', handleDeliveryUndeliverable);
+    sphere.on('delivery:deferred', handleDeliveryDeferred);
 
     return () => {
       if (invalidateTimerRef.current) {
@@ -250,6 +288,8 @@ export function useSphereEvents(): void {
       sphere.off('payment_request:incoming', handlePaymentRequestIncoming);
       sphere.off('storage:degraded', handleStorageDegraded);
       sphere.off('split:checkpoint-stuck', handleSplitCheckpointStuck);
+      sphere.off('delivery:undeliverable', handleDeliveryUndeliverable);
+      sphere.off('delivery:deferred', handleDeliveryDeferred);
     };
   }, [sphere, queryClient]);
 }


### PR DESCRIPTION
Closes #433, closes #434.

Two delivery-visibility fixes ahead of mainnet, found while root-causing a support case (dApp `intent('send')` to a Node.js-owned nametag — sender confirmed, recipient saw nothing):

## Changes

- **Connect send intent result (#433)** — `SendIntentModal` no longer discards the `TransferResult`: the intent resolves with `{ success, transferId?, status, deliveryPending }` (additive fields, protocol-compatible). `transferId` is omitted on the synthetic pending results (#631/#665), which carry an empty id by design. A wallet-side toast covers the `deliveryPending` case since the modal unmounts on resolve (SendModal's equivalent is its pending screen).
- **Delivery failure events (#434)** — `useSphereEvents` now bridges:
  - `delivery:undeliverable` (sdk#517 item 1: journaled post-commit delivery exhausted its bounded replay budget — kept journaled, never auto-retried again) → loud error toast with a support reference. Previously a permanently-stranded transfer produced zero UI signal.
  - `delivery:deferred` (recipient mailbox full, §3.1/sdk#621 — retries automatically) → once-per-transfer info toast; dedup set cleared on `identity:changed` like the incoming-transfer set.
- **DocsPage** — the send-intent example was itself invalid (missing required `coinId`, whole-token amount; our own `validateIntent` rejects it with INVALID_PARAMS). Fixed to base units + `coinId`, and documents the new result contract including the never-re-send-on-`deliveryPending` rule.

## Testing

- `npx tsc --noEmit` clean, ESLint 0 errors (3 pre-existing warnings in untouched files), `npm run test:run` 285/285 pass.
- Event payload shapes and emit semantics verified against sdk 0.11.10 dist (`markDeliveryPoison`, `deferDelivery`) and the 0.11.9→0.11.10 typings.