### PR TITLE
chore(deps): bump sphere-sdk 0.11.11 -> 0.11.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.11",
+        "@unicitylabs/sphere-sdk": "0.11.12",
         "@unicitylabs/sphere-ui": "^0.1.30",
         "crypto-js": "^4.2.0",
         "elliptic": "^6.6.1",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.11.tgz",
-      "integrity": "sha512-Fh/aKulXLlThG4/MeCuhRPcGR8tC73s5nhnydr4gfy73/IBPBhtLqnlOJXhLPk2UzJla1bKLrdASNlxOJMFqjw==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.12.tgz",
+      "integrity": "sha512-2lO3YmHMMnYEdqYHpahrFM6YUTU4O/mZf1qJZFa4o5EqnEEjrXWWrfoPDkLXIcKJg3criIXPS9glkHYFGv/QAA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
@@ -2907,8 +2907,7 @@
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
-        "crypto-js": "^4.2.0",
-        "elliptic": "^6.6.1"
+        "crypto-js": "^4.2.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.11",
+    "@unicitylabs/sphere-sdk": "0.11.12",
     "@unicitylabs/sphere-ui": "^0.1.30",
     "crypto-js": "^4.2.0",
     "elliptic": "^6.6.1",


### PR DESCRIPTION
Routine SDK bump to the just-published 0.11.12.

- `npx tsc --noEmit` clean, ESLint 0 errors (3 pre-existing warnings in untouched files), `npm run test:run` 350/350 pass.
- Does not include the elliptic→noble migration (sphere-sdk#675, still open/under review) — carries whatever landed on sdk main at publish time.