### PR TITLE
chore(deps): bump sphere-sdk to 0.11.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.14",
+        "@unicitylabs/sphere-sdk": "0.11.15",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
@@ -2863,9 +2863,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.14.tgz",
-      "integrity": "sha512-bS3tRC/ofZK4uqj9pRO8TE4gfFxKUvLAmsl2GLove/1yY7OINjOLzsZbqa2BbWrxl09s5cJSgG/WMFRNXcWyuw==",
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.15.tgz",
+      "integrity": "sha512-dCcY6jKOQpxZDNSJBq2qyfITBcInuc8Zz+IlXT6UOIDQAWEf34dh/IlAApIpjfIRFhfzNnEUh+cTR0d23HILHg==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.14",
+    "@unicitylabs/sphere-sdk": "0.11.15",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",


### PR DESCRIPTION
Bump `@unicitylabs/sphere-sdk` **0.11.14 → 0.11.15**.

0.11.15 is the release cut of the pre-mainnet money-safety work — the four concurrency-audit criticals (#687/#688/#689 state-aware reacquire + split-strand/payment-double-pay/knownSpends-poison + intents-blob mutex, and #690 resume partial-conflict) plus the e2e-hygiene fixes.

This branch started as the dev.2 transfer-latency test; latency validated, so it's repointed to the released `0.11.15` and collapsed to a single clean dependency bump (package.json + lockfile only). Build passes (`npm run build`, tsc + vite).