### PR TITLE
chore(deps): bump sphere-sdk to 0.12.0-dev.1 + gate Connect to ≥ 0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.12.0-dev.1",
+        "@unicitylabs/sphere-sdk": "0.12.0",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
@@ -2863,9 +2863,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.12.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0-dev.1.tgz",
-      "integrity": "sha512-lcz5lSjwz4dzvKCvI5qey6H4wVBg8UjAnPJhOnxY1xdVod6pH19ZR/NoOaBUMl2dYmuUM+p+Vrb6JlyO2kYRRQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0.tgz",
+      "integrity": "sha512-y3t64uac9cjKLmhgbVav5nCfz5iyovJ9YofSKeTr+Zl6dsp9rshsuJXPtMJELu1Sze8f8A7qvpu997QnD5q3Tw==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.11.15",
+        "@unicitylabs/sphere-sdk": "0.12.0-dev.1",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
@@ -2863,16 +2863,16 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.11.15.tgz",
-      "integrity": "sha512-dCcY6jKOQpxZDNSJBq2qyfITBcInuc8Zz+IlXT6UOIDQAWEf34dh/IlAApIpjfIRFhfzNnEUh+cTR0d23HILHg==",
+      "version": "0.12.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.12.0-dev.1.tgz",
+      "integrity": "sha512-lcz5lSjwz4dzvKCvI5qey6H4wVBg8UjAnPJhOnxY1xdVod6pH19ZR/NoOaBUMl2dYmuUM+p+Vrb6JlyO2kYRRQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@unicitylabs/nostr-js-sdk": "^0.6.0",
-        "@unicitylabs/state-transition-sdk": "2.0.0-rc.68bc1e5",
+        "@unicitylabs/state-transition-sdk": "2.0.1",
         "bip39": "^3.1.0",
         "buffer": "^6.0.3",
         "canonicalize": "^3.0.0",
@@ -2980,9 +2980,9 @@
       "license": "MIT"
     },
     "node_modules/@unicitylabs/state-transition-sdk": {
-      "version": "2.0.0-rc.68bc1e5",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.0-rc.68bc1e5.tgz",
-      "integrity": "sha512-JJ1jQFTexMBRwpn3pmhm4s2FulBcOBGyNZmQ4qd5ZheenbVLUkY5KSJ++J3Gnh/Vmhd6WVuCBw+FCyqXN39aHQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/state-transition-sdk/-/state-transition-sdk-2.0.1.tgz",
+      "integrity": "sha512-O0pjxaL32VgHYjSM3Ei64UWBG2qwBzdQ9aIdlyhzTnPdI+kKu3h9saSMF1uV9XTfqKHsNGUpE/2dFUulNfmdmg==",
       "license": "ISC",
       "dependencies": {
         "@noble/curves": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.11.15",
+    "@unicitylabs/sphere-sdk": "0.12.0-dev.1",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.12.0-dev.1",
+    "@unicitylabs/sphere-sdk": "0.12.0",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",

--- a/src/components/agents/IframeAgent.tsx
+++ b/src/components/agents/IframeAgent.tsx
@@ -4,6 +4,7 @@ import { ConnectHost, HOST_READY_TYPE } from '@unicitylabs/sphere-sdk/connect';
 import type { DAppMetadata, PermissionScope } from '@unicitylabs/sphere-sdk/connect';
 import { PostMessageTransport } from '@unicitylabs/sphere-sdk/connect/browser';
 import type { AgentConfig } from '../../config/activities';
+import { CONNECT_MIN_SDK_VERSION } from '../../config/connect';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
 import { useConnectContext } from '../connect/ConnectContext';
 import {
@@ -92,6 +93,8 @@ export function IframeAgent({ agent }: IframeAgentProps) {
     const host = new ConnectHost({
       sphere: sphereRef.current,
       transport,
+      // Reject dApps built against sphere-sdk < 0.12 (incompatible Connect/token contract).
+      minSdkVersion: CONNECT_MIN_SDK_VERSION,
       onConnectionRequest: async (dapp: DAppMetadata, perms: PermissionScope[], silent?: boolean) => {
         // Check if this iframe origin was already approved
         const saved = getApprovedOrigin(origin);

--- a/src/components/agents/IframeAgent.tsx
+++ b/src/components/agents/IframeAgent.tsx
@@ -7,6 +7,8 @@ import type { AgentConfig } from '../../config/activities';
 import { CONNECT_MIN_SDK_VERSION } from '../../config/connect';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
 import { useConnectContext } from '../connect/ConnectContext';
+import { describeConnectRejection } from '../connect/rejectionMessage';
+import { showToast } from '../ui/toast-utils';
 import {
   getApprovedOrigin,
   saveApprovedOrigin,
@@ -114,6 +116,13 @@ export function IframeAgent({ agent }: IframeAgentProps) {
           saveApprovedOrigin(origin, dapp, result.grantedPermissions);
         }
         return result;
+      },
+      onConnectionRejected: (dapp, error, silent) => {
+        // The compatibility gate refused the connection (e.g. an app built against
+        // sphere-sdk < 0.12). Surface why — but stay quiet for background auto-connect.
+        if (silent) return;
+        const data = (error.data as Record<string, unknown> | undefined) ?? undefined;
+        showToast(`${dapp?.name ?? 'This app'} ${describeConnectRejection(data)}`, 'warning');
       },
       onDisconnect: () => {
         revokeApprovedOrigin(origin);

--- a/src/components/connect/rejectionMessage.ts
+++ b/src/components/connect/rejectionMessage.ts
@@ -1,0 +1,19 @@
+/**
+ * Human-readable explanation for a Sphere Connect compatibility-gate rejection,
+ * derived from the SphereRpcError `data.reason` (see the SDK's `checkCompatibility`).
+ * Shared by the wallet's Connect surfaces (ConnectPage popup, IframeAgent) so the
+ * copy stays consistent.
+ *
+ * The returned phrase is a sentence fragment meant to follow the dApp name, e.g.
+ * `${dapp.name} ${describeConnectRejection(data)}`.
+ */
+export function describeConnectRejection(data: Record<string, unknown> | undefined): string {
+  const reason = data?.reason as string | undefined;
+  if (reason === 'protocol_incompatible') {
+    return 'was built for an older version of Sphere. Its developer needs to update it before it can connect.';
+  }
+  if (reason === 'network_incompatible') {
+    return 'is built for a different Unicity network than your wallet, so it cannot connect here.';
+  }
+  return 'is not compatible with this wallet.';
+}

--- a/src/config/connect.ts
+++ b/src/config/connect.ts
@@ -13,10 +13,11 @@
  * background auto-connect attempts).
  *
  * The floor is the earliest 0.12.0 PRE-RELEASE (`-0`), not `0.12.0`, because
- * semver orders prereleases below the release: the wallet and the current
- * reference dApps ship `0.12.0-dev.1`, and a plain `0.12.0` floor would reject
- * them (`compareSemver('0.12.0-dev.1', '0.12.0') === -1`). `0.12.0-0` admits
- * any 0.12.0 prerelease and up while still rejecting every 0.11.x and below.
+ * semver orders prereleases below the release. The wallet ships stable
+ * `0.12.0`, but dApps mid-migration (and dev builds) may still be on a
+ * `0.12.0-dev.x` prerelease; a plain `0.12.0` floor would reject those
+ * (`compareSemver('0.12.0-dev.1', '0.12.0') === -1`). `0.12.0-0` admits any
+ * 0.12.0 prerelease and up while still rejecting every 0.11.x and below.
  *
  * Bump this in lockstep with the wallet's major.minor line.
  */

--- a/src/config/connect.ts
+++ b/src/config/connect.ts
@@ -1,0 +1,23 @@
+/**
+ * Sphere Connect wallet-side (host) policy.
+ */
+
+/**
+ * Minimum `@unicitylabs/sphere-sdk` version a connecting dApp must be built
+ * against for this wallet to accept its Sphere Connect handshake.
+ *
+ * The wallet is on the 0.12.x line; apps built against < 0.12 speak an
+ * incompatible Connect / token contract, so their handshake is refused by the
+ * SDK's compatibility gate (`checkCompatibility` → `protocol_incompatible`),
+ * surfaced to the user via `onConnectionRejected` (and silently dropped for
+ * background auto-connect attempts).
+ *
+ * The floor is the earliest 0.12.0 PRE-RELEASE (`-0`), not `0.12.0`, because
+ * semver orders prereleases below the release: the wallet and the current
+ * reference dApps ship `0.12.0-dev.1`, and a plain `0.12.0` floor would reject
+ * them (`compareSemver('0.12.0-dev.1', '0.12.0') === -1`). `0.12.0-0` admits
+ * any 0.12.0 prerelease and up while still rejecting every 0.11.x and below.
+ *
+ * Bump this in lockstep with the wallet's major.minor line.
+ */
+export const CONNECT_MIN_SDK_VERSION = '0.12.0-0';

--- a/src/pages/ConnectPage.tsx
+++ b/src/pages/ConnectPage.tsx
@@ -6,6 +6,7 @@ import { PostMessageTransport } from '@unicitylabs/sphere-sdk/connect/browser';
 import { CONNECT_MIN_SDK_VERSION } from '../config/connect';
 import { useSphereContext } from '../sdk/hooks/core/useSphere';
 import { useConnectContext } from '../components/connect/ConnectContext';
+import { describeConnectRejection } from '../components/connect/rejectionMessage';
 import { WalletPanel } from '../components/wallet/WalletPanel';
 import {
   getApprovedOrigin,
@@ -15,17 +16,6 @@ import {
 } from '../utils/connected-sites';
 
 type RejectionInfo = { dappName: string; code: number; message: string; data: Record<string, unknown> | undefined };
-
-function describeRejection(data: Record<string, unknown> | undefined): string {
-  const reason = data?.reason as string | undefined;
-  if (reason === 'protocol_incompatible') {
-    return 'was built for an older version of Sphere. Its developer needs to update it before it can connect.';
-  }
-  if (reason === 'network_incompatible') {
-    return 'is built for a different Unicity network than your wallet, so it cannot connect here.';
-  }
-  return 'is not compatible with this wallet.';
-}
 
 export function ConnectPage() {
   const [searchParams] = useSearchParams();
@@ -217,7 +207,7 @@ export function ConnectPage() {
               <h2 className="text-base font-semibold text-gray-900 dark:text-neutral-100">Unable to connect</h2>
             </div>
             <p className="text-sm text-gray-700 dark:text-neutral-300">
-              <span className="font-medium">{rejection.dappName}</span> {describeRejection(rejection.data)}
+              <span className="font-medium">{rejection.dappName}</span> {describeConnectRejection(rejection.data)}
             </p>
             <p className="mt-2 text-xs text-gray-400 dark:text-neutral-500">Error code {rejection.code}</p>
             <button

--- a/src/pages/ConnectPage.tsx
+++ b/src/pages/ConnectPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { ConnectHost, HOST_READY_TYPE } from '@unicitylabs/sphere-sdk/connect';
 import type { DAppMetadata, PermissionScope } from '@unicitylabs/sphere-sdk/connect';
 import { PostMessageTransport } from '@unicitylabs/sphere-sdk/connect/browser';
+import { CONNECT_MIN_SDK_VERSION } from '../config/connect';
 import { useSphereContext } from '../sdk/hooks/core/useSphere';
 import { useConnectContext } from '../components/connect/ConnectContext';
 import { WalletPanel } from '../components/wallet/WalletPanel';
@@ -109,6 +110,8 @@ export function ConnectPage() {
     const host = new ConnectHost({
       sphere: currentSphere,
       transport,
+      // Reject dApps built against sphere-sdk < 0.12 (incompatible Connect/token contract).
+      minSdkVersion: CONNECT_MIN_SDK_VERSION,
       onConnectionRequest: async (dapp: DAppMetadata, perms: PermissionScope[], silent?: boolean) => {
         // Check if this origin was already approved
         const saved = getApprovedOrigin(origin);


### PR DESCRIPTION
## Summary
- Bump `@unicitylabs/sphere-sdk` `0.11.15` → `0.12.0-dev.1` (base `state-transition-sdk` `2.0.1`).
- Reject dApps built against sphere-sdk **< 0.12** over Sphere Connect.

## Connect version gate
The SDK already ships a wallet-side compatibility gate (`ConnectHost` config `minSdkVersion` → `checkCompatibility`); it was simply unset. This wires it on **both** host-creation sites — `ConnectPage.tsx` (popup flow) and `IframeAgent.tsx` (iframe agents) — via one shared constant `CONNECT_MIN_SDK_VERSION` in `src/config/connect.ts` so the two hosts can't drift.

### Why the floor is `0.12.0-0`, not `0.12.0`
The SDK's `compareSemver` is real semver, so prereleases sort **below** the release. A `0.12.0` floor would also reject `0.12.0-dev.1` clients — i.e. the wallet's own current-generation dApps. `0.12.0-0` (the earliest 0.12.0 prerelease) admits any `0.12.x` while rejecting all `0.11.x` and below. Verified against the SDK's actual comparator:

| client SDK | result |
|---|---|
| `0.10.1`, `0.11.15`, `0.11.99`, *(none reported)* | **REJECT** |
| `0.12.0-dev.1`, `0.12.0`, `0.12.3`, `1.0.0` | **ALLOW** |

A client reporting no SDK version fails closed (rejected).

## Testing
- `npx tsc --noEmit` — clean
- `npm run test:run` — 371 passed

## Note
`ConnectPage` surfaces the refusal to the user (`onConnectionRejected`); `IframeAgent`'s host has no such callback, so a below-0.12 iframe app is refused **silently** (connection just fails, no explanation). The rejection itself works in both — this is only about user-facing messaging. Happy to add an `onConnectionRejected` to the iframe host in a follow-up if desired.