### PR TITLE
feat(wallet): optional wallet password — at-rest lock, unlock screen, idle auto-lock, backup gate (#449)

### DIFF
--- a/src/components/connect/ConnectProvider.tsx
+++ b/src/components/connect/ConnectProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from './ConnectContext';
 import { ConnectionApprovalModal } from './ConnectionApprovalModal';
 import { ConnectIntentHandler } from './ConnectIntentHandler';
+import { setActiveConnectHost } from '../../sdk/connectHostRegistry';
 
 interface ConnectProviderProps {
   children: ReactNode;
@@ -31,6 +32,10 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
       autoIntentHandlersRef.current.clear();
     }
     connectHostRef.current = host;
+    // Mirror into the module-scoped registry so SphereProvider.lock() — an
+    // ANCESTOR in the tree that can't consume this context — can still reach
+    // the live host to notify it before destroying the Sphere instance (#449).
+    setActiveConnectHost(host);
     forceUpdate((n) => n + 1);
   }, []);
 

--- a/src/components/wallet/L3/modals/SecurityModal.tsx
+++ b/src/components/wallet/L3/modals/SecurityModal.tsx
@@ -1,0 +1,295 @@
+/**
+ * Settings → Security (#449 Task 8b): set / change / remove the wallet's
+ * at-rest password (works for ANY existing wallet, including plaintext
+ * create-flow wallets), and pick the auto-lock timeout.
+ *
+ * Password changes go through `useSphereContext()`'s
+ * setWalletPassword/changeWalletPassword/removeWalletPassword, which use the
+ * VERIFIED-SAFE in-place mnemonic re-encryption (reencryptStoredMnemonic) —
+ * never Sphere.import()/Sphere.clear(), which would wipe the token DB.
+ */
+import { useCallback, useState } from 'react';
+import { Clock, Lock, ShieldCheck, ShieldOff } from 'lucide-react';
+import { WalletScreen } from '../../ui/WalletScreen';
+import { AlertMessage, MenuButton, ModalHeader } from '../../ui';
+import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
+import { AUTO_LOCK_OPTIONS, type AutoLockValue } from '../../../../sdk/walletLock/lockSettings';
+
+interface SecurityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type Mode = 'menu' | 'set' | 'change' | 'remove';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+const MODE_TITLES: Record<Mode, string> = {
+  menu: 'Security',
+  set: 'Set Password',
+  change: 'Change Password',
+  remove: 'Remove Password',
+};
+
+function formatAutoLockLabel(value: AutoLockValue): string {
+  return value === 'never' ? 'Never' : `${value}m`;
+}
+
+const inputClass =
+  'w-full px-4 py-2.5 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 ' +
+  'text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-orange-500/60';
+
+export function SecurityModal({ isOpen, onClose }: SecurityModalProps) {
+  const {
+    hasWalletPassword,
+    setWalletPassword,
+    changeWalletPassword,
+    removeWalletPassword,
+    autoLockMinutes,
+    setAutoLockTimeout,
+  } = useSphereContext();
+
+  const [mode, setMode] = useState<Mode>('menu');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const resetForm = useCallback(() => {
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setError(null);
+    setBusy(false);
+  }, []);
+
+  const goToMenu = useCallback(() => {
+    resetForm();
+    setMode('menu');
+  }, [resetForm]);
+
+  const handleClose = useCallback(() => {
+    resetForm();
+    setMode('menu');
+    onClose();
+  }, [resetForm, onClose]);
+
+  const validateNewPassword = useCallback((): string | null => {
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      return `Password must be at least ${MIN_PASSWORD_LENGTH} characters`;
+    }
+    if (newPassword !== confirmPassword) {
+      return "Passwords don't match";
+    }
+    return null;
+  }, [newPassword, confirmPassword]);
+
+  const handleSet = useCallback(async () => {
+    const validationError = validateNewPassword();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await setWalletPassword(newPassword);
+      goToMenu();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to set password');
+    } finally {
+      setBusy(false);
+    }
+  }, [newPassword, validateNewPassword, setWalletPassword, goToMenu]);
+
+  const handleChange = useCallback(async () => {
+    const validationError = validateNewPassword();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await changeWalletPassword(currentPassword, newPassword);
+      goToMenu();
+    } catch (e) {
+      // Surfaces "Incorrect current password" from reencryptStoredMnemonic verbatim.
+      setError(e instanceof Error ? e.message : 'Failed to change password');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentPassword, newPassword, validateNewPassword, changeWalletPassword, goToMenu]);
+
+  const handleRemove = useCallback(async () => {
+    if (!currentPassword) {
+      setError('Enter your current password');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await removeWalletPassword(currentPassword);
+      goToMenu();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to remove password');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentPassword, removeWalletPassword, goToMenu]);
+
+  return (
+    <WalletScreen isOpen={isOpen} onClose={handleClose}>
+      <ModalHeader
+        variant="screen"
+        title={MODE_TITLES[mode]}
+        icon={ShieldCheck}
+        iconVariant="neutral"
+        onClose={mode === 'menu' ? handleClose : goToMenu}
+        closeDisabled={busy}
+      />
+
+      <div className="px-4 py-6 space-y-4 flex-1 overflow-y-auto">
+        {mode === 'menu' && (
+          <>
+            {!hasWalletPassword ? (
+              <MenuButton
+                icon={Lock}
+                color="orange"
+                label="Set Password"
+                subtitle="Encrypt your wallet on this device"
+                onClick={() => setMode('set')}
+              />
+            ) : (
+              <div className="space-y-2">
+                <MenuButton
+                  icon={Lock}
+                  color="orange"
+                  label="Change Password"
+                  onClick={() => setMode('change')}
+                />
+                <MenuButton
+                  icon={ShieldOff}
+                  color="red"
+                  label="Remove Password"
+                  danger
+                  onClick={() => setMode('remove')}
+                />
+              </div>
+            )}
+
+            {hasWalletPassword && (
+              <div className="pt-2">
+                <div className="flex items-center gap-1.5 px-1 pb-2 text-xs font-medium text-neutral-500 dark:text-white/45">
+                  <Clock className="w-3.5 h-3.5" />
+                  Auto-lock after inactivity
+                </div>
+                <div className="grid grid-cols-5 gap-1.5">
+                  {AUTO_LOCK_OPTIONS.map((option) => (
+                    <button
+                      key={String(option)}
+                      onClick={() => setAutoLockTimeout(option)}
+                      aria-pressed={autoLockMinutes === option}
+                      className={`py-2 text-xs font-semibold rounded-lg transition-colors ${
+                        autoLockMinutes === option
+                          ? 'bg-orange-500 dark:bg-brand-orange text-white'
+                          : 'bg-neutral-100 dark:bg-white/6 text-neutral-600 dark:text-white/55 hover:bg-neutral-200 dark:hover:bg-white/10'
+                      }`}
+                    >
+                      {formatAutoLockLabel(option)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {(mode === 'set' || mode === 'change') && (
+          <>
+            <p className="text-sm text-neutral-500 dark:text-white/45">
+              {mode === 'set'
+                ? 'Add a password to encrypt your wallet on this device.'
+                : 'Enter your current password and choose a new one.'}{' '}
+              <span className="text-orange-600 dark:text-brand-orange font-semibold">
+                This can only be recovered with your recovery phrase
+              </span>{' '}
+              — there is no other way to reset it.
+            </p>
+
+            {mode === 'change' && (
+              <input
+                type="password"
+                aria-label="Current password"
+                autoComplete="current-password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                placeholder="Current password"
+                className={inputClass}
+              />
+            )}
+            <input
+              type="password"
+              aria-label="New password"
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="New password"
+              className={inputClass}
+            />
+            <input
+              type="password"
+              aria-label="Confirm new password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && (mode === 'set' ? handleSet() : handleChange())}
+              placeholder="Confirm new password"
+              className={inputClass}
+            />
+
+            {error && <AlertMessage variant="error">{error}</AlertMessage>}
+
+            <button
+              onClick={mode === 'set' ? handleSet : handleChange}
+              disabled={busy}
+              className="w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-orange-500 to-orange-600 dark:from-brand-orange dark:to-brand-orange-dark text-white text-sm font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy ? 'Saving…' : mode === 'set' ? 'Set Password' : 'Change Password'}
+            </button>
+          </>
+        )}
+
+        {mode === 'remove' && (
+          <>
+            <p className="text-sm text-neutral-500 dark:text-white/45">
+              Removing your password stores your wallet unencrypted on this device.
+              Enter your current password to confirm.
+            </p>
+            <input
+              type="password"
+              aria-label="Current password"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleRemove()}
+              placeholder="Current password"
+              className={inputClass}
+            />
+
+            {error && <AlertMessage variant="error">{error}</AlertMessage>}
+
+            <button
+              onClick={handleRemove}
+              disabled={busy}
+              className="w-full py-3.5 px-5 rounded-xl bg-red-500 hover:bg-red-600 text-white text-sm font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy ? 'Removing…' : 'Remove Password'}
+            </button>
+          </>
+        )}
+      </div>
+    </WalletScreen>
+  );
+}

--- a/src/components/wallet/L3/modals/SecurityModal.tsx
+++ b/src/components/wallet/L3/modals/SecurityModal.tsx
@@ -86,6 +86,12 @@ export function SecurityModal({ isOpen, onClose }: SecurityModalProps) {
   }, [newPassword, confirmPassword]);
 
   const handleSet = useCallback(async () => {
+    // Re-entrancy guard (#449 review fix): a rapid double-submit / Enter-mash
+    // must not launch a second concurrent setWalletPassword() call. `busy`
+    // has to be a dependency below for this check to see the LATEST value —
+    // otherwise useCallback would keep returning a stale closure that never
+    // observes busy flipping true.
+    if (busy) return;
     const validationError = validateNewPassword();
     if (validationError) {
       setError(validationError);
@@ -101,9 +107,11 @@ export function SecurityModal({ isOpen, onClose }: SecurityModalProps) {
     } finally {
       setBusy(false);
     }
-  }, [newPassword, validateNewPassword, setWalletPassword, goToMenu]);
+  }, [busy, newPassword, validateNewPassword, setWalletPassword, goToMenu]);
 
   const handleChange = useCallback(async () => {
+    // Re-entrancy guard (#449 review fix) — see handleSet.
+    if (busy) return;
     const validationError = validateNewPassword();
     if (validationError) {
       setError(validationError);
@@ -120,9 +128,11 @@ export function SecurityModal({ isOpen, onClose }: SecurityModalProps) {
     } finally {
       setBusy(false);
     }
-  }, [currentPassword, newPassword, validateNewPassword, changeWalletPassword, goToMenu]);
+  }, [busy, currentPassword, newPassword, validateNewPassword, changeWalletPassword, goToMenu]);
 
   const handleRemove = useCallback(async () => {
+    // Re-entrancy guard (#449 review fix) — see handleSet.
+    if (busy) return;
     if (!currentPassword) {
       setError('Enter your current password');
       return;
@@ -137,7 +147,7 @@ export function SecurityModal({ isOpen, onClose }: SecurityModalProps) {
     } finally {
       setBusy(false);
     }
-  }, [currentPassword, removeWalletPassword, goToMenu]);
+  }, [busy, currentPassword, removeWalletPassword, goToMenu]);
 
   return (
     <WalletScreen isOpen={isOpen} onClose={handleClose}>

--- a/src/components/wallet/L3/modals/SeedPhraseModal.tsx
+++ b/src/components/wallet/L3/modals/SeedPhraseModal.tsx
@@ -33,7 +33,7 @@ export function SeedPhraseModal({ isOpen, onClose, seedPhrase }: SeedPhraseModal
   };
 
   return (
-    <WalletScreen isOpen={isOpen} onClose={onClose}>
+    <WalletScreen isOpen={isOpen} onClose={onClose} className="!z-30">
       <ModalHeader variant="screen" title="Recovery Phrase" onClose={onClose} />
 
       {/* Content */}

--- a/src/components/wallet/L3/modals/SettingsModal.tsx
+++ b/src/components/wallet/L3/modals/SettingsModal.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
-import { Settings, Download, LogOut, Key, AtSign, Link, CreditCard } from 'lucide-react';
+import { Settings, Download, LogOut, Key, AtSign, Link, CreditCard, ShieldCheck } from 'lucide-react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, MenuButton } from '../../ui';
 import { LookupModal } from './LookupModal';
 import { AddressManagerModal } from './AddressManagerModal';
 import { ConnectedSitesModal } from './ConnectedSitesModal';
 import { SubscriptionModal } from './SubscriptionModal';
+import { SecurityModal } from './SecurityModal';
 import { useUpgrade } from '../../../upgrade';
 import { useUtilization } from '../../../../sdk/hooks/subscription';
+import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
 import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
 
 interface SettingsModalProps {
@@ -28,7 +30,9 @@ export function SettingsModal({
   const [isAddressManagerOpen, setIsAddressManagerOpen] = useState(false);
   const [isConnectedSitesOpen, setIsConnectedSitesOpen] = useState(false);
   const [isSubscriptionOpen, setIsSubscriptionOpen] = useState(false);
+  const [isSecurityOpen, setIsSecurityOpen] = useState(false);
   const { openUpgrade } = useUpgrade();
+  const { hasWalletPassword } = useSphereContext();
 
   // Show the active address's current plan in the row subtitle, e.g. "Free plan".
   const util = useUtilization();
@@ -81,6 +85,17 @@ export function SettingsModal({
           )}
 
           <MenuButton
+            icon={ShieldCheck}
+            color="orange"
+            label="Security"
+            subtitle={hasWalletPassword ? 'Password set' : 'Set a password, auto-lock'}
+            onClick={() => {
+              onClose();
+              setIsSecurityOpen(true);
+            }}
+          />
+
+          <MenuButton
             icon={Download}
             color="green"
             label="Backup Wallet"
@@ -124,6 +139,11 @@ export function SettingsModal({
         isOpen={isSubscriptionOpen}
         onClose={() => setIsSubscriptionOpen(false)}
         onUpgrade={() => { setIsSubscriptionOpen(false); openUpgrade('settings'); }}
+      />
+
+      <SecurityModal
+        isOpen={isSecurityOpen}
+        onClose={() => setIsSecurityOpen(false)}
       />
     </>
   );

--- a/src/components/wallet/L3/modals/SettingsModal.tsx
+++ b/src/components/wallet/L3/modals/SettingsModal.tsx
@@ -102,7 +102,11 @@ export function SettingsModal({
             subtitle={undefined}
             showChevron={false}
             onClick={() => {
-              onClose();
+              // Drill-in: open Backup ON TOP of Settings (which stays mounted
+              // behind) instead of closing Settings at the same time. Closing
+              // Settings here made its slide-out panel cross the Backup panel's
+              // slide-in (both animate from the right) — a jarring "two panels
+              // passing through each other" effect. Closing Backup returns here.
               onBackupWallet();
             }}
           />

--- a/src/components/wallet/L3/modals/SettingsModal.tsx
+++ b/src/components/wallet/L3/modals/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Settings, Download, LogOut, Key, AtSign, Link, CreditCard, ShieldCheck } from 'lucide-react';
+import { Settings, Download, LogOut, Key, AtSign, Link, CreditCard, ShieldCheck, Lock } from 'lucide-react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, MenuButton } from '../../ui';
 import { LookupModal } from './LookupModal';
@@ -32,7 +32,7 @@ export function SettingsModal({
   const [isSubscriptionOpen, setIsSubscriptionOpen] = useState(false);
   const [isSecurityOpen, setIsSecurityOpen] = useState(false);
   const { openUpgrade } = useUpgrade();
-  const { hasWalletPassword } = useSphereContext();
+  const { hasWalletPassword, lock } = useSphereContext();
 
   // Show the active address's current plan in the row subtitle, e.g. "Free plan".
   const util = useUtilization();
@@ -110,6 +110,24 @@ export function SettingsModal({
               onBackupWallet();
             }}
           />
+
+          {/* Manual lock — only when a password is set. Locking a
+              password-less wallet would demand an unlock password that
+              doesn't exist (recoverable only from seed), so it is hidden
+              in that case (#449). */}
+          {hasWalletPassword && (
+            <MenuButton
+              icon={Lock}
+              color="neutral"
+              label="Lock Wallet"
+              subtitle="Lock now; unlock with your password"
+              showChevron={false}
+              onClick={() => {
+                onClose();
+                void lock();
+              }}
+            />
+          )}
 
           <MenuButton
             icon={LogOut}

--- a/src/components/wallet/L3/views/L3WalletView.tsx
+++ b/src/components/wallet/L3/views/L3WalletView.tsx
@@ -280,7 +280,9 @@ export function L3WalletView({
 
   // Handle backup and logout
   const handleBackupAndLogout = () => {
-    setIsLogoutConfirmOpen(false);
+    // Keep the logout confirm mounted (z-10) behind the Backup screen (z-20) so
+    // Backup slides in cleanly on top instead of crossing the logout panel's
+    // slide-out. Closing Backup returns to the logout confirm.
     setIsBackupOpen(true);
   };
 
@@ -550,7 +552,7 @@ function SaveWalletModal({ show, onConfirm, onCancel, hasMnemonic, defaultFilena
   };
 
   return (
-    <WalletScreen isOpen={show} onClose={onCancel}>
+    <WalletScreen isOpen={show} onClose={onCancel} className="!z-30">
       <ModalHeader variant="screen" title="Backup Wallet" onClose={onCancel} />
       <div className="px-6 py-8 flex flex-col flex-1 overflow-y-auto">
         <div className="flex flex-col items-center text-center mb-6">

--- a/src/components/wallet/L3/views/L3WalletView.tsx
+++ b/src/components/wallet/L3/views/L3WalletView.tsx
@@ -447,11 +447,6 @@ export function L3WalletView({
         pay={paymentRequestsPay}
         clearProcessed={paymentRequestsClearProcessed}
       />
-      <SeedPhraseModal
-        isOpen={isSeedPhraseOpen}
-        onClose={() => setIsSeedPhraseOpen(false)}
-        seedPhrase={seedPhrase}
-      />
       <TransactionHistoryModal isOpen={isHistoryOpen} onClose={() => setIsHistoryOpen(false)} />
 
       {/* New Modals */}
@@ -469,6 +464,15 @@ export function L3WalletView({
         onExportWalletFile={handleExportWalletFile}
         onShowRecoveryPhrase={handleShowSeedPhrase}
         hasMnemonic={hasMnemonic}
+      />
+
+      {/* Rendered AFTER Settings/Backup so, when opened from the Backup
+          drill-in (which keeps Settings mounted behind it), the seed screen
+          stacks ON TOP of them instead of being hidden behind the menu. */}
+      <SeedPhraseModal
+        isOpen={isSeedPhraseOpen}
+        onClose={() => setIsSeedPhraseOpen(false)}
+        seedPhrase={seedPhrase}
       />
 
       <LogoutConfirmModal

--- a/src/components/wallet/WalletPanel.tsx
+++ b/src/components/wallet/WalletPanel.tsx
@@ -145,7 +145,11 @@ export function WalletPanel() {
       <div className={PANEL_SHELL} data-wallet-panel>
         <div className="flex-1 relative overflow-y-auto flex items-center justify-center">
           {restoreFromLock ? (
-            <CreateWalletFlow initialStep="restoreMethod" />
+            <CreateWalletFlow
+              initialStep="restoreMethod"
+              fromLock
+              onExitToUnlock={() => setRestoreFromLock(false)}
+            />
           ) : (
             <UnlockScreen onRestore={() => setRestoreFromLock(true)} />
           )}

--- a/src/components/wallet/WalletPanel.tsx
+++ b/src/components/wallet/WalletPanel.tsx
@@ -9,6 +9,7 @@ import { RegisterNametagModal } from './shared/components/RegisterNametagModal';
 import { NewAddressModal } from './shared/modals/NewAddressModal';
 import { AddressSelector } from './shared/components';
 import { CreateWalletFlow } from './onboarding/CreateWalletFlow';
+import { UnlockScreen } from './onboarding/components/UnlockScreen';
 
 const PANEL_SHELL = "bg-white dark:bg-modal-bg/50 backdrop-blur-xl overflow-hidden h-full relative lg:border-l lg:border-neutral-100 dark:lg:border-brand-orange-border flex flex-col rounded-2xl";
 
@@ -21,9 +22,14 @@ export function WalletPanel() {
   // #413: derive-address flow — hosted at panel level (like RegisterNametagModal)
   // so the slide-in screen paints above the wallet content in DOM order.
   const [isNewAddressOpen, setIsNewAddressOpen] = useState(false);
+  // #449: once the user picks "forgot password → restore from recovery
+  // phrase" on the UnlockScreen, drop them straight into onboarding's restore
+  // flow instead of the unlock prompt. Reset when the wallet unlocks/restores
+  // (isLocked flips false) so a future lock starts fresh at the unlock screen.
+  const [restoreFromLock, setRestoreFromLock] = useState(false);
   const { isLoading: isWalletLoading, walletExists, error: walletError } = useWalletStatus();
   const { identity, nametag, isLoading: isLoadingIdentity } = useIdentity();
-  const { initProgress } = useSphereContext();
+  const { initProgress, isLocked } = useSphereContext();
   const { pendingCount, requests, reject, pay, clearProcessed } = useIncomingPaymentRequests();
   const { setFullscreen } = useUIState();
 
@@ -51,6 +57,12 @@ export function WalletPanel() {
     }
     prevPendingCountRef.current = pendingCount;
   }, [pendingCount, requests.length, setFullscreen]);
+
+  // Reset the "restore from lock" escape once the wallet is no longer locked
+  // (unlocked with the correct password, or a restore just finalized it).
+  useEffect(() => {
+    if (!isLocked) setRestoreFromLock(false);
+  }, [isLocked]);
 
   // Initialization error (e.g. IndexedDB timeout after retry)
   if (walletError) {
@@ -116,6 +128,26 @@ export function WalletPanel() {
             >
               {initProgress.message}
             </motion.p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Encrypted wallet exists on disk but hasn't been unlocked this session
+  // (#449). Gate on `isLocked` ONLY — an existing plaintext wallet always has
+  // isLocked === false and must never see this screen (no-wallet-loss
+  // constraint). Checked before the `!walletExists` branch below purely for
+  // clarity; SphereProvider only ever sets isLocked true while walletExists
+  // is already true, so the two branches never actually compete.
+  if (isLocked) {
+    return (
+      <div className={PANEL_SHELL} data-wallet-panel>
+        <div className="flex-1 relative overflow-y-auto flex items-center justify-center">
+          {restoreFromLock ? (
+            <CreateWalletFlow initialStep="restoreMethod" />
+          ) : (
+            <UnlockScreen onRestore={() => setRestoreFromLock(true)} />
           )}
         </div>
       </div>

--- a/src/components/wallet/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/onboarding/CreateWalletFlow.tsx
@@ -17,7 +17,9 @@ import {
   AddressSelectionScreen,
   NametagScreen,
   ProcessingScreen,
-  MnemonicBackupScreen,
+  MnemonicShowScreen,
+  ConfirmMnemonicScreen,
+  BackupDownloadScreen,
   SetPasswordScreen,
   PlanCapabilitiesScreen,
 } from "./components";
@@ -70,7 +72,10 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
     processingTitle,
     processingCompleteTitle,
     isProcessingComplete,
-    handleMnemonicBackupComplete,
+    handleMnemonicShowContinue,
+    handleConfirmMnemonic,
+    handleMnemonicConfirmBack,
+    handleBackupDownloadComplete,
     handleDownloadBackup,
     backupEncrypted,
     handleSetPassword,
@@ -117,7 +122,12 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
   // Block navigation clicks outside wallet panel during critical steps.
   // Sets pointer-events:none on body, re-enables on wallet panel and on
   // fixed/absolute modals (z-100) so Connect intents still work.
-  const isLocked = step === "processing" || step === "mnemonicBackup" || step === "setPassword";
+  const isLocked =
+    step === "processing" ||
+    step === "mnemonicShow" ||
+    step === "mnemonicConfirm" ||
+    step === "setPassword" ||
+    step === "backupDownload";
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -248,12 +258,18 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
           />
         )}
 
-        {step === "mnemonicBackup" && generatedMnemonic && (
-          <MnemonicBackupScreen
+        {step === "mnemonicShow" && generatedMnemonic && (
+          <MnemonicShowScreen
             mnemonic={generatedMnemonic}
-            encrypted={backupEncrypted}
-            onDownloadBackup={handleDownloadBackup}
-            onConfirm={handleMnemonicBackupComplete}
+            onContinue={handleMnemonicShowContinue}
+          />
+        )}
+
+        {step === "mnemonicConfirm" && (
+          <ConfirmMnemonicScreen
+            error={error}
+            onSubmit={handleConfirmMnemonic}
+            onBack={handleMnemonicConfirmBack}
           />
         )}
 
@@ -263,6 +279,14 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
             error={error}
             onSet={(password) => void handleSetPassword(password)}
             onSkip={() => void handleSetPassword()}
+          />
+        )}
+
+        {step === "backupDownload" && (
+          <BackupDownloadScreen
+            encrypted={backupEncrypted}
+            onDownloadBackup={handleDownloadBackup}
+            onContinue={handleBackupDownloadComplete}
           />
         )}
 

--- a/src/components/wallet/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/onboarding/CreateWalletFlow.tsx
@@ -72,6 +72,7 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
     isProcessingComplete,
     handleMnemonicBackupComplete,
     handleDownloadBackup,
+    backupEncrypted,
     handleSetPassword,
 
     // Subscription plan-capabilities state (post-finalize provisioning)
@@ -250,6 +251,7 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
         {step === "mnemonicBackup" && generatedMnemonic && (
           <MnemonicBackupScreen
             mnemonic={generatedMnemonic}
+            encrypted={backupEncrypted}
             onDownloadBackup={handleDownloadBackup}
             onConfirm={handleMnemonicBackupComplete}
           />
@@ -258,6 +260,7 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
         {step === "setPassword" && (
           <SetPasswordScreen
             isBusy={isBusy}
+            error={error}
             onSet={(password) => void handleSetPassword(password)}
             onSkip={() => void handleSetPassword()}
           />

--- a/src/components/wallet/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/onboarding/CreateWalletFlow.tsx
@@ -18,6 +18,7 @@ import {
   NametagScreen,
   ProcessingScreen,
   MnemonicBackupScreen,
+  SetPasswordScreen,
   PlanCapabilitiesScreen,
 } from "./components";
 
@@ -71,6 +72,7 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
     isProcessingComplete,
     handleMnemonicBackupComplete,
     handleDownloadBackup,
+    handleSetPassword,
 
     // Subscription plan-capabilities state (post-finalize provisioning)
     planName,
@@ -114,7 +116,7 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
   // Block navigation clicks outside wallet panel during critical steps.
   // Sets pointer-events:none on body, re-enables on wallet panel and on
   // fixed/absolute modals (z-100) so Connect intents still work.
-  const isLocked = step === "processing" || step === "mnemonicBackup";
+  const isLocked = step === "processing" || step === "mnemonicBackup" || step === "setPassword";
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -250,6 +252,13 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
             mnemonic={generatedMnemonic}
             onDownloadBackup={handleDownloadBackup}
             onConfirm={handleMnemonicBackupComplete}
+          />
+        )}
+
+        {step === "setPassword" && (
+          <SetPasswordScreen
+            onSet={(password) => void handleSetPassword(password)}
+            onSkip={() => void handleSetPassword()}
           />
         )}
 

--- a/src/components/wallet/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/onboarding/CreateWalletFlow.tsx
@@ -23,7 +23,20 @@ import {
 
 export type { OnboardingStep } from "./hooks/useOnboardingFlow";
 
-export function CreateWalletFlow({ initialStep }: { initialStep?: OnboardingStep } = {}) {
+interface CreateWalletFlowProps {
+  initialStep?: OnboardingStep;
+  /**
+   * True when entered via the UnlockScreen "forgot password" lock-escape
+   * (#449) — a real, locked wallet sits on disk. Requires the restore path
+   * to show an explicit erase-confirmation and never fall through to the
+   * generic StartScreen's "Create New Wallet".
+   */
+  fromLock?: boolean;
+  /** Called instead of showing the "start" step when `fromLock` is true (exits back to UnlockScreen). */
+  onExitToUnlock?: () => void;
+}
+
+export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: CreateWalletFlowProps = {}) {
   const { initProgress } = useSphereContext();
   const progressMessage = initProgress?.message ?? null;
 
@@ -96,7 +109,7 @@ export function CreateWalletFlow({ initialStep }: { initialStep?: OnboardingStep
     // Wallet context
     identity,
     nametag,
-  } = useOnboardingFlow(initialStep);
+  } = useOnboardingFlow(initialStep, { fromLock, onExitToUnlock });
 
   // Block navigation clicks outside wallet panel during critical steps.
   // Sets pointer-events:none on body, re-enables on wallet panel and on
@@ -147,6 +160,7 @@ export function CreateWalletFlow({ initialStep }: { initialStep?: OnboardingStep
           <RestoreMethodScreen
             isBusy={isBusy}
             error={error}
+            fromLock={fromLock}
             onSelectMnemonic={() => setStep("restore")}
             onSelectFile={() => setStep("importFile")}
             onBack={goToStart}

--- a/src/components/wallet/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/onboarding/CreateWalletFlow.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useRef } from "react";
 import { AnimatePresence } from "framer-motion";
 import { useSphereContext } from "../../../sdk/hooks/core/useSphere";
-import { useOnboardingFlow } from "./hooks/useOnboardingFlow";
+import { useOnboardingFlow, type OnboardingStep } from "./hooks/useOnboardingFlow";
 
 // Import screen components
 import {
@@ -23,7 +23,7 @@ import {
 
 export type { OnboardingStep } from "./hooks/useOnboardingFlow";
 
-export function CreateWalletFlow() {
+export function CreateWalletFlow({ initialStep }: { initialStep?: OnboardingStep } = {}) {
   const { initProgress } = useSphereContext();
   const progressMessage = initProgress?.message ?? null;
 
@@ -96,7 +96,7 @@ export function CreateWalletFlow() {
     // Wallet context
     identity,
     nametag,
-  } = useOnboardingFlow();
+  } = useOnboardingFlow(initialStep);
 
   // Block navigation clicks outside wallet panel during critical steps.
   // Sets pointer-events:none on body, re-enables on wallet panel and on

--- a/src/components/wallet/onboarding/CreateWalletFlow.tsx
+++ b/src/components/wallet/onboarding/CreateWalletFlow.tsx
@@ -257,6 +257,7 @@ export function CreateWalletFlow({ initialStep, fromLock, onExitToUnlock }: Crea
 
         {step === "setPassword" && (
           <SetPasswordScreen
+            isBusy={isBusy}
             onSet={(password) => void handleSetPassword(password)}
             onSkip={() => void handleSetPassword()}
           />

--- a/src/components/wallet/onboarding/components/BackupDownloadScreen.tsx
+++ b/src/components/wallet/onboarding/components/BackupDownloadScreen.tsx
@@ -1,0 +1,83 @@
+/**
+ * BackupDownloadScreen - optional backup-file download, AFTER the password
+ * step (#449 create-flow reorder: show -> confirm -> password -> download).
+ *
+ * Running after setPassword means the SAME password chosen there (if any)
+ * encrypts this download, exactly like the in-wallet "Save Wallet" — see
+ * `handleDownloadBackup` / `createBackupPasswordRef` in useOnboardingFlow.
+ * `encrypted` only drives this screen's own label/copy.
+ */
+import { motion } from "framer-motion";
+import { Download, ShieldAlert } from "lucide-react";
+
+interface BackupDownloadScreenProps {
+  /** True when a wallet password was set on the preceding setPassword step —
+   *  the SAME password encrypts this download; false means it will be
+   *  plaintext (password step skipped). */
+  encrypted: boolean;
+  onDownloadBackup: () => void;
+  onContinue: () => void;
+}
+
+export function BackupDownloadScreen({
+  encrypted,
+  onDownloadBackup,
+  onContinue,
+}: BackupDownloadScreenProps) {
+  return (
+    <motion.div
+      key="backupDownload"
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.1 }}
+      className="relative z-10 w-full max-w-95"
+    >
+      {/* Icon */}
+      <div className="relative w-18 h-18 mx-auto mb-5">
+        <div className="absolute inset-0 bg-amber-500/30 rounded-2xl blur-xl" />
+        <div className="relative w-full h-full rounded-2xl bg-linear-to-br from-amber-500 to-amber-600 flex items-center justify-center shadow-xl shadow-amber-500/25">
+          <ShieldAlert className="w-9 h-9 text-white" />
+        </div>
+      </div>
+
+      <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-2 tracking-tight">
+        Download Wallet Backup
+      </h2>
+
+      <p className="text-neutral-500 dark:text-[#ffe2cc] text-sm mb-5 mx-auto leading-relaxed">
+        Optionally save a backup file of your wallet{" "}
+        {encrypted
+          ? "encrypted with the password you just set."
+          : "in plain text — you can add a password from Settings later."}
+      </p>
+
+      {/* Download backup button — reuses the wallet password from the
+          preceding setPassword step; no separate password entry here. */}
+      <button
+        onClick={onDownloadBackup}
+        className="flex items-center justify-center gap-2 w-full mb-5 px-4 py-2.5 text-sm text-neutral-600 dark:text-[#ffe2cc] border border-neutral-200 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/6 transition-colors rounded-xl"
+      >
+        <Download className="w-4 h-4" />
+        <span>{encrypted ? "Download Encrypted Backup" : "Download Backup File"}</span>
+      </button>
+
+      {/* Warning notice */}
+      <div className="mb-5 p-3 rounded-lg bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20">
+        <p className="text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
+          {encrypted
+            ? "This backup file is encrypted with your wallet password — you'll need it to restore. Anyone with your recovery phrase can still access your funds, so keep it safe too."
+            : "Without a password the backup file contains your recovery phrase in plain text. Anyone with it can access your wallet and funds — set a password or store it securely."}
+        </p>
+      </div>
+
+      {/* Continue button */}
+      <button
+        onClick={onContinue}
+        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group"
+      >
+        <div className="absolute inset-0 bg-linear-to-r from-brand-orange to-brand-orange-dark opacity-0 group-hover:opacity-100 transition-opacity" />
+        <span className="relative z-10">Continue</span>
+      </button>
+    </motion.div>
+  );
+}

--- a/src/components/wallet/onboarding/components/ConfirmMnemonicScreen.tsx
+++ b/src/components/wallet/onboarding/components/ConfirmMnemonicScreen.tsx
@@ -3,13 +3,12 @@
  * (#449 create-flow reorder: show -> confirm -> password -> download).
  *
  * MnemonicShowScreen only asks the user to LOOK at the 12 words; this screen
- * makes them prove they actually saved them by retyping the phrase. The
- * caller (useOnboardingFlow's `handleConfirmMnemonic`) normalizes both sides
- * (trim / collapse whitespace / lowercase) and compares against
- * `generatedMnemonic` — only an exact match advances the flow to the
- * optional password step. A mismatch surfaces `error` here and does NOT
- * advance, so a user who mistyped (or didn't actually write it down) can't
- * proceed believing they have a working backup. "Back" returns to
+ * makes them prove they actually saved them by retyping the phrase into a
+ * 12-word grid (same cell layout as the import/restore screen). The caller
+ * (useOnboardingFlow's `handleConfirmMnemonic`) normalizes both sides (trim /
+ * collapse whitespace / lowercase) and compares against `generatedMnemonic` —
+ * only an exact match advances to the optional password step. A mismatch
+ * surfaces `error` here and does NOT advance. "Back" returns to
  * MnemonicShowScreen to re-view the words.
  */
 import { useState, useCallback } from "react";
@@ -17,6 +16,7 @@ import { motion } from "framer-motion";
 import { ShieldCheck } from "lucide-react";
 
 interface ConfirmMnemonicScreenProps {
+  /** Called with the 12 words joined by single spaces. */
   onSubmit: (entered: string) => void;
   onBack: () => void;
   /** Surfaced by the caller on a mismatch — cleared once the user retries. */
@@ -28,11 +28,47 @@ export function ConfirmMnemonicScreen({
   onBack,
   error = null,
 }: ConfirmMnemonicScreenProps) {
-  const [value, setValue] = useState("");
+  const [words, setWords] = useState<string[]>(() => Array(12).fill(""));
+
+  const handleWordChange = (index: number, value: string) => {
+    setWords((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const pasted = e.clipboardData.getData("text").trim();
+    const parts = pasted.split(/\s+/).filter((w) => w.length > 0);
+    // Pasting the whole phrase fills every cell at once.
+    if (parts.length > 1) {
+      e.preventDefault();
+      const next = Array(12).fill("");
+      parts.slice(0, 12).forEach((w, i) => {
+        next[i] = w.toLowerCase();
+      });
+      setWords(next);
+    }
+  };
+
+  const isComplete = words.every((w) => w.trim());
 
   const handleSubmit = useCallback(() => {
-    onSubmit(value);
-  }, [value, onSubmit]);
+    if (!words.every((w) => w.trim())) return;
+    onSubmit(words.map((w) => w.trim()).join(" "));
+  }, [words, onSubmit]);
+
+  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key !== "Enter") return;
+    if (index < 11) {
+      const nextInput = (e.currentTarget as HTMLElement).parentElement
+        ?.nextElementSibling?.querySelector("input");
+      (nextInput as HTMLInputElement | null)?.focus();
+    } else {
+      handleSubmit();
+    }
+  };
 
   return (
     <motion.div
@@ -55,22 +91,33 @@ export function ConfirmMnemonicScreen({
       </h2>
 
       <p className="text-neutral-500 dark:text-[#ffe2cc] text-sm mb-5 mx-auto leading-relaxed">
-        Re-enter your 12-word recovery phrase, separated by spaces, to
-        confirm you saved it correctly.
+        Re-enter your 12-word recovery phrase to confirm you saved it correctly.
       </p>
 
-      <textarea
-        aria-label="Recovery phrase"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        placeholder="Enter your 12 words separated by spaces"
-        rows={3}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        className="w-full px-4 py-3 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-brand-orange/60 mb-3 resize-none"
-      />
+      {/* 12-word grid (same layout as import) */}
+      <div className="grid grid-cols-3 gap-2 mb-4">
+        {Array.from({ length: 12 }).map((_, index) => (
+          <div key={`confirm-word-${index}`} className="relative">
+            <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-xs text-neutral-400 dark:text-neutral-600 font-medium z-10">
+              {index + 1}.
+            </span>
+            <input
+              type="text"
+              value={words[index]}
+              onChange={(e) => handleWordChange(index, e.target.value)}
+              onPaste={handlePaste}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              placeholder="word"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              className="w-full bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 rounded-lg py-2.5 pl-8 pr-2 text-sm text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-600 focus:outline-none focus:border-brand-orange/60 transition-all"
+              autoFocus={index === 0}
+            />
+          </div>
+        ))}
+      </div>
 
       {error && (
         <p className="text-red-500 dark:text-red-400 text-xs bg-red-500/10 border border-red-500/20 p-2 rounded-lg mb-3 text-left">
@@ -80,7 +127,8 @@ export function ConfirmMnemonicScreen({
 
       <button
         onClick={handleSubmit}
-        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group mb-2.5"
+        disabled={!isComplete}
+        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group mb-2.5 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <div className="absolute inset-0 bg-linear-to-r from-brand-orange to-brand-orange-dark opacity-0 group-hover:opacity-100 transition-opacity" />
         <span className="relative z-10">Confirm</span>

--- a/src/components/wallet/onboarding/components/ConfirmMnemonicScreen.tsx
+++ b/src/components/wallet/onboarding/components/ConfirmMnemonicScreen.tsx
@@ -1,0 +1,96 @@
+/**
+ * ConfirmMnemonicScreen - re-entry verification step for the recovery phrase
+ * (#449 create-flow reorder: show -> confirm -> password -> download).
+ *
+ * MnemonicShowScreen only asks the user to LOOK at the 12 words; this screen
+ * makes them prove they actually saved them by retyping the phrase. The
+ * caller (useOnboardingFlow's `handleConfirmMnemonic`) normalizes both sides
+ * (trim / collapse whitespace / lowercase) and compares against
+ * `generatedMnemonic` — only an exact match advances the flow to the
+ * optional password step. A mismatch surfaces `error` here and does NOT
+ * advance, so a user who mistyped (or didn't actually write it down) can't
+ * proceed believing they have a working backup. "Back" returns to
+ * MnemonicShowScreen to re-view the words.
+ */
+import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import { ShieldCheck } from "lucide-react";
+
+interface ConfirmMnemonicScreenProps {
+  onSubmit: (entered: string) => void;
+  onBack: () => void;
+  /** Surfaced by the caller on a mismatch — cleared once the user retries. */
+  error?: string | null;
+}
+
+export function ConfirmMnemonicScreen({
+  onSubmit,
+  onBack,
+  error = null,
+}: ConfirmMnemonicScreenProps) {
+  const [value, setValue] = useState("");
+
+  const handleSubmit = useCallback(() => {
+    onSubmit(value);
+  }, [value, onSubmit]);
+
+  return (
+    <motion.div
+      key="mnemonicConfirm"
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.1 }}
+      className="relative z-10 w-full max-w-95"
+    >
+      {/* Icon */}
+      <div className="relative w-18 h-18 mx-auto mb-5">
+        <div className="absolute inset-0 bg-brand-orange/30 rounded-2xl blur-xl" />
+        <div className="relative w-full h-full rounded-2xl bg-linear-to-br from-brand-orange to-brand-orange-dark flex items-center justify-center shadow-xl shadow-brand-orange/25">
+          <ShieldCheck className="w-9 h-9 text-white" />
+        </div>
+      </div>
+
+      <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-2 tracking-tight">
+        Confirm Recovery Phrase
+      </h2>
+
+      <p className="text-neutral-500 dark:text-[#ffe2cc] text-sm mb-5 mx-auto leading-relaxed">
+        Re-enter your 12-word recovery phrase, separated by spaces, to
+        confirm you saved it correctly.
+      </p>
+
+      <textarea
+        aria-label="Recovery phrase"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Enter your 12 words separated by spaces"
+        rows={3}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="w-full px-4 py-3 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-brand-orange/60 mb-3 resize-none"
+      />
+
+      {error && (
+        <p className="text-red-500 dark:text-red-400 text-xs bg-red-500/10 border border-red-500/20 p-2 rounded-lg mb-3 text-left">
+          {error}
+        </p>
+      )}
+
+      <button
+        onClick={handleSubmit}
+        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group mb-2.5"
+      >
+        <div className="absolute inset-0 bg-linear-to-r from-brand-orange to-brand-orange-dark opacity-0 group-hover:opacity-100 transition-opacity" />
+        <span className="relative z-10">Confirm</span>
+      </button>
+      <button
+        onClick={onBack}
+        className="w-full py-2.5 px-5 text-sm text-neutral-500 dark:text-[#ffe2cc] hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors rounded-xl hover:bg-neutral-100 dark:hover:bg-white/6"
+      >
+        Back
+      </button>
+    </motion.div>
+  );
+}

--- a/src/components/wallet/onboarding/components/MnemonicBackupScreen.tsx
+++ b/src/components/wallet/onboarding/components/MnemonicBackupScreen.tsx
@@ -2,6 +2,12 @@
  * MnemonicBackupScreen - Shows recovery phrase after wallet creation
  * Allows user to copy, download backup, and confirm before entering wallet
  * Layout matches sphere-extension's MnemonicBackupScreen for consistency
+ *
+ * #449 UX refinement: this screen now runs AFTER the optional setPassword
+ * step, so there's no separate backup-file password input here anymore
+ * (that was the #450 field) — the download reuses whichever wallet password
+ * was just chosen (or none, if skipped). `encrypted` tells the caller which
+ * happened, purely to drive this screen's own label/copy.
  */
 import { motion } from "framer-motion";
 import { ShieldAlert, Copy, Check, Download } from "lucide-react";
@@ -9,17 +15,21 @@ import { useState, useCallback } from "react";
 
 interface MnemonicBackupScreenProps {
   mnemonic: string;
-  onDownloadBackup: (password?: string) => void;
+  /** True when a wallet password was set on the preceding setPassword step —
+   *  the SAME password encrypts this download; false means it will be
+   *  plaintext (password step skipped). */
+  encrypted: boolean;
+  onDownloadBackup: () => void;
   onConfirm: () => void;
 }
 
 export function MnemonicBackupScreen({
   mnemonic,
+  encrypted,
   onDownloadBackup,
   onConfirm,
 }: MnemonicBackupScreenProps) {
   const [copied, setCopied] = useState(false);
-  const [backupPassword, setBackupPassword] = useState("");
   const words = mnemonic.split(" ");
 
   const handleCopy = useCallback(async () => {
@@ -106,31 +116,21 @@ export function MnemonicBackupScreen({
         )}
       </button>
 
-      {/* Optional backup-file encryption password */}
-      <input
-        type="password"
-        value={backupPassword}
-        onChange={(e) => setBackupPassword(e.target.value)}
-        placeholder="Backup file password (optional)"
-        aria-label="Backup file password (optional)"
-        autoComplete="new-password"
-        className="w-full mb-2 px-4 py-2.5 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-brand-orange/60"
-      />
-
-      {/* Download backup button */}
+      {/* Download backup button — reuses the wallet password from the
+          preceding setPassword step; no separate password entry here. */}
       <button
-        onClick={() => onDownloadBackup(backupPassword || undefined)}
+        onClick={onDownloadBackup}
         className="flex items-center justify-center gap-2 w-full mb-5 px-4 py-2.5 text-sm text-neutral-600 dark:text-[#ffe2cc] border border-neutral-200 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/6 transition-colors rounded-xl"
       >
         <Download className="w-4 h-4" />
-        <span>{backupPassword ? "Download Encrypted Backup" : "Download Backup File"}</span>
+        <span>{encrypted ? "Download Encrypted Backup" : "Download Backup File"}</span>
       </button>
 
       {/* Warning notice */}
       <div className="mb-5 p-3 rounded-lg bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20">
         <p className="text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
-          {backupPassword
-            ? "The backup file is encrypted with this password — you'll need it to restore. Keep both safe. Anyone with your recovery phrase can access your funds."
+          {encrypted
+            ? "This backup file is encrypted with your wallet password — you'll need it to restore. Anyone with your recovery phrase can still access your funds, so keep it safe too."
             : "Without a password the backup file contains your recovery phrase in plain text. Anyone with it can access your wallet and funds — set a password or store it securely."}
         </p>
       </div>

--- a/src/components/wallet/onboarding/components/MnemonicShowScreen.tsx
+++ b/src/components/wallet/onboarding/components/MnemonicShowScreen.tsx
@@ -1,34 +1,30 @@
 /**
- * MnemonicBackupScreen - Shows recovery phrase after wallet creation
- * Allows user to copy, download backup, and confirm before entering wallet
- * Layout matches sphere-extension's MnemonicBackupScreen for consistency
+ * MnemonicShowScreen - shows the recovery phrase after wallet creation
+ * Allows the user to copy the phrase. Layout matches sphere-extension's
+ * original MnemonicBackupScreen for consistency.
  *
- * #449 UX refinement: this screen now runs AFTER the optional setPassword
- * step, so there's no separate backup-file password input here anymore
- * (that was the #450 field) — the download reuses whichever wallet password
- * was just chosen (or none, if skipped). `encrypted` tells the caller which
- * happened, purely to drive this screen's own label/copy.
+ * #449 create-flow reorder: show -> confirm -> password -> download. Renamed
+ * from MnemonicBackupScreen and stripped of the download button — the backup
+ * file download now lives on BackupDownloadScreen, AFTER the optional
+ * password step, so it can reuse whichever password the user just chose (see
+ * useOnboardingFlow's createBackupPasswordRef / handleDownloadBackup).
+ * "Continue" here advances to ConfirmMnemonicScreen, which makes the user
+ * re-type the phrase and verifies it matches before the flow proceeds — the
+ * real backup verification this screen alone can't provide.
  */
 import { motion } from "framer-motion";
-import { ShieldAlert, Copy, Check, Download } from "lucide-react";
+import { ShieldAlert, Copy, Check } from "lucide-react";
 import { useState, useCallback } from "react";
 
-interface MnemonicBackupScreenProps {
+interface MnemonicShowScreenProps {
   mnemonic: string;
-  /** True when a wallet password was set on the preceding setPassword step —
-   *  the SAME password encrypts this download; false means it will be
-   *  plaintext (password step skipped). */
-  encrypted: boolean;
-  onDownloadBackup: () => void;
-  onConfirm: () => void;
+  onContinue: () => void;
 }
 
-export function MnemonicBackupScreen({
+export function MnemonicShowScreen({
   mnemonic,
-  encrypted,
-  onDownloadBackup,
-  onConfirm,
-}: MnemonicBackupScreenProps) {
+  onContinue,
+}: MnemonicShowScreenProps) {
   const [copied, setCopied] = useState(false);
   const words = mnemonic.split(" ");
 
@@ -53,7 +49,7 @@ export function MnemonicBackupScreen({
 
   return (
     <motion.div
-      key="mnemonicBackup"
+      key="mnemonicShow"
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.1 }}
@@ -75,7 +71,8 @@ export function MnemonicBackupScreen({
         Write down these 12 words in order and keep them safe.{" "}
         <span className="text-brand-orange font-semibold">
           This is the only way to recover your wallet.
-        </span>
+        </span>{" "}
+        You'll be asked to re-enter them next to confirm.
       </p>
 
       {/* Mnemonic word grid */}
@@ -116,28 +113,10 @@ export function MnemonicBackupScreen({
         )}
       </button>
 
-      {/* Download backup button — reuses the wallet password from the
-          preceding setPassword step; no separate password entry here. */}
+      {/* Continue button — advances to the re-entry confirmation step, NOT
+          finalize (that's ConfirmMnemonicScreen's job next). */}
       <button
-        onClick={onDownloadBackup}
-        className="flex items-center justify-center gap-2 w-full mb-5 px-4 py-2.5 text-sm text-neutral-600 dark:text-[#ffe2cc] border border-neutral-200 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/6 transition-colors rounded-xl"
-      >
-        <Download className="w-4 h-4" />
-        <span>{encrypted ? "Download Encrypted Backup" : "Download Backup File"}</span>
-      </button>
-
-      {/* Warning notice */}
-      <div className="mb-5 p-3 rounded-lg bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20">
-        <p className="text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
-          {encrypted
-            ? "This backup file is encrypted with your wallet password — you'll need it to restore. Anyone with your recovery phrase can still access your funds, so keep it safe too."
-            : "Without a password the backup file contains your recovery phrase in plain text. Anyone with it can access your wallet and funds — set a password or store it securely."}
-        </p>
-      </div>
-
-      {/* Confirm button */}
-      <button
-        onClick={onConfirm}
+        onClick={onContinue}
         className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group"
       >
         <div className="absolute inset-0 bg-linear-to-r from-brand-orange to-brand-orange-dark opacity-0 group-hover:opacity-100 transition-opacity" />

--- a/src/components/wallet/onboarding/components/RestoreMethodScreen.tsx
+++ b/src/components/wallet/onboarding/components/RestoreMethodScreen.tsx
@@ -1,12 +1,20 @@
 /**
  * RestoreMethodScreen - Choose restore method (mnemonic or file)
  */
+import { useState } from "react";
 import { motion } from "framer-motion";
-import { KeyRound, Upload, ArrowRight, ArrowLeft } from "lucide-react";
+import { KeyRound, Upload, ArrowRight, ArrowLeft, AlertTriangle } from "lucide-react";
 
 interface RestoreMethodScreenProps {
   isBusy: boolean;
   error: string | null;
+  /**
+   * True when entered via the UnlockScreen "forgot password" lock-escape
+   * (#449): a real, still-recoverable (locked) wallet sits on disk. Gates
+   * both restore options behind an explicit erase-confirmation checkbox so
+   * the destructive replace (mnemonic/file import) can't run by accident.
+   */
+  fromLock?: boolean;
   onSelectMnemonic: () => void;
   onSelectFile: () => void;
   onBack: () => void;
@@ -15,10 +23,14 @@ interface RestoreMethodScreenProps {
 export function RestoreMethodScreen({
   isBusy,
   error,
+  fromLock,
   onSelectMnemonic,
   onSelectFile,
   onBack,
 }: RestoreMethodScreenProps) {
+  const [eraseConfirmed, setEraseConfirmed] = useState(false);
+  const optionsDisabled = isBusy || (!!fromLock && !eraseConfirmed);
+
   return (
     <motion.div
       key="restoreMethod"
@@ -46,13 +58,41 @@ export function RestoreMethodScreen({
         Choose how you want to restore your wallet
       </p>
 
+      {/* Lock-escape erase confirmation (#449): a real, recoverable wallet is
+          still on disk — restoring here replaces it, so require an explicit,
+          affirmative confirmation before either option becomes clickable. */}
+      {fromLock && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mb-4 p-3 rounded-xl bg-amber-500/10 border border-amber-500/20 text-left"
+        >
+          <div className="flex gap-2 mb-2">
+            <AlertTriangle className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+            <p className="text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
+              Restoring will erase the wallet currently on this device. Only continue if you have its recovery phrase.
+            </p>
+          </div>
+          <label className="flex items-center gap-2 text-xs text-neutral-700 dark:text-neutral-300 pl-6 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={eraseConfirmed}
+              onChange={(e) => setEraseConfirmed(e.target.checked)}
+              className="w-3.5 h-3.5 accent-amber-500"
+            />
+            I understand, and I have the recovery phrase
+          </label>
+        </motion.div>
+      )}
+
       <div className="space-y-3 mb-5">
         {/* Recovery Phrase Option */}
         <motion.button
           onClick={onSelectMnemonic}
+          disabled={optionsDisabled}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
-          className="w-full p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 hover:border-blue-500/50 dark:hover:border-blue-500/50 transition-all text-left group"
+          className="w-full p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 hover:border-blue-500/50 dark:hover:border-blue-500/50 transition-all text-left group disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <div className="flex items-center gap-4">
             <div className="w-12 h-12 rounded-xl bg-blue-500/10 flex items-center justify-center group-hover:bg-blue-500/20 transition-colors">
@@ -73,9 +113,10 @@ export function RestoreMethodScreen({
         {/* Import from File Option */}
         <motion.button
           onClick={onSelectFile}
+          disabled={optionsDisabled}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
-          className="w-full p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 hover:border-orange-500/50 dark:hover:border-orange-500/50 transition-all text-left group"
+          className="w-full p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 hover:border-orange-500/50 dark:hover:border-orange-500/50 transition-all text-left group disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <div className="flex items-center gap-4">
             <div className="w-12 h-12 rounded-xl bg-orange-500/10 flex items-center justify-center group-hover:bg-orange-500/20 transition-colors">

--- a/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
+++ b/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
@@ -1,14 +1,18 @@
 /**
- * SetPasswordScreen - optional at-rest password step for onboarding + import (#449)
+ * SetPasswordScreen - optional at-rest password step for onboarding + import
+ * (#449, #449 follow-up)
  *
  * Shown AFTER the seed-backup screen in the create flow, and after the
  * mnemonic is entered/known in the import/restore flow. Purely a form —
- * validation only (match + min length). The caller decides how the chosen
- * password is applied; the ONLY safe application of a password here is into
- * the wallet's initial `createWallet({ password })` / `importWallet(mnemonic,
- * { password })` call (a fresh wallet, nothing to lose) — never an in-place
- * re-encrypt of an already-persisted wallet (that's the Settings "set
- * password" flow on an existing wallet, a separate task).
+ * validation only (match + min length). The caller (useOnboardingFlow's
+ * `handleSetPassword`) decides how the chosen password is applied:
+ *  - Restore/import flow: into the wallet's initial `importWallet(mnemonic,
+ *    { password })` call — a fresh wallet, nothing persisted yet.
+ *  - Create flow: the wallet is ALREADY persisted (plaintext) by this point,
+ *    so the password is applied via the reviewed-SAFE in-place mnemonic
+ *    re-encrypt (`setWalletPassword` from `useSphereContext()`) — never a
+ *    second `importWallet`/`Sphere.import()` call, which would wipe the
+ *    token DB. See `handleSetPassword`'s doc-comment for the full history.
  */
 import { useState, useCallback } from "react";
 import { motion } from "framer-motion";

--- a/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
+++ b/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
@@ -19,9 +19,13 @@ const MIN_PASSWORD_LENGTH = 8;
 interface SetPasswordScreenProps {
   onSet: (password: string) => void;
   onSkip: () => void;
+  /** Disables Set/Skip while a persist is in flight (#449 re-entrancy guard —
+   *  this screen has no other affordance stopping a double-click / a fast
+   *  Set-then-Skip from firing two overlapping persist calls). */
+  isBusy?: boolean;
 }
 
-export function SetPasswordScreen({ onSet, onSkip }: SetPasswordScreenProps) {
+export function SetPasswordScreen({ onSet, onSkip, isBusy = false }: SetPasswordScreenProps) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -97,14 +101,16 @@ export function SetPasswordScreen({ onSet, onSkip }: SetPasswordScreenProps) {
 
       <button
         onClick={handleSet}
-        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group mb-2.5"
+        disabled={isBusy}
+        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group mb-2.5 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <div className="absolute inset-0 bg-linear-to-r from-brand-orange to-brand-orange-dark opacity-0 group-hover:opacity-100 transition-opacity" />
         <span className="relative z-10">Set Password</span>
       </button>
       <button
         onClick={onSkip}
-        className="w-full py-2.5 px-5 text-sm text-neutral-500 dark:text-[#ffe2cc] hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors rounded-xl hover:bg-neutral-100 dark:hover:bg-white/6"
+        disabled={isBusy}
+        className="w-full py-2.5 px-5 text-sm text-neutral-500 dark:text-[#ffe2cc] hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors rounded-xl hover:bg-neutral-100 dark:hover:bg-white/6 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         Skip
       </button>

--- a/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
+++ b/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
@@ -1,0 +1,113 @@
+/**
+ * SetPasswordScreen - optional at-rest password step for onboarding + import (#449)
+ *
+ * Shown AFTER the seed-backup screen in the create flow, and after the
+ * mnemonic is entered/known in the import/restore flow. Purely a form —
+ * validation only (match + min length). The caller decides how the chosen
+ * password is applied; the ONLY safe application of a password here is into
+ * the wallet's initial `createWallet({ password })` / `importWallet(mnemonic,
+ * { password })` call (a fresh wallet, nothing to lose) — never an in-place
+ * re-encrypt of an already-persisted wallet (that's the Settings "set
+ * password" flow on an existing wallet, a separate task).
+ */
+import { useState, useCallback } from "react";
+import { motion } from "framer-motion";
+import { ShieldCheck } from "lucide-react";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+interface SetPasswordScreenProps {
+  onSet: (password: string) => void;
+  onSkip: () => void;
+}
+
+export function SetPasswordScreen({ onSet, onSkip }: SetPasswordScreenProps) {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSet = useCallback(() => {
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords don't match");
+      return;
+    }
+    setError(null);
+    onSet(password);
+  }, [password, confirmPassword, onSet]);
+
+  return (
+    <motion.div
+      key="setPassword"
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.1 }}
+      className="relative z-10 w-full max-w-90 mx-auto"
+    >
+      {/* Icon */}
+      <div className="relative w-16 h-16 mx-auto mb-5">
+        <div className="absolute inset-0 bg-brand-orange/30 rounded-2xl blur-xl" />
+        <div className="relative w-full h-full rounded-2xl bg-linear-to-br from-brand-orange to-brand-orange-dark flex items-center justify-center shadow-xl shadow-brand-orange/25">
+          <ShieldCheck className="w-8 h-8 text-white" />
+        </div>
+      </div>
+
+      <h2 className="text-2xl font-bold text-neutral-900 dark:text-white mb-2 tracking-tight">
+        Protect Your Wallet
+      </h2>
+
+      <p className="text-neutral-500 dark:text-[#ffe2cc] text-sm mb-5 leading-relaxed">
+        Add a password to encrypt your wallet on this device.{" "}
+        <span className="text-brand-orange font-semibold">
+          This can only be recovered with your recovery phrase
+        </span>{" "}
+        — there is no other way to reset it.
+      </p>
+
+      <div className="flex flex-col gap-3 mb-2">
+        <input
+          type="password"
+          aria-label="Password"
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full px-4 py-2.5 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-brand-orange/60"
+        />
+        <input
+          type="password"
+          aria-label="Confirm password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSet()}
+          placeholder="Confirm password"
+          className="w-full px-4 py-2.5 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-brand-orange/60"
+        />
+      </div>
+
+      {error && (
+        <p className="text-red-500 dark:text-red-400 text-xs bg-red-500/10 border border-red-500/20 p-2 rounded-lg mb-3 text-left">
+          {error}
+        </p>
+      )}
+
+      <button
+        onClick={handleSet}
+        className="relative w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-brand-orange to-brand-orange-dark text-white text-sm font-bold shadow-xl shadow-brand-orange/25 flex items-center justify-center gap-2 overflow-hidden group mb-2.5"
+      >
+        <div className="absolute inset-0 bg-linear-to-r from-brand-orange to-brand-orange-dark opacity-0 group-hover:opacity-100 transition-opacity" />
+        <span className="relative z-10">Set Password</span>
+      </button>
+      <button
+        onClick={onSkip}
+        className="w-full py-2.5 px-5 text-sm text-neutral-500 dark:text-[#ffe2cc] hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors rounded-xl hover:bg-neutral-100 dark:hover:bg-white/6"
+      >
+        Skip
+      </button>
+    </motion.div>
+  );
+}

--- a/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
+++ b/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
@@ -3,16 +3,14 @@
  * (#449, #449 follow-up)
  *
  * Shown AFTER the seed-backup screen in the create flow, and after the
- * mnemonic is entered/known in the import/restore flow. Purely a form —
+ * addresses are selected in the import/restore flow. Purely a form —
  * validation only (match + min length). The caller (useOnboardingFlow's
- * `handleSetPassword`) decides how the chosen password is applied:
- *  - Restore/import flow: into the wallet's initial `importWallet(mnemonic,
- *    { password })` call — a fresh wallet, nothing persisted yet.
- *  - Create flow: the wallet is ALREADY persisted (plaintext) by this point,
- *    so the password is applied via the reviewed-SAFE in-place mnemonic
- *    re-encrypt (`setWalletPassword` from `useSphereContext()`) — never a
- *    second `importWallet`/`Sphere.import()` call, which would wipe the
- *    token DB. See `handleSetPassword`'s doc-comment for the full history.
+ * `handleSetPassword`) applies the chosen password the SAME way in both
+ * flows: the wallet is ALREADY persisted (plaintext) by this point, so the
+ * password is applied via the reviewed-SAFE in-place mnemonic re-encrypt
+ * (`setWalletPassword` from `useSphereContext()`) — never a second
+ * `importWallet`/`Sphere.import()` call, which would wipe the token DB.
+ * See `handleSetPassword`'s doc-comment for the full history.
  */
 import { useState, useCallback } from "react";
 import { motion } from "framer-motion";

--- a/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
+++ b/src/components/wallet/onboarding/components/SetPasswordScreen.tsx
@@ -27,25 +27,39 @@ interface SetPasswordScreenProps {
    *  this screen has no other affordance stopping a double-click / a fast
    *  Set-then-Skip from firing two overlapping persist calls). */
   isBusy?: boolean;
+  /**
+   * External failure surfaced by the caller (e.g. `setWalletPassword`
+   * rejecting) — distinct from this screen's own local validation errors
+   * (mismatch / too-short). Without this the caller had no way to report a
+   * failed persist, so the UI would silently advance the user into what
+   * they'd believe was a password-protected wallet while it stayed
+   * plaintext (#449 review fix — see `handleSetPassword`).
+   */
+  error?: string | null;
 }
 
-export function SetPasswordScreen({ onSet, onSkip, isBusy = false }: SetPasswordScreenProps) {
+export function SetPasswordScreen({ onSet, onSkip, isBusy = false, error: externalError = null }: SetPasswordScreenProps) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const handleSet = useCallback(() => {
     if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      setValidationError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
       return;
     }
     if (password !== confirmPassword) {
-      setError("Passwords don't match");
+      setValidationError("Passwords don't match");
       return;
     }
-    setError(null);
+    setValidationError(null);
     onSet(password);
   }, [password, confirmPassword, onSet]);
+
+  // Local validation takes priority (it's about what's currently typed);
+  // otherwise surface the caller's error (a failed persist against what was
+  // already submitted).
+  const error = validationError ?? externalError;
 
   return (
     <motion.div

--- a/src/components/wallet/onboarding/components/UnlockScreen.tsx
+++ b/src/components/wallet/onboarding/components/UnlockScreen.tsx
@@ -1,0 +1,92 @@
+/**
+ * UnlockScreen — cold-start unlock gate for an encrypted wallet.
+ * Rendered by WalletPanel whenever useSphereContext().isLocked is true (#449).
+ * Wrong-password attempts add an in-memory progressive delay (capped at 5s)
+ * before retrying, purely client-side rate limiting — nothing is persisted.
+ */
+import { useState, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { Lock, KeyRound } from 'lucide-react';
+import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
+import { isDecryptionError } from '../../../../sdk/walletLock/isDecryptionError';
+
+export function UnlockScreen({ onRestore }: { onRestore: () => void }) {
+  const { unlock } = useSphereContext();
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const attemptsRef = useRef(0);
+
+  const handleUnlock = async () => {
+    if (!password || busy) return;
+    setBusy(true);
+    setError(null);
+    // Progressive delay (in-memory only, resets on success/reload): 0, 0.5s, 1s, ... capped at 5s.
+    const delay = Math.min(attemptsRef.current * 500, 5000);
+    if (delay) await new Promise((r) => setTimeout(r, delay));
+    try {
+      await unlock(password);
+      attemptsRef.current = 0;
+    } catch (e) {
+      attemptsRef.current += 1;
+      setError(isDecryptionError(e) ? 'Incorrect password' : 'Could not unlock. Try again.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <motion.div
+      key="unlock"
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.1 }}
+      className="min-h-full flex flex-col items-center justify-center gap-4 p-6 text-center w-full max-w-90 mx-auto"
+    >
+      <div className="w-16 h-16 mx-auto rounded-2xl bg-linear-to-br from-orange-500 to-orange-600 dark:from-brand-orange dark:to-brand-orange-dark flex items-center justify-center">
+        <Lock className="w-8 h-8 text-white" />
+      </div>
+      <div>
+        <h2 className="text-2xl font-bold text-neutral-900 dark:text-[#fefefe] mb-2 tracking-tight" style={{ fontFamily: "'Geist', sans-serif" }}>
+          Wallet Locked
+        </h2>
+        <p className="text-neutral-500 dark:text-[rgba(255,255,255,0.45)] text-sm">
+          Enter your password to unlock your wallet.
+        </p>
+      </div>
+      <input
+        type="password"
+        aria-label="Password"
+        autoFocus
+        autoComplete="current-password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+        placeholder="Enter your password"
+        className="w-full px-4 py-2.5 rounded-xl bg-neutral-100 dark:bg-[rgba(255,255,255,0.06)] border border-neutral-200 dark:border-[rgba(255,255,255,0.1)] text-neutral-900 dark:text-white text-sm outline-none focus:border-orange-500 dark:focus:border-brand-orange"
+      />
+      {error && (
+        <p className="text-red-500 dark:text-red-400 text-xs bg-red-500/10 border border-red-500/20 p-2 rounded-lg w-full">
+          {error}
+        </p>
+      )}
+      <motion.button
+        onClick={handleUnlock}
+        disabled={busy}
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        transition={{ duration: 0.1 }}
+        className="w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-orange-500 to-orange-600 dark:from-brand-orange dark:to-brand-orange-dark text-white text-sm font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {busy ? 'Unlocking…' : 'Unlock'}
+      </motion.button>
+      <button
+        onClick={onRestore}
+        className="flex items-center justify-center gap-1.5 text-xs text-neutral-500 dark:text-[rgba(255,255,255,0.45)] hover:text-orange-500 dark:hover:text-brand-orange transition-colors"
+      >
+        <KeyRound className="w-3.5 h-3.5" />
+        Forgot password? Restore from recovery phrase
+      </button>
+    </motion.div>
+  );
+}

--- a/src/components/wallet/onboarding/components/index.ts
+++ b/src/components/wallet/onboarding/components/index.ts
@@ -12,3 +12,4 @@ export { NametagScreen, type NametagAvailability } from "./NametagScreen";
 export { ProcessingScreen } from "./ProcessingScreen";
 export { MnemonicBackupScreen } from "./MnemonicBackupScreen";
 export { PlanCapabilitiesScreen } from "./PlanCapabilitiesScreen";
+export { UnlockScreen } from "./UnlockScreen";

--- a/src/components/wallet/onboarding/components/index.ts
+++ b/src/components/wallet/onboarding/components/index.ts
@@ -10,7 +10,9 @@ export { AddressSelectionScreen, type DerivedAddressInfo } from "./AddressSelect
 export { addrKey, parseAddrKey } from "./addrKey";
 export { NametagScreen, type NametagAvailability } from "./NametagScreen";
 export { ProcessingScreen } from "./ProcessingScreen";
-export { MnemonicBackupScreen } from "./MnemonicBackupScreen";
+export { MnemonicShowScreen } from "./MnemonicShowScreen";
+export { ConfirmMnemonicScreen } from "./ConfirmMnemonicScreen";
+export { BackupDownloadScreen } from "./BackupDownloadScreen";
 export { PlanCapabilitiesScreen } from "./PlanCapabilitiesScreen";
 export { UnlockScreen } from "./UnlockScreen";
 export { SetPasswordScreen } from "./SetPasswordScreen";

--- a/src/components/wallet/onboarding/components/index.ts
+++ b/src/components/wallet/onboarding/components/index.ts
@@ -13,3 +13,4 @@ export { ProcessingScreen } from "./ProcessingScreen";
 export { MnemonicBackupScreen } from "./MnemonicBackupScreen";
 export { PlanCapabilitiesScreen } from "./PlanCapabilitiesScreen";
 export { UnlockScreen } from "./UnlockScreen";
+export { SetPasswordScreen } from "./SetPasswordScreen";

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -105,15 +105,18 @@ export interface UseOnboardingFlowReturn {
   generatedMnemonic: string | null;
 }
 
-export function useOnboardingFlow(): UseOnboardingFlowReturn {
+export function useOnboardingFlow(initialStep?: OnboardingStep): UseOnboardingFlowReturn {
   const queryClient = useQueryClient();
   const { sphere, network, createWallet, resolveNametag, importWallet, importFromFile, finalizeWallet, walletExists, initProgress } = useSphereContext();
 
   // Step management — start at "nametag" only if wallet is fully finalized but missing nametag
   // (e.g. page refresh after wallet creation without nametag).
   // During import flow, walletExists is false (deferred to finalizeWallet) so we always start at "start".
+  // `initialStep` (e.g. "restoreMethod") lets a caller drop the user straight
+  // into a specific screen — used by the UnlockScreen "forgot password" escape
+  // (#449) so it doesn't have to re-click through the start screen.
   const [step, setStep] = useState<OnboardingStep>(
-    sphere && walletExists && !sphere.identity?.nametag ? "nametag" : "start"
+    initialStep ?? (sphere && walletExists && !sphere.identity?.nametag ? "nametag" : "start")
   );
 
   // Common state

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -68,10 +68,12 @@ export interface UseOnboardingFlowReturn {
   handleMnemonicBackupComplete: () => void;
   handleDownloadBackup: (password?: string) => Promise<void>;
   /**
-   * Set/Skip handler for `SetPasswordScreen` (#449) — shared by the create
-   * flow (after the seed-backup screen) and the restore/import-from-mnemonic
-   * flow (before the wallet's one-and-only persisting call). Omit `password`
-   * to skip.
+   * Set/Skip handler for `SetPasswordScreen` (#449). Restore/import-from-
+   * mnemonic flow ONLY — the create flow does not reach this handler (see
+   * its implementation comment for why: a second `importWallet()` call on an
+   * already-persisted wallet is a wallet-loss/lockout hazard, since it
+   * unconditionally `Sphere.clear()`s existing storage before rebuilding).
+   * Omit `password` to skip.
    */
   handleSetPassword: (password?: string) => Promise<void>;
 
@@ -153,10 +155,10 @@ export function useOnboardingFlow(
   const [error, setError] = useState<string | null>(null);
 
   // Block page reload / tab close during wallet creation. "setPassword" is
-  // included here too (#449): in the create flow it sits between a just
-  // created, still-unprotected wallet and finalize; guarding it the same way
-  // as "mnemonicBackup" costs nothing on the restore path (nothing persisted
-  // yet there either).
+  // included here too (#449): it's the restore/import flow's last step
+  // before its one-and-only persisting importWallet() call; guarding it the
+  // same way as "mnemonicBackup" costs nothing on the create path (which no
+  // longer uses this step — see handleSetPassword).
   const isProcessingActive = step === "processing" || step === "mnemonicBackup" || step === "setPassword";
   useEffect(() => {
     if (!isProcessingActive) return;
@@ -185,9 +187,14 @@ export function useOnboardingFlow(
   // `setPassword` step is shown, so the chosen (or skipped) password can be
   // threaded straight into the ONE `importWallet` call that persists it —
   // nothing is on disk yet for this mnemonic, so no re-encryption is needed.
-  // null while in the create-flow's post-backup `setPassword` step (there the
-  // already-created wallet's own `generatedMnemonic` is used instead).
+  // Restore/import flow only — the create flow doesn't reach `setPassword`.
   const pendingRestoreMnemonicRef = useRef<string | null>(null);
+  // #449: re-entrancy guard for handleSetPassword. SetPasswordScreen doesn't
+  // disable its Set/Skip buttons while busy, so a double-click (or a fast
+  // Set-then-Skip) could otherwise fire two overlapping `importWallet()`
+  // calls — the second would re-run `Sphere.import()`, clearing storage the
+  // first call just persisted mid-write.
+  const isPersistingRef = useRef(false);
 
   // Nametag state
   const [nametagInput, setNametagInput] = useState("");
@@ -707,111 +714,114 @@ export function useOnboardingFlow(
   }, [doFinalizeWallet]);
 
   // Action: Confirm mnemonic backup (called after user saves recovery phrase).
-  // #449: instead of finalizing immediately, offer the optional SetPasswordScreen
-  // next — the seed is secured first, so a forgotten password still has the
-  // seed as an escape hatch. `handleSetPassword` (below) finalizes afterwards.
+  // The wallet was already created (plaintext) before this screen ran, in
+  // handleMintNametag/handleSkipNametag — finalize directly. (#449: the
+  // create flow does NOT offer an at-rest password here anymore — see
+  // handleSetPassword's comment below for why.)
   const handleMnemonicBackupComplete = useCallback(() => {
-    setStep("setPassword");
-  }, []);
+    void doFinalizeWallet();
+  }, [doFinalizeWallet]);
 
-  // Action: Set/Skip handler for SetPasswordScreen (#449). Shared by two
-  // distinct call sites, distinguished by `pendingRestoreMnemonicRef`:
-  //  - Restore/import flow (from handleRestoreWallet): nothing has been
-  //    persisted for this mnemonic yet — thread the (optional) password
-  //    straight into the ONE importWallet call that creates it.
-  //  - Create flow (from handleMnemonicBackupComplete above): the wallet
-  //    already exists (created before the backup screen, #448) WITHOUT a
-  //    password. The only safe way to protect it here is to re-create it
-  //    from its OWN already-shown, already-backed-up mnemonic — the wallet is
-  //    brand new (no funds/history yet), so nothing can be lost.
-  //    Re-encrypting an EXISTING/funded wallet in place is a separate,
-  //    riskier operation (Settings "set password", out of scope here) —
-  //    never performed by this handler.
+  // Action: Set/Skip handler for SetPasswordScreen (#449) — restore/import-
+  // from-mnemonic flow ONLY (reached from handleRestoreWallet). Nothing has
+  // been persisted for this mnemonic yet, so the chosen (or skipped)
+  // password threads straight into the ONE importWallet call that creates
+  // it; no re-encryption/re-persist step is ever needed.
+  //
+  // The create flow used to reach this same handler too, re-creating the
+  // just-shown wallet from its own mnemonic WITH the chosen password. That
+  // required a SECOND `importWallet()` call on a wallet `createWallet()` had
+  // already persisted moments earlier (#448's create-without-nametag step) —
+  // `importWallet` wraps the SDK's `Sphere.import()`, which unconditionally
+  // `Sphere.clear()`s any already-persisted wallet before rebuilding it. If
+  // that rebuild then threw (a network hiccup during identity/nametag sync,
+  // etc.), storage was left cleared while the app kept using the in-memory
+  // instance for the rest of the session — on next reload the wallet could
+  // show unexpectedly LOCKED or vanish entirely. It also raced the
+  // just-published Nostr nametag binding from createWalletThenRegister
+  // (#448), risking permanently burning it. Fixed by removing the
+  // create-flow branch entirely: the create flow now finalizes straight from
+  // the backup screen (handleMnemonicBackupComplete above) and never reaches
+  // this step. Setting a password on an already-created wallet safely needs
+  // a Settings-side "set password" (re-encrypt in place) flow, which doesn't
+  // exist yet — a future task, not this handler.
   const handleSetPassword = useCallback(async (password?: string) => {
     const restoreMnemonic = pendingRestoreMnemonicRef.current;
     pendingRestoreMnemonicRef.current = null;
 
-    if (restoreMnemonic) {
-      setIsBusy(true);
-      setError(null);
-
-      // Show processing screen during import
-      setStep("processing");
-      setProcessingTitle("Importing Wallet...");
-      setProcessingCompleteTitle("Import Complete!");
-      setProcessingStep(0);
-      setProcessingTotalSteps(3);
-      setProcessingStatus("Importing wallet...");
-      setIsProcessingComplete(false);
-
-      try {
-        // Call shape mirrors the pre-#449 direct call exactly when no
-        // password is chosen (`importWallet(mnemonic)`, single argument) —
-        // the SKIP path stays byte-for-byte identical, down to call arity.
-        const instance = password
-          ? await importWallet(restoreMnemonic, { password })
-          : await importWallet(restoreMnemonic);
-
-        // Store in ref so handleMintNametag / handleSkipNametag can access it
-        importedSphereRef.current = instance;
-
-        // Route to next screen after import completes
-        const allAddresses = instance.getAllTrackedAddresses();
-        if (allAddresses.length >= 1) {
-          const addresses: DerivedAddressInfo[] = allAddresses.map(a => ({
-            index: a.index,
-            l3Address: a.directAddress,
-            chainPubkey: a.chainPubkey,
-            path: `m/44'/60'/0'/0/${a.index}`,
-            hasNametag: !!a.nametag,
-            existingNametag: a.nametag,
-            isChange: false,
-            balanceLoading: false,
-            ipnsLoading: false,
-          }));
-          setDerivedAddresses(addresses);
-          setSelectedKeys(new Set(addresses.map(a => addrKey(a.index, false))));
-          setStep("addressSelection");
-        } else if (instance.identity?.nametag) {
-          setProcessingStep(2);
-          setProcessingStatus("Setup complete!");
-          setIsProcessingComplete(true);
-        } else {
-          setStep("nametag");
-        }
-      } catch (e) {
-        const message = e instanceof Error ? e.message : "Invalid recovery phrase";
-        setError(message);
-        setStep("restore");
-      } finally {
-        setIsBusy(false);
-      }
+    // Defensive: this step is only ever reached via handleRestoreWallet,
+    // which always sets pendingRestoreMnemonicRef right before showing it.
+    // If it's ever missing (a stray navigation), there is nothing safe to
+    // persist here — finalize with whatever wallet already exists rather
+    // than guessing at a re-import.
+    if (!restoreMnemonic) {
+      void doFinalizeWallet();
       return;
     }
 
-    // Create flow: re-create the just-shown, brand-new wallet from its own
-    // mnemonic WITH the chosen password. Skipped (no password) is a no-op —
-    // `importedSphereRef.current` stays the original plaintext instance, and
-    // finalize proceeds exactly as it did before this step existed (#449
-    // no-wallet-loss: the SKIP path is byte-for-byte identical to today).
-    if (password && generatedMnemonic && Sphere.validateMnemonic(generatedMnemonic)) {
-      setIsBusy(true);
-      setError(null);
-      try {
-        const instance = await importWallet(generatedMnemonic, { password });
-        importedSphereRef.current = instance;
-      } catch (e) {
-        // Never lose the wallet: the plaintext instance created earlier is
-        // still valid and already persisted on disk — fall back to it rather
-        // than surface an error that could strand the user mid-onboarding.
-        console.error("Failed to protect the wallet with a password; continuing without one", e);
-      } finally {
-        setIsBusy(false);
-      }
-    }
+    // Re-entrancy guard: a double-click on "Set Password", or a fast
+    // Set-then-Skip, must not fire two overlapping importWallet() calls —
+    // the second would re-run Sphere.import() and clear storage the first
+    // call just persisted mid-write.
+    if (isPersistingRef.current) return;
+    isPersistingRef.current = true;
 
-    void doFinalizeWallet();
-  }, [importWallet, generatedMnemonic, doFinalizeWallet]);
+    setIsBusy(true);
+    setError(null);
+
+    // Show processing screen during import
+    setStep("processing");
+    setProcessingTitle("Importing Wallet...");
+    setProcessingCompleteTitle("Import Complete!");
+    setProcessingStep(0);
+    setProcessingTotalSteps(3);
+    setProcessingStatus("Importing wallet...");
+    setIsProcessingComplete(false);
+
+    try {
+      // Call shape mirrors the pre-#449 direct call exactly when no
+      // password is chosen (`importWallet(mnemonic)`, single argument) —
+      // the SKIP path stays byte-for-byte identical, down to call arity.
+      const instance = password
+        ? await importWallet(restoreMnemonic, { password })
+        : await importWallet(restoreMnemonic);
+
+      // Store in ref so handleMintNametag / handleSkipNametag can access it
+      importedSphereRef.current = instance;
+
+      // Route to next screen after import completes
+      const allAddresses = instance.getAllTrackedAddresses();
+      if (allAddresses.length >= 1) {
+        const addresses: DerivedAddressInfo[] = allAddresses.map(a => ({
+          index: a.index,
+          l3Address: a.directAddress,
+          chainPubkey: a.chainPubkey,
+          path: `m/44'/60'/0'/0/${a.index}`,
+          hasNametag: !!a.nametag,
+          existingNametag: a.nametag,
+          isChange: false,
+          balanceLoading: false,
+          ipnsLoading: false,
+        }));
+        setDerivedAddresses(addresses);
+        setSelectedKeys(new Set(addresses.map(a => addrKey(a.index, false))));
+        setStep("addressSelection");
+      } else if (instance.identity?.nametag) {
+        setProcessingStep(2);
+        setProcessingStatus("Setup complete!");
+        setIsProcessingComplete(true);
+      } else {
+        setStep("nametag");
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Invalid recovery phrase";
+      setError(message);
+      setStep("restore");
+    } finally {
+      setIsBusy(false);
+      isPersistingRef.current = false;
+    }
+  }, [importWallet, doFinalizeWallet]);
 
   // Action: Continue from the plan-capabilities screen into the wallet
   const handlePlanCapabilitiesContinue = useCallback(() => {

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -30,8 +30,10 @@ export type OnboardingStep =
   | "addressSelection"
   | "nametag"
   | "processing"
-  | "mnemonicBackup"
+  | "mnemonicShow"
+  | "mnemonicConfirm"
   | "setPassword"
+  | "backupDownload"
   | "planCapabilities";
 
 export interface UseOnboardingFlowReturn {
@@ -65,13 +67,30 @@ export interface UseOnboardingFlowReturn {
   processingCompleteTitle: string;
   isProcessingComplete: boolean;
   handleCompleteOnboarding: () => Promise<void>;
-  handleMnemonicBackupComplete: () => void;
+  /**
+   * Advances from the mnemonic SHOW step to the mnemonic CONFIRM step
+   * (#449 create-flow reorder: show -> confirm -> password -> download).
+   */
+  handleMnemonicShowContinue: () => void;
+  /**
+   * Verifies the re-entered recovery phrase against `generatedMnemonic`
+   * (both sides normalized: trim / collapse whitespace / lowercase). On a
+   * match, advances to `setPassword`; on a mismatch, surfaces an inline
+   * `error` and stays on the confirm step — never advances on a wrong
+   * phrase.
+   */
+  handleConfirmMnemonic: (entered: string) => void;
+  /** Returns from the mnemonic CONFIRM step back to the SHOW step. */
+  handleMnemonicConfirmBack: () => void;
+  /** Finalizes the wallet after the backup-download step. */
+  handleBackupDownloadComplete: () => void;
   handleDownloadBackup: () => Promise<void>;
   /**
    * True once a wallet password was set in this create flow's `setPassword`
-   * step (which now runs BEFORE the backup screen). The SAME password is
-   * what `handleDownloadBackup` threads into the exported backup file, so
-   * this also tells `MnemonicBackupScreen` which label/copy to show.
+   * step (which now runs BEFORE the backup-download screen). The SAME
+   * password is what `handleDownloadBackup` threads into the exported backup
+   * file, so this also tells `BackupDownloadScreen` which label/copy to
+   * show.
    */
   backupEncrypted: boolean;
   /**
@@ -81,10 +100,11 @@ export interface UseOnboardingFlowReturn {
    *    mnemonic, so the chosen (or skipped) password threads straight into
    *    the ONE `importWallet` call that creates it.
    *  - Create: the wallet is ALREADY persisted (plaintext) by the time this
-   *    screen shows, so a chosen password is applied via the reviewed-SAFE
-   *    in-place re-encrypt (`setWalletPassword` from `useSphereContext()`) —
-   *    never a second `importWallet()`/`Sphere.import()` call, which would be
-   *    a wallet-loss/lockout hazard (it unconditionally `Sphere.clear()`s
+   *    screen shows (reached via show -> confirm -> here), so a chosen
+   *    password is applied via the reviewed-SAFE in-place re-encrypt
+   *    (`setWalletPassword` from `useSphereContext()`) — never a second
+   *    `importWallet()`/`Sphere.import()` call, which would be a
+   *    wallet-loss/lockout hazard (it unconditionally `Sphere.clear()`s
    *    existing storage before rebuilding). See the implementation comment
    *    for full detail.
    * Omit `password` to skip.
@@ -174,7 +194,17 @@ export function useOnboardingFlow(
   // restore/import flow's last step before its one-and-only persisting
   // importWallet() call, and (since #449 follow-up) the create flow's
   // optional in-place re-encrypt (setWalletPassword) before finalizing.
-  const isProcessingActive = step === "processing" || step === "mnemonicBackup" || step === "setPassword";
+  // "mnemonicShow"/"mnemonicConfirm"/"backupDownload" (#449 create-flow
+  // reorder) are also covered: the create flow's wallet is already
+  // persisted (plaintext) by the time these show, so a reload mid-flow
+  // would silently drop the user back to onboarding while a real wallet
+  // sits on disk — same hazard the original guard was written for.
+  const isProcessingActive =
+    step === "processing" ||
+    step === "mnemonicShow" ||
+    step === "mnemonicConfirm" ||
+    step === "setPassword" ||
+    step === "backupDownload";
   useEffect(() => {
     if (!isProcessingActive) return;
     const handler = (e: BeforeUnloadEvent) => {
@@ -723,14 +753,16 @@ export function useOnboardingFlow(
   }, [sphere, network, finishFinalize]);
 
   // Auto-transition when processing completes. Create flow ordering (#449
-  // UX refinement): setPassword now runs BEFORE mnemonicBackup, so the one
-  // password chosen there can also encrypt the backup file shown right
-  // after it (see handleSetPassword / handleDownloadBackup).
+  // reorder): show -> confirm -> setPassword -> backupDownload -> finalize.
+  // The mnemonic must be SHOWN and re-entry VERIFIED before the optional
+  // password step, so the one password chosen there can still encrypt the
+  // backup-download file shown right after it (see handleSetPassword /
+  // handleDownloadBackup).
   useEffect(() => {
     if (isProcessingComplete && step === "processing") {
       const timer = setTimeout(() => {
         if (isCreateFlowRef.current && generatedMnemonic) {
-          setStep("setPassword");
+          setStep("mnemonicShow");
         } else {
           void doFinalizeWallet();
         }
@@ -744,13 +776,41 @@ export function useOnboardingFlow(
     void doFinalizeWallet();
   }, [doFinalizeWallet]);
 
-  // Action: Confirm mnemonic backup (called after user saves recovery phrase
-  // and optionally downloads the backup file). #449 UX refinement: this is
-  // now the LAST create-flow step — setPassword already ran right after
-  // processing, BEFORE this screen (ordering: processing → setPassword →
-  // mnemonicBackup → planCapabilities → wallet) — so confirming here just
-  // finalizes.
-  const handleMnemonicBackupComplete = useCallback(() => {
+  // Action: advance from the mnemonic SHOW step to the mnemonic CONFIRM step
+  // (#449 create-flow reorder: processing → mnemonicShow → mnemonicConfirm →
+  // setPassword → backupDownload → planCapabilities → wallet).
+  const handleMnemonicShowContinue = useCallback(() => {
+    setError(null);
+    setStep("mnemonicConfirm");
+  }, []);
+
+  // Action: verify the re-entered recovery phrase (#449 real backup
+  // verification). Both sides are normalized — trimmed, internal whitespace
+  // collapsed to single spaces, lowercased — before comparison, so stray
+  // spacing/casing from the textarea doesn't cause a false mismatch. Only an
+  // EXACT match (post-normalization) advances to the optional password step;
+  // a mismatch surfaces an inline error and does NOT advance, so a user who
+  // mistyped (or never actually wrote the phrase down) can't proceed
+  // believing they have a working backup.
+  const handleConfirmMnemonic = useCallback((entered: string) => {
+    const normalize = (s: string) => s.trim().toLowerCase().replace(/\s+/g, " ");
+    if (!generatedMnemonic || normalize(entered) !== normalize(generatedMnemonic)) {
+      setError("Recovery phrase doesn't match. Please check the words and try again.");
+      return;
+    }
+    setError(null);
+    setStep("setPassword");
+  }, [generatedMnemonic]);
+
+  // Action: back out of the CONFIRM step to re-view the phrase on SHOW.
+  const handleMnemonicConfirmBack = useCallback(() => {
+    setError(null);
+    setStep("mnemonicShow");
+  }, []);
+
+  // Action: finalize after the backup-download step (the LAST create-flow
+  // step — setPassword already ran right before it).
+  const handleBackupDownloadComplete = useCallback(() => {
     void doFinalizeWallet();
   }, [doFinalizeWallet]);
 
@@ -764,9 +824,10 @@ export function useOnboardingFlow(
   //     creates it; no re-encryption/re-persist step is ever needed.
   //
   //  2. Create flow (handleSkipNametag/handleMintNametag's processing
-  //     auto-transition above; no pending restore mnemonic). #449 UX
-  //     refinement: this now runs BEFORE the backup screen (ordering:
-  //     processing → setPassword → mnemonicBackup → planCapabilities →
+  //     auto-transition above; no pending restore mnemonic). #449 reorder:
+  //     this now runs AFTER the mnemonic show/confirm screens and BEFORE the
+  //     backup-download screen (ordering: processing → mnemonicShow →
+  //     mnemonicConfirm → setPassword → backupDownload → planCapabilities →
   //     wallet). The wallet was ALREADY persisted (plaintext) moments
   //     earlier by createWallet()/createWalletThenRegister() (#448's
   //     create-without-nametag step) — by the time this screen shows, there
@@ -821,7 +882,7 @@ export function useOnboardingFlow(
           } catch (e) {
             // Self-restoring on failure (see doc-comment above) — the
             // wallet is never at risk. Surface the failure and stay on this
-            // screen (do NOT advance to mnemonicBackup) so the user can
+            // screen (do NOT advance to backupDownload) so the user can
             // retry or explicitly Skip.
             const message = e instanceof Error ? e.message : "Failed to set a wallet password";
             setError(message);
@@ -834,7 +895,7 @@ export function useOnboardingFlow(
         } else {
           createBackupPasswordRef.current = null;
         }
-        setStep("mnemonicBackup");
+        setStep("backupDownload");
       } finally {
         isPersistingRef.current = false;
         setIsBusy(false);
@@ -1093,7 +1154,10 @@ export function useOnboardingFlow(
     processingCompleteTitle,
     isProcessingComplete,
     handleCompleteOnboarding,
-    handleMnemonicBackupComplete,
+    handleMnemonicShowContinue,
+    handleConfirmMnemonic,
+    handleMnemonicConfirmBack,
+    handleBackupDownloadComplete,
     handleDownloadBackup,
     backupEncrypted: createBackupPasswordRef.current !== null,
     handleSetPassword,

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -94,20 +94,19 @@ export interface UseOnboardingFlowReturn {
    */
   backupEncrypted: boolean;
   /**
-   * Set/Skip handler for `SetPasswordScreen` (#449 / #449 follow-up). Reached
-   * from BOTH flows now:
-   *  - Restore/import-from-mnemonic: nothing is persisted yet for this
-   *    mnemonic, so the chosen (or skipped) password threads straight into
-   *    the ONE `importWallet` call that creates it.
+   * Set/Skip handler for `SetPasswordScreen` (#449 / #449 follow-up / #449
+   * Task C). Reached from THREE flows, all handled identically now:
    *  - Create: the wallet is ALREADY persisted (plaintext) by the time this
-   *    screen shows (reached via show -> confirm -> here), so a chosen
-   *    password is applied via the reviewed-SAFE in-place re-encrypt
-   *    (`setWalletPassword` from `useSphereContext()`) — never a second
-   *    `importWallet()`/`Sphere.import()` call, which would be a
-   *    wallet-loss/lockout hazard (it unconditionally `Sphere.clear()`s
-   *    existing storage before rebuilding). See the implementation comment
-   *    for full detail.
-   * Omit `password` to skip.
+   *    screen shows (reached via show -> confirm -> here).
+   *  - Restore-from-mnemonic / plain file import: the wallet is ALREADY
+   *    persisted (plaintext) by `importWallet`/`importFromFile` before this
+   *    screen shows (reached after address selection + nametag).
+   * In every case a chosen password is applied via the reviewed-SAFE
+   * in-place re-encrypt (`setWalletPassword` from `useSphereContext()`) —
+   * NEVER a second `importWallet()`/`Sphere.import()` call, which would be a
+   * wallet-loss/lockout hazard (it unconditionally `Sphere.clear()`s
+   * existing storage before rebuilding). See the implementation comment
+   * for full detail. Omit `password` to skip.
    */
   handleSetPassword: (password?: string) => Promise<void>;
 
@@ -189,16 +188,14 @@ export function useOnboardingFlow(
   const [error, setError] = useState<string | null>(null);
 
   // Block page reload / tab close during wallet creation. "setPassword" is
-  // included here too (#449 / #449 follow-up): it's a step where a
-  // persisting/re-encrypting call is either about to run or in flight — the
-  // restore/import flow's last step before its one-and-only persisting
-  // importWallet() call, and (since #449 follow-up) the create flow's
-  // optional in-place re-encrypt (setWalletPassword) before finalizing.
-  // "mnemonicShow"/"mnemonicConfirm"/"backupDownload" (#449 create-flow
-  // reorder) are also covered: the create flow's wallet is already
-  // persisted (plaintext) by the time these show, so a reload mid-flow
-  // would silently drop the user back to onboarding while a real wallet
-  // sits on disk — same hazard the original guard was written for.
+  // included here too (#449 / #449 follow-up / #449 Task C): by the time any
+  // flow reaches it (create, restore-from-mnemonic, or file import), the
+  // wallet is ALREADY persisted (plaintext) on disk, and this step's
+  // in-place re-encrypt (setWalletPassword) may be about to run or in
+  // flight. "mnemonicShow"/"mnemonicConfirm"/"backupDownload" (#449
+  // create-flow reorder, create flow only) are also covered: a reload
+  // mid-flow would silently drop the user back to onboarding while a real
+  // wallet sits on disk — same hazard the original guard was written for.
   const isProcessingActive =
     step === "processing" ||
     step === "mnemonicShow" ||
@@ -228,15 +225,14 @@ export function useOnboardingFlow(
   const importedSphereRef = useRef<Sphere | null>(null);
   // True when the current flow created a brand-new wallet (vs import/restore).
   const isCreateFlowRef = useRef(false);
-  // #449: holds a validated-but-not-yet-imported restore mnemonic while
-  // `setPassword` step is shown, so the chosen (or skipped) password can be
-  // threaded straight into the ONE `importWallet` call that persists it —
-  // nothing is on disk yet for this mnemonic, so no re-encryption is needed.
-  // Restore/import flow only. Left `null` for the create flow (#449
-  // follow-up: the create flow reaches `setPassword` too now, but via
-  // `doFinalizeWallet`/`setWalletPassword` in-place re-encrypt, never this
-  // ref/`importWallet` path — see handleSetPassword).
-  const pendingRestoreMnemonicRef = useRef<string | null>(null);
+  // #449 Task C: true once an encrypted file's decrypt password has already
+  // been auto-applied as the wallet's at-rest password (handlePasswordSubmit)
+  // — set on a successful `setWalletPassword` there. The "processing
+  // complete" auto-transition below checks this to skip the optional
+  // `setPassword` screen for a wallet that's already protected. Import/file
+  // flow only; always `false` for the create flow and for restore-from-
+  // mnemonic (which always shows the optional screen). Reset in `goToStart`.
+  const passwordAutoAppliedRef = useRef(false);
   // Create flow only (#449 UX refinement): remembers the password chosen on
   // `setPassword` — which now runs BEFORE the backup screen — purely in
   // memory (never persisted as its own secret) so `handleDownloadBackup`,
@@ -248,9 +244,9 @@ export function useOnboardingFlow(
   const createBackupPasswordRef = useRef<string | null>(null);
   // #449: re-entrancy guard for handleSetPassword. SetPasswordScreen doesn't
   // disable its Set/Skip buttons while busy, so a double-click (or a fast
-  // Set-then-Skip) could otherwise fire two overlapping `importWallet()`
-  // calls — the second would re-run `Sphere.import()`, clearing storage the
-  // first call just persisted mid-write.
+  // Set-then-Skip) could otherwise fire two overlapping `setWalletPassword()`
+  // calls against the same in-flight re-encrypt (read → encrypt → write) of
+  // the mnemonic storage key.
   const isPersistingRef = useRef(false);
 
   // Nametag state
@@ -345,6 +341,7 @@ export function useOnboardingFlow(
     importedSphereRef.current = null;
     isCreateFlowRef.current = false;
     createBackupPasswordRef.current = null;
+    passwordAutoAppliedRef.current = false;
     setError(null);
     // #449 no-wallet-loss: entered via the lock-escape → never show the
     // generic StartScreen (its "Create New Wallet" would run against storage
@@ -520,8 +517,38 @@ export function useOnboardingFlow(
         setGeneratedMnemonic(result.mnemonic);
       }
 
-
       if (result.sphere) {
+        // #449 Task C: this file needed `password` to DECRYPT it — apply that
+        // SAME password as the wallet's new at-rest password automatically.
+        // The wallet was just persisted PLAINTEXT regardless of the file's
+        // own encryption: `importFromFile`/`Sphere.importFromLegacyFile` only
+        // ever uses `password` to decrypt the legacy file's contents — it is
+        // never threaded into the new on-disk mnemonic (verified against the
+        // SDK: `baseOptions` passed to the internal `Sphere.import()` call
+        // strips `password` out in every legacy-format branch). Applied via
+        // the SAME reviewed-SAFE in-place re-encrypt as everywhere else
+        // (`setWalletPassword`) — never a second `importWallet`/`Sphere.
+        // import()` call.
+        //
+        // Only meaningful when the import actually recovered a MNEMONIC — a
+        // master-key-only legacy import (.dat/.txt/legacy-JSON with no seed
+        // phrase) has none, and `setWalletPassword`/`reencryptStoredMnemonic`
+        // throws "No wallet mnemonic found" for that case. Caught and skipped
+        // gracefully here (no scary error for an automatic step the user
+        // never asked for) — the wallet simply stays plaintext. If there IS
+        // a mnemonic, this succeeds and the optional `setPassword` screen
+        // shown later (see the "processing complete" auto-transition below)
+        // is skipped entirely — the wallet is already protected.
+        try {
+          await setWalletPassword(password);
+          passwordAutoAppliedRef.current = true;
+        } catch {
+          // No mnemonic to protect (or some other re-encrypt hiccup) — leave
+          // the wallet plaintext and fall through to the normal, optional
+          // setPassword screen. If there really is no mnemonic, a manual
+          // attempt there will (correctly) fail too, but as an ordinary
+          // user-initiated error rather than a silent automatic one.
+        }
         routeAfterImport(result.sphere);
       } else {
         setStep("nametag");
@@ -532,7 +559,7 @@ export function useOnboardingFlow(
     } finally {
       setIsBusy(false);
     }
-  }, [fileContent, selectedFile, importFromFile, routeAfterImport]);
+  }, [fileContent, selectedFile, importFromFile, routeAfterImport, setWalletPassword]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -584,16 +611,35 @@ export function useOnboardingFlow(
     }
 
     setError(null);
+    setIsBusy(true);
 
-    // #449: offer the SAME optional at-rest password as the create flow —
-    // BEFORE the one-and-only `importWallet` call for this mnemonic, so
-    // nothing has been persisted yet and the (optional) password can be
-    // threaded straight into that single call. No re-encryption/re-persist
-    // step is ever needed. `handleSetPassword` performs the actual import
-    // once the user sets or skips a password on `SetPasswordScreen`.
-    pendingRestoreMnemonicRef.current = mnemonic;
-    setStep("setPassword");
-  }, [seedWords]);
+    // #449 Task C: import PLAINTEXT immediately — no password threaded into
+    // this call anymore. The optional at-rest password is now offered near
+    // the END of the flow (after address selection + nametag, same place the
+    // create flow offers it), applied via the in-place `setWalletPassword`
+    // re-encrypt — never a second `importWallet()`/`Sphere.import()` call.
+    // This unifies the restore flow with the create flow and the plain
+    // file-import flow: all three route through `routeAfterImport` and the
+    // shared "processing complete" auto-transition below.
+    setStep("processing");
+    setProcessingTitle("Importing Wallet...");
+    setProcessingCompleteTitle("Import Complete!");
+    setProcessingStep(0);
+    setProcessingTotalSteps(3);
+    setProcessingStatus("Importing wallet...");
+    setIsProcessingComplete(false);
+
+    try {
+      const instance = await importWallet(mnemonic);
+      routeAfterImport(instance);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Invalid recovery phrase";
+      setError(message);
+      setStep("restore");
+    } finally {
+      setIsBusy(false);
+    }
+  }, [seedWords, importWallet, routeAfterImport]);
 
   // Action: Create wallet WITH nametag (or register nametag on imported wallet)
   const handleMintNametag = useCallback(async () => {
@@ -752,17 +798,24 @@ export function useOnboardingFlow(
     finishFinalize();
   }, [sphere, network, finishFinalize]);
 
-  // Auto-transition when processing completes. Create flow ordering (#449
-  // reorder): show -> confirm -> setPassword -> backupDownload -> finalize.
-  // The mnemonic must be SHOWN and re-entry VERIFIED before the optional
-  // password step, so the one password chosen there can still encrypt the
-  // backup-download file shown right after it (see handleSetPassword /
-  // handleDownloadBackup).
+  // Auto-transition when processing completes.
+  //  - Create flow ordering (#449 reorder): show -> confirm -> setPassword ->
+  //    backupDownload -> finalize. The mnemonic must be SHOWN and re-entry
+  //    VERIFIED before the optional password step, so the one password
+  //    chosen there can still encrypt the backup-download file shown right
+  //    after it (see handleSetPassword / handleDownloadBackup).
+  //  - Restore/import flow (#449 Task C): no mnemonic show/confirm/backup
+  //    screens — straight to the SAME optional `setPassword` screen the
+  //    create flow uses, UNLESS an encrypted file's password was already
+  //    auto-applied (handlePasswordSubmit), in which case the wallet is
+  //    already protected and there's nothing to ask.
   useEffect(() => {
     if (isProcessingComplete && step === "processing") {
       const timer = setTimeout(() => {
         if (isCreateFlowRef.current && generatedMnemonic) {
           setStep("mnemonicShow");
+        } else if (!isCreateFlowRef.current && !passwordAutoAppliedRef.current) {
+          setStep("setPassword");
         } else {
           void doFinalizeWallet();
         }
@@ -814,159 +867,95 @@ export function useOnboardingFlow(
     void doFinalizeWallet();
   }, [doFinalizeWallet]);
 
-  // Action: Set/Skip handler for SetPasswordScreen (#449 / #449 follow-up).
-  // Reached from TWO places, each handled by its own branch below:
+  // Action: Set/Skip handler for SetPasswordScreen (#449 / #449 follow-up /
+  // #449 Task C). Reached from THREE places, all handled the SAME way now:
   //
-  //  1. Restore/import-from-mnemonic (handleRestoreWallet sets
-  //     pendingRestoreMnemonicRef right before showing this step). Nothing
-  //     has been persisted for this mnemonic yet, so the chosen (or skipped)
-  //     password threads straight into the ONE importWallet call that
-  //     creates it; no re-encryption/re-persist step is ever needed.
+  //  1. Create flow (handleSkipNametag/handleMintNametag's processing
+  //     auto-transition above, via mnemonicShow -> mnemonicConfirm -> here).
+  //     Ordering: processing → mnemonicShow → mnemonicConfirm → setPassword
+  //     → backupDownload → planCapabilities → wallet. The wallet was ALREADY
+  //     persisted (plaintext) moments earlier by createWallet()/
+  //     createWalletThenRegister() (#448's create-without-nametag step).
   //
-  //  2. Create flow (handleSkipNametag/handleMintNametag's processing
-  //     auto-transition above; no pending restore mnemonic). #449 reorder:
-  //     this now runs AFTER the mnemonic show/confirm screens and BEFORE the
-  //     backup-download screen (ordering: processing → mnemonicShow →
-  //     mnemonicConfirm → setPassword → backupDownload → planCapabilities →
-  //     wallet). The wallet was ALREADY persisted (plaintext) moments
-  //     earlier by createWallet()/createWalletThenRegister() (#448's
-  //     create-without-nametag step) — by the time this screen shows, there
-  //     is a real wallet on disk with a token DB etc. A SECOND
-  //     `importWallet()` call here (re-creating that same wallet from its
-  //     own mnemonic WITH the chosen password) was the #449 CRITICAL
-  //     wallet-loss bug: `importWallet` wraps the SDK's `Sphere.import()`,
-  //     which unconditionally `Sphere.clear()`s any already-persisted wallet
-  //     before rebuilding it. If that rebuild then threw (a network hiccup
-  //     during identity/nametag sync, etc.), storage was left cleared while
-  //     the app kept using the in-memory instance for the rest of the
-  //     session — on next reload the wallet could show unexpectedly LOCKED
-  //     or vanish entirely. It also raced the just-published Nostr nametag
-  //     binding from createWalletThenRegister (#448), risking permanently
-  //     burning it.
+  //  2. Restore-from-mnemonic (handleRestoreWallet) and plain file import
+  //     (handleFileImport/handlePasswordSubmit), reached via the "processing
+  //     complete" auto-transition after address selection + nametag. The
+  //     wallet was ALREADY persisted (plaintext) by importWallet()/
+  //     importFromFile() before this screen ever shows.
   //
-  //     Instead, the create-flow branch applies a chosen password via
-  //     `setWalletPassword` (from `useSphereContext()`) — the same
-  //     reviewed-SAFE in-place mnemonic re-encrypt built for Settings →
-  //     Security: read mnemonic → encrypt → write back to the MNEMONIC key
-  //     ONLY, with read-back verify and restore-on-failure. `Sphere.import`/
-  //     `Sphere.clear` are never called; the token DB and everything else
-  //     already on disk are untouched. On success the password is also
-  //     remembered in `createBackupPasswordRef` (memory-only) so the backup
-  //     screen right after this one can encrypt the exported file with the
-  //     SAME password — see handleDownloadBackup. On failure,
-  //     `setWalletPassword` is itself self-restoring (leaves the existing
-  //     plaintext mnemonic intact), so the wallet is never at risk — but
-  //     unlike Skip, a rejection here does NOT advance: it surfaces the
-  //     error on this screen and lets the user retry or explicitly Skip,
-  //     rather than silently landing them in a wallet they believe is
-  //     password-protected while it's still plaintext (#449 review fix).
+  // In every case there is a real wallet on disk (with a token DB, etc.) by
+  // the time this runs. A SECOND `importWallet()`/`Sphere.import()` call
+  // here (re-creating that same wallet from its own mnemonic WITH the chosen
+  // password) was the #449 CRITICAL wallet-loss bug: `Sphere.import()`
+  // unconditionally `Sphere.clear()`s any already-persisted wallet before
+  // rebuilding it. If that rebuild then threw (a network hiccup during
+  // identity/nametag sync, etc.), storage was left cleared while the app
+  // kept using the in-memory instance for the rest of the session — on next
+  // reload the wallet could show unexpectedly LOCKED or vanish entirely. It
+  // could also race a just-published Nostr nametag binding, risking
+  // permanently burning it.
+  //
+  // Instead, a chosen password is ALWAYS applied via `setWalletPassword`
+  // (from `useSphereContext()`) — the same reviewed-SAFE in-place mnemonic
+  // re-encrypt built for Settings → Security: read mnemonic → encrypt →
+  // write back to the MNEMONIC key ONLY, with read-back verify and
+  // restore-on-failure. `Sphere.import`/`Sphere.clear` are never called; the
+  // token DB and everything else already on disk are untouched. On success
+  // the password is also remembered in `createBackupPasswordRef`
+  // (memory-only) so the create flow's backup screen right after this one
+  // can encrypt the exported file with the SAME password — see
+  // handleDownloadBackup (a no-op for the restore/import flows, which have
+  // no backup-download screen). On failure, `setWalletPassword` is itself
+  // self-restoring (leaves the existing plaintext mnemonic intact), so the
+  // wallet is never at risk — but unlike Skip, a rejection here does NOT
+  // advance: it surfaces the error on this screen and lets the user retry or
+  // explicitly Skip, rather than silently landing them in a wallet they
+  // believe is password-protected while it's still plaintext (#449 review
+  // fix).
+  //
+  // After applying (or skipping) the password: the create flow advances to
+  // the backup-download screen; the restore/import flows have no such
+  // screen and finalize directly.
   const handleSetPassword = useCallback(async (password?: string) => {
-    const restoreMnemonic = pendingRestoreMnemonicRef.current;
-    pendingRestoreMnemonicRef.current = null;
-
-    // Create flow: no pending restore mnemonic — see branch 2 in the
-    // doc-comment above.
-    if (!restoreMnemonic) {
-      // Re-entrancy guard: a double-click on "Set Password", or a fast
-      // Set-then-Skip, must not fire two overlapping setWalletPassword()
-      // calls (reencryptStoredMnemonic's read → encrypt → write cycle is not
-      // safe to run concurrently against the same storage key).
-      if (isPersistingRef.current) return;
-      isPersistingRef.current = true;
-      setIsBusy(true);
-      setError(null);
-      try {
-        if (password) {
-          try {
-            await setWalletPassword(password);
-          } catch (e) {
-            // Self-restoring on failure (see doc-comment above) — the
-            // wallet is never at risk. Surface the failure and stay on this
-            // screen (do NOT advance to backupDownload) so the user can
-            // retry or explicitly Skip.
-            const message = e instanceof Error ? e.message : "Failed to set a wallet password";
-            setError(message);
-            return;
-          }
-          // Remembered ONLY in memory — never persisted as its own secret —
-          // so handleDownloadBackup can encrypt the backup file with this
-          // SAME password.
-          createBackupPasswordRef.current = password;
-        } else {
-          createBackupPasswordRef.current = null;
-        }
-        setStep("backupDownload");
-      } finally {
-        isPersistingRef.current = false;
-        setIsBusy(false);
-      }
-      return;
-    }
-
-    // Restore/import-from-mnemonic flow — see branch 1 in the doc-comment
-    // above. Re-entrancy guard: a double-click on "Set Password", or a fast
-    // Set-then-Skip, must not fire two overlapping importWallet() calls —
-    // the second would re-run Sphere.import() and clear storage the first
-    // call just persisted mid-write.
+    // Re-entrancy guard: a double-click on "Set Password", or a fast
+    // Set-then-Skip, must not fire two overlapping setWalletPassword()
+    // calls (reencryptStoredMnemonic's read → encrypt → write cycle is not
+    // safe to run concurrently against the same storage key).
     if (isPersistingRef.current) return;
     isPersistingRef.current = true;
-
     setIsBusy(true);
     setError(null);
-
-    // Show processing screen during import
-    setStep("processing");
-    setProcessingTitle("Importing Wallet...");
-    setProcessingCompleteTitle("Import Complete!");
-    setProcessingStep(0);
-    setProcessingTotalSteps(3);
-    setProcessingStatus("Importing wallet...");
-    setIsProcessingComplete(false);
-
     try {
-      // Call shape mirrors the pre-#449 direct call exactly when no
-      // password is chosen (`importWallet(mnemonic)`, single argument) —
-      // the SKIP path stays byte-for-byte identical, down to call arity.
-      const instance = password
-        ? await importWallet(restoreMnemonic, { password })
-        : await importWallet(restoreMnemonic);
-
-      // Store in ref so handleMintNametag / handleSkipNametag can access it
-      importedSphereRef.current = instance;
-
-      // Route to next screen after import completes
-      const allAddresses = instance.getAllTrackedAddresses();
-      if (allAddresses.length >= 1) {
-        const addresses: DerivedAddressInfo[] = allAddresses.map(a => ({
-          index: a.index,
-          l3Address: a.directAddress,
-          chainPubkey: a.chainPubkey,
-          path: `m/44'/60'/0'/0/${a.index}`,
-          hasNametag: !!a.nametag,
-          existingNametag: a.nametag,
-          isChange: false,
-          balanceLoading: false,
-          ipnsLoading: false,
-        }));
-        setDerivedAddresses(addresses);
-        setSelectedKeys(new Set(addresses.map(a => addrKey(a.index, false))));
-        setStep("addressSelection");
-      } else if (instance.identity?.nametag) {
-        setProcessingStep(2);
-        setProcessingStatus("Setup complete!");
-        setIsProcessingComplete(true);
+      if (password) {
+        try {
+          await setWalletPassword(password);
+        } catch (e) {
+          // Self-restoring on failure (see doc-comment above) — the
+          // wallet is never at risk. Surface the failure and stay on this
+          // screen (do NOT advance) so the user can retry or explicitly
+          // Skip.
+          const message = e instanceof Error ? e.message : "Failed to set a wallet password";
+          setError(message);
+          return;
+        }
+        // Remembered ONLY in memory — never persisted as its own secret —
+        // so handleDownloadBackup (create flow only) can encrypt the backup
+        // file with this SAME password.
+        createBackupPasswordRef.current = password;
       } else {
-        setStep("nametag");
+        createBackupPasswordRef.current = null;
       }
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Invalid recovery phrase";
-      setError(message);
-      setStep("restore");
+      if (isCreateFlowRef.current) {
+        setStep("backupDownload");
+      } else {
+        // Restore/import flow: no backup-download screen — finalize directly.
+        void doFinalizeWallet();
+      }
     } finally {
-      setIsBusy(false);
       isPersistingRef.current = false;
+      setIsBusy(false);
     }
-  }, [importWallet, setWalletPassword]);
+  }, [setWalletPassword, doFinalizeWallet]);
 
   // Action: Continue from the plan-capabilities screen into the wallet
   const handlePlanCapabilitiesContinue = useCallback(() => {

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -105,7 +105,28 @@ export interface UseOnboardingFlowReturn {
   generatedMnemonic: string | null;
 }
 
-export function useOnboardingFlow(initialStep?: OnboardingStep): UseOnboardingFlowReturn {
+export interface UseOnboardingFlowOptions {
+  /**
+   * True when this flow was entered via the UnlockScreen's "forgot password
+   * → restore from recovery phrase" lock-escape (#449): a REAL, still-
+   * recoverable (locked) wallet sits on disk. In this mode `goToStart()`
+   * must never land on the generic StartScreen — its "Create New Wallet"
+   * button would call `createWallet()` against storage that still holds the
+   * locked wallet, which SDK-level `Sphere.init`/`Sphere.load` cannot open
+   * without the password, tripping the create-wallet failure cleanup and
+   * wiping it. `onExitToUnlock` is called instead wherever `goToStart()`
+   * would otherwise fire.
+   */
+  fromLock?: boolean;
+  /** Called instead of showing the "start" step when `fromLock` is true. */
+  onExitToUnlock?: () => void;
+}
+
+export function useOnboardingFlow(
+  initialStep?: OnboardingStep,
+  options?: UseOnboardingFlowOptions,
+): UseOnboardingFlowReturn {
+  const { fromLock, onExitToUnlock } = options ?? {};
   const queryClient = useQueryClient();
   const { sphere, network, createWallet, resolveNametag, importWallet, importFromFile, finalizeWallet, walletExists, initProgress } = useSphereContext();
 
@@ -232,7 +253,6 @@ export function useOnboardingFlow(initialStep?: OnboardingStep): UseOnboardingFl
 
   // Go back to start screen
   const goToStart = useCallback(() => {
-    setStep("start");
     setSeedWords(Array(12).fill(""));
     setSelectedFile(null);
     setFileContent(null);
@@ -242,7 +262,17 @@ export function useOnboardingFlow(initialStep?: OnboardingStep): UseOnboardingFl
     importedSphereRef.current = null;
     isCreateFlowRef.current = false;
     setError(null);
-  }, []);
+    // #449 no-wallet-loss: entered via the lock-escape → never show the
+    // generic StartScreen (its "Create New Wallet" would run against storage
+    // that still holds the locked, recoverable wallet). Exit back up to the
+    // UnlockScreen instead; the caller (WalletPanel) resets its
+    // "restoreFromLock" flag so the lock gate renders UnlockScreen again.
+    if (fromLock) {
+      onExitToUnlock?.();
+      return;
+    }
+    setStep("start");
+  }, [fromLock, onExitToUnlock]);
 
   // ---- File import handlers ----
 
@@ -455,6 +485,20 @@ export function useOnboardingFlow(initialStep?: OnboardingStep): UseOnboardingFl
       return;
     }
 
+    const mnemonic = words.join(" ");
+
+    // #449 no-wallet-loss: validate the mnemonic BEFORE calling importWallet.
+    // Sphere.import() clears any existing wallet from storage BEFORE it
+    // validates the mnemonic internally — so a wrong/typo'd recovery phrase
+    // would otherwise wipe whatever wallet (locked or plaintext) is
+    // currently on disk before ever discovering it can't even use the
+    // phrase it just destroyed the wallet for. Checking here means an
+    // invalid phrase never reaches importWallet: nothing touches storage.
+    if (!Sphere.validateMnemonic(mnemonic)) {
+      setError("Invalid recovery phrase. Please check the words and try again.");
+      return;
+    }
+
     setIsBusy(true);
     setError(null);
 
@@ -468,7 +512,6 @@ export function useOnboardingFlow(initialStep?: OnboardingStep): UseOnboardingFl
     setIsProcessingComplete(false);
 
     try {
-      const mnemonic = words.join(" ");
       const instance = await importWallet(mnemonic);
 
       // Store in ref so handleMintNametag / handleSkipNametag can access it

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -31,6 +31,7 @@ export type OnboardingStep =
   | "nametag"
   | "processing"
   | "mnemonicBackup"
+  | "setPassword"
   | "planCapabilities";
 
 export interface UseOnboardingFlowReturn {
@@ -66,6 +67,13 @@ export interface UseOnboardingFlowReturn {
   handleCompleteOnboarding: () => Promise<void>;
   handleMnemonicBackupComplete: () => void;
   handleDownloadBackup: (password?: string) => Promise<void>;
+  /**
+   * Set/Skip handler for `SetPasswordScreen` (#449) — shared by the create
+   * flow (after the seed-backup screen) and the restore/import-from-mnemonic
+   * flow (before the wallet's one-and-only persisting call). Omit `password`
+   * to skip.
+   */
+  handleSetPassword: (password?: string) => Promise<void>;
 
   // Subscription plan-capabilities state (post-finalize provisioning)
   planName: string | null;
@@ -144,8 +152,12 @@ export function useOnboardingFlow(
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Block page reload / tab close during wallet creation
-  const isProcessingActive = step === "processing" || step === "mnemonicBackup";
+  // Block page reload / tab close during wallet creation. "setPassword" is
+  // included here too (#449): in the create flow it sits between a just
+  // created, still-unprotected wallet and finalize; guarding it the same way
+  // as "mnemonicBackup" costs nothing on the restore path (nothing persisted
+  // yet there either).
+  const isProcessingActive = step === "processing" || step === "mnemonicBackup" || step === "setPassword";
   useEffect(() => {
     if (!isProcessingActive) return;
     const handler = (e: BeforeUnloadEvent) => {
@@ -169,6 +181,13 @@ export function useOnboardingFlow(
   const importedSphereRef = useRef<Sphere | null>(null);
   // True when the current flow created a brand-new wallet (vs import/restore).
   const isCreateFlowRef = useRef(false);
+  // #449: holds a validated-but-not-yet-imported restore mnemonic while
+  // `setPassword` step is shown, so the chosen (or skipped) password can be
+  // threaded straight into the ONE `importWallet` call that persists it —
+  // nothing is on disk yet for this mnemonic, so no re-encryption is needed.
+  // null while in the create-flow's post-backup `setPassword` step (there the
+  // already-created wallet's own `generatedMnemonic` is used instead).
+  const pendingRestoreMnemonicRef = useRef<string | null>(null);
 
   // Nametag state
   const [nametagInput, setNametagInput] = useState("");
@@ -499,56 +518,17 @@ export function useOnboardingFlow(
       return;
     }
 
-    setIsBusy(true);
     setError(null);
 
-    // Show processing screen during import
-    setStep("processing");
-    setProcessingTitle("Importing Wallet...");
-    setProcessingCompleteTitle("Import Complete!");
-    setProcessingStep(0);
-    setProcessingTotalSteps(3);
-    setProcessingStatus("Importing wallet...");
-    setIsProcessingComplete(false);
-
-    try {
-      const instance = await importWallet(mnemonic);
-
-      // Store in ref so handleMintNametag / handleSkipNametag can access it
-      importedSphereRef.current = instance;
-
-      // Route to next screen after import completes
-      const allAddresses = instance.getAllTrackedAddresses();
-      if (allAddresses.length >= 1) {
-        const addresses: DerivedAddressInfo[] = allAddresses.map(a => ({
-          index: a.index,
-          l3Address: a.directAddress,
-          chainPubkey: a.chainPubkey,
-          path: `m/44'/60'/0'/0/${a.index}`,
-          hasNametag: !!a.nametag,
-          existingNametag: a.nametag,
-          isChange: false,
-          balanceLoading: false,
-          ipnsLoading: false,
-        }));
-        setDerivedAddresses(addresses);
-        setSelectedKeys(new Set(addresses.map(a => addrKey(a.index, false))));
-        setStep("addressSelection");
-      } else if (instance.identity?.nametag) {
-        setProcessingStep(2);
-        setProcessingStatus("Setup complete!");
-        setIsProcessingComplete(true);
-      } else {
-        setStep("nametag");
-      }
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Invalid recovery phrase";
-      setError(message);
-      setStep("restore");
-    } finally {
-      setIsBusy(false);
-    }
-  }, [seedWords, importWallet]);
+    // #449: offer the SAME optional at-rest password as the create flow —
+    // BEFORE the one-and-only `importWallet` call for this mnemonic, so
+    // nothing has been persisted yet and the (optional) password can be
+    // threaded straight into that single call. No re-encryption/re-persist
+    // step is ever needed. `handleSetPassword` performs the actual import
+    // once the user sets or skips a password on `SetPasswordScreen`.
+    pendingRestoreMnemonicRef.current = mnemonic;
+    setStep("setPassword");
+  }, [seedWords]);
 
   // Action: Create wallet WITH nametag (or register nametag on imported wallet)
   const handleMintNametag = useCallback(async () => {
@@ -726,10 +706,112 @@ export function useOnboardingFlow(
     void doFinalizeWallet();
   }, [doFinalizeWallet]);
 
-  // Action: Confirm mnemonic backup (called after user saves recovery phrase)
+  // Action: Confirm mnemonic backup (called after user saves recovery phrase).
+  // #449: instead of finalizing immediately, offer the optional SetPasswordScreen
+  // next — the seed is secured first, so a forgotten password still has the
+  // seed as an escape hatch. `handleSetPassword` (below) finalizes afterwards.
   const handleMnemonicBackupComplete = useCallback(() => {
+    setStep("setPassword");
+  }, []);
+
+  // Action: Set/Skip handler for SetPasswordScreen (#449). Shared by two
+  // distinct call sites, distinguished by `pendingRestoreMnemonicRef`:
+  //  - Restore/import flow (from handleRestoreWallet): nothing has been
+  //    persisted for this mnemonic yet — thread the (optional) password
+  //    straight into the ONE importWallet call that creates it.
+  //  - Create flow (from handleMnemonicBackupComplete above): the wallet
+  //    already exists (created before the backup screen, #448) WITHOUT a
+  //    password. The only safe way to protect it here is to re-create it
+  //    from its OWN already-shown, already-backed-up mnemonic — the wallet is
+  //    brand new (no funds/history yet), so nothing can be lost.
+  //    Re-encrypting an EXISTING/funded wallet in place is a separate,
+  //    riskier operation (Settings "set password", out of scope here) —
+  //    never performed by this handler.
+  const handleSetPassword = useCallback(async (password?: string) => {
+    const restoreMnemonic = pendingRestoreMnemonicRef.current;
+    pendingRestoreMnemonicRef.current = null;
+
+    if (restoreMnemonic) {
+      setIsBusy(true);
+      setError(null);
+
+      // Show processing screen during import
+      setStep("processing");
+      setProcessingTitle("Importing Wallet...");
+      setProcessingCompleteTitle("Import Complete!");
+      setProcessingStep(0);
+      setProcessingTotalSteps(3);
+      setProcessingStatus("Importing wallet...");
+      setIsProcessingComplete(false);
+
+      try {
+        // Call shape mirrors the pre-#449 direct call exactly when no
+        // password is chosen (`importWallet(mnemonic)`, single argument) —
+        // the SKIP path stays byte-for-byte identical, down to call arity.
+        const instance = password
+          ? await importWallet(restoreMnemonic, { password })
+          : await importWallet(restoreMnemonic);
+
+        // Store in ref so handleMintNametag / handleSkipNametag can access it
+        importedSphereRef.current = instance;
+
+        // Route to next screen after import completes
+        const allAddresses = instance.getAllTrackedAddresses();
+        if (allAddresses.length >= 1) {
+          const addresses: DerivedAddressInfo[] = allAddresses.map(a => ({
+            index: a.index,
+            l3Address: a.directAddress,
+            chainPubkey: a.chainPubkey,
+            path: `m/44'/60'/0'/0/${a.index}`,
+            hasNametag: !!a.nametag,
+            existingNametag: a.nametag,
+            isChange: false,
+            balanceLoading: false,
+            ipnsLoading: false,
+          }));
+          setDerivedAddresses(addresses);
+          setSelectedKeys(new Set(addresses.map(a => addrKey(a.index, false))));
+          setStep("addressSelection");
+        } else if (instance.identity?.nametag) {
+          setProcessingStep(2);
+          setProcessingStatus("Setup complete!");
+          setIsProcessingComplete(true);
+        } else {
+          setStep("nametag");
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Invalid recovery phrase";
+        setError(message);
+        setStep("restore");
+      } finally {
+        setIsBusy(false);
+      }
+      return;
+    }
+
+    // Create flow: re-create the just-shown, brand-new wallet from its own
+    // mnemonic WITH the chosen password. Skipped (no password) is a no-op —
+    // `importedSphereRef.current` stays the original plaintext instance, and
+    // finalize proceeds exactly as it did before this step existed (#449
+    // no-wallet-loss: the SKIP path is byte-for-byte identical to today).
+    if (password && generatedMnemonic && Sphere.validateMnemonic(generatedMnemonic)) {
+      setIsBusy(true);
+      setError(null);
+      try {
+        const instance = await importWallet(generatedMnemonic, { password });
+        importedSphereRef.current = instance;
+      } catch (e) {
+        // Never lose the wallet: the plaintext instance created earlier is
+        // still valid and already persisted on disk — fall back to it rather
+        // than surface an error that could strand the user mid-onboarding.
+        console.error("Failed to protect the wallet with a password; continuing without one", e);
+      } finally {
+        setIsBusy(false);
+      }
+    }
+
     void doFinalizeWallet();
-  }, [doFinalizeWallet]);
+  }, [importWallet, generatedMnemonic, doFinalizeWallet]);
 
   // Action: Continue from the plan-capabilities screen into the wallet
   const handlePlanCapabilitiesContinue = useCallback(() => {
@@ -915,6 +997,7 @@ export function useOnboardingFlow(
     handleCompleteOnboarding,
     handleMnemonicBackupComplete,
     handleDownloadBackup,
+    handleSetPassword,
 
     // Subscription plan-capabilities state (post-finalize provisioning)
     planName,

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -68,11 +68,18 @@ export interface UseOnboardingFlowReturn {
   handleMnemonicBackupComplete: () => void;
   handleDownloadBackup: (password?: string) => Promise<void>;
   /**
-   * Set/Skip handler for `SetPasswordScreen` (#449). Restore/import-from-
-   * mnemonic flow ONLY — the create flow does not reach this handler (see
-   * its implementation comment for why: a second `importWallet()` call on an
-   * already-persisted wallet is a wallet-loss/lockout hazard, since it
-   * unconditionally `Sphere.clear()`s existing storage before rebuilding).
+   * Set/Skip handler for `SetPasswordScreen` (#449 / #449 follow-up). Reached
+   * from BOTH flows now:
+   *  - Restore/import-from-mnemonic: nothing is persisted yet for this
+   *    mnemonic, so the chosen (or skipped) password threads straight into
+   *    the ONE `importWallet` call that creates it.
+   *  - Create: the wallet is ALREADY persisted (plaintext) by the time this
+   *    screen shows, so a chosen password is applied via the reviewed-SAFE
+   *    in-place re-encrypt (`setWalletPassword` from `useSphereContext()`) —
+   *    never a second `importWallet()`/`Sphere.import()` call, which would be
+   *    a wallet-loss/lockout hazard (it unconditionally `Sphere.clear()`s
+   *    existing storage before rebuilding). See the implementation comment
+   *    for full detail.
    * Omit `password` to skip.
    */
   handleSetPassword: (password?: string) => Promise<void>;
@@ -138,7 +145,7 @@ export function useOnboardingFlow(
 ): UseOnboardingFlowReturn {
   const { fromLock, onExitToUnlock } = options ?? {};
   const queryClient = useQueryClient();
-  const { sphere, network, createWallet, resolveNametag, importWallet, importFromFile, finalizeWallet, walletExists, initProgress } = useSphereContext();
+  const { sphere, network, createWallet, resolveNametag, importWallet, importFromFile, finalizeWallet, walletExists, initProgress, setWalletPassword } = useSphereContext();
 
   // Step management — start at "nametag" only if wallet is fully finalized but missing nametag
   // (e.g. page refresh after wallet creation without nametag).
@@ -155,10 +162,11 @@ export function useOnboardingFlow(
   const [error, setError] = useState<string | null>(null);
 
   // Block page reload / tab close during wallet creation. "setPassword" is
-  // included here too (#449): it's the restore/import flow's last step
-  // before its one-and-only persisting importWallet() call; guarding it the
-  // same way as "mnemonicBackup" costs nothing on the create path (which no
-  // longer uses this step — see handleSetPassword).
+  // included here too (#449 / #449 follow-up): it's a step where a
+  // persisting/re-encrypting call is either about to run or in flight — the
+  // restore/import flow's last step before its one-and-only persisting
+  // importWallet() call, and (since #449 follow-up) the create flow's
+  // optional in-place re-encrypt (setWalletPassword) before finalizing.
   const isProcessingActive = step === "processing" || step === "mnemonicBackup" || step === "setPassword";
   useEffect(() => {
     if (!isProcessingActive) return;
@@ -187,7 +195,10 @@ export function useOnboardingFlow(
   // `setPassword` step is shown, so the chosen (or skipped) password can be
   // threaded straight into the ONE `importWallet` call that persists it —
   // nothing is on disk yet for this mnemonic, so no re-encryption is needed.
-  // Restore/import flow only — the create flow doesn't reach `setPassword`.
+  // Restore/import flow only. Left `null` for the create flow (#449
+  // follow-up: the create flow reaches `setPassword` too now, but via
+  // `doFinalizeWallet`/`setWalletPassword` in-place re-encrypt, never this
+  // ref/`importWallet` path — see handleSetPassword).
   const pendingRestoreMnemonicRef = useRef<string | null>(null);
   // #449: re-entrancy guard for handleSetPassword. SetPasswordScreen doesn't
   // disable its Set/Skip buttons while busy, so a double-click (or a fast
@@ -715,51 +726,94 @@ export function useOnboardingFlow(
 
   // Action: Confirm mnemonic backup (called after user saves recovery phrase).
   // The wallet was already created (plaintext) before this screen ran, in
-  // handleMintNametag/handleSkipNametag — finalize directly. (#449: the
-  // create flow does NOT offer an at-rest password here anymore — see
-  // handleSetPassword's comment below for why.)
+  // handleMintNametag/handleSkipNametag. #449 follow-up: rather than
+  // finalizing straight away, offer the SAME optional at-rest password the
+  // restore flow offers — the ordering is now
+  // mnemonicBackup → setPassword → planCapabilities → wallet. This is safe
+  // because handleSetPassword's create-flow branch below applies the
+  // password via the reviewed-SAFE in-place re-encrypt (setWalletPassword),
+  // never a second importWallet()/Sphere.import() call.
   const handleMnemonicBackupComplete = useCallback(() => {
-    void doFinalizeWallet();
-  }, [doFinalizeWallet]);
+    setStep("setPassword");
+  }, []);
 
-  // Action: Set/Skip handler for SetPasswordScreen (#449) — restore/import-
-  // from-mnemonic flow ONLY (reached from handleRestoreWallet). Nothing has
-  // been persisted for this mnemonic yet, so the chosen (or skipped)
-  // password threads straight into the ONE importWallet call that creates
-  // it; no re-encryption/re-persist step is ever needed.
+  // Action: Set/Skip handler for SetPasswordScreen (#449 / #449 follow-up).
+  // Reached from TWO places, each handled by its own branch below:
   //
-  // The create flow used to reach this same handler too, re-creating the
-  // just-shown wallet from its own mnemonic WITH the chosen password. That
-  // required a SECOND `importWallet()` call on a wallet `createWallet()` had
-  // already persisted moments earlier (#448's create-without-nametag step) —
-  // `importWallet` wraps the SDK's `Sphere.import()`, which unconditionally
-  // `Sphere.clear()`s any already-persisted wallet before rebuilding it. If
-  // that rebuild then threw (a network hiccup during identity/nametag sync,
-  // etc.), storage was left cleared while the app kept using the in-memory
-  // instance for the rest of the session — on next reload the wallet could
-  // show unexpectedly LOCKED or vanish entirely. It also raced the
-  // just-published Nostr nametag binding from createWalletThenRegister
-  // (#448), risking permanently burning it. Fixed by removing the
-  // create-flow branch entirely: the create flow now finalizes straight from
-  // the backup screen (handleMnemonicBackupComplete above) and never reaches
-  // this step. Setting a password on an already-created wallet safely needs
-  // a Settings-side "set password" (re-encrypt in place) flow, which doesn't
-  // exist yet — a future task, not this handler.
+  //  1. Restore/import-from-mnemonic (handleRestoreWallet sets
+  //     pendingRestoreMnemonicRef right before showing this step). Nothing
+  //     has been persisted for this mnemonic yet, so the chosen (or skipped)
+  //     password threads straight into the ONE importWallet call that
+  //     creates it; no re-encryption/re-persist step is ever needed.
+  //
+  //  2. Create flow (handleMnemonicBackupComplete above; no pending restore
+  //     mnemonic). The wallet was ALREADY persisted (plaintext) moments
+  //     earlier by createWallet()/createWalletThenRegister() (#448's
+  //     create-without-nametag step) — by the time this screen shows, there
+  //     is a real wallet on disk with a token DB etc. A SECOND
+  //     `importWallet()` call here (re-creating that same wallet from its
+  //     own mnemonic WITH the chosen password) was the #449 CRITICAL
+  //     wallet-loss bug: `importWallet` wraps the SDK's `Sphere.import()`,
+  //     which unconditionally `Sphere.clear()`s any already-persisted wallet
+  //     before rebuilding it. If that rebuild then threw (a network hiccup
+  //     during identity/nametag sync, etc.), storage was left cleared while
+  //     the app kept using the in-memory instance for the rest of the
+  //     session — on next reload the wallet could show unexpectedly LOCKED
+  //     or vanish entirely. It also raced the just-published Nostr nametag
+  //     binding from createWalletThenRegister (#448), risking permanently
+  //     burning it.
+  //
+  //     Instead, the create-flow branch applies a chosen password via
+  //     `setWalletPassword` (from `useSphereContext()`) — the same
+  //     reviewed-SAFE in-place mnemonic re-encrypt built for Settings →
+  //     Security: read mnemonic → encrypt → write back to the MNEMONIC key
+  //     ONLY, with read-back verify and restore-on-failure. `Sphere.import`/
+  //     `Sphere.clear` are never called; the token DB and everything else
+  //     already on disk are untouched. On failure, `setWalletPassword` is
+  //     itself self-restoring (leaves the existing plaintext mnemonic
+  //     intact) — so a rejection here surfaces an error but still lets the
+  //     user proceed into their (now-plaintext) wallet, exactly like Skip,
+  //     rather than stranding them on this screen or losing the wallet.
   const handleSetPassword = useCallback(async (password?: string) => {
     const restoreMnemonic = pendingRestoreMnemonicRef.current;
     pendingRestoreMnemonicRef.current = null;
 
-    // Defensive: this step is only ever reached via handleRestoreWallet,
-    // which always sets pendingRestoreMnemonicRef right before showing it.
-    // If it's ever missing (a stray navigation), there is nothing safe to
-    // persist here — finalize with whatever wallet already exists rather
-    // than guessing at a re-import.
+    // Create flow: no pending restore mnemonic — see branch 2 in the
+    // doc-comment above.
     if (!restoreMnemonic) {
+      // Re-entrancy guard: a double-click on "Set Password", or a fast
+      // Set-then-Skip, must not fire two overlapping setWalletPassword()
+      // calls (reencryptStoredMnemonic's read → encrypt → write cycle is not
+      // safe to run concurrently against the same storage key).
+      if (isPersistingRef.current) return;
+      isPersistingRef.current = true;
+      setIsBusy(true);
+      setError(null);
+      try {
+        if (password) {
+          try {
+            await setWalletPassword(password);
+          } catch (e) {
+            // Self-restoring on failure (see doc-comment above) — the
+            // wallet is never at risk. Surface the failure but still
+            // finalize below so the user isn't stuck on this screen.
+            const message = e instanceof Error ? e.message : "Failed to set a wallet password";
+            setError(message);
+          }
+        }
+      } finally {
+        isPersistingRef.current = false;
+        setIsBusy(false);
+      }
+      // Finalize regardless of outcome: password set, password skipped, and
+      // password-attempt-failed all converge here — the skip/failure cases
+      // finalize the plaintext wallet exactly as Skip always has.
       void doFinalizeWallet();
       return;
     }
 
-    // Re-entrancy guard: a double-click on "Set Password", or a fast
+    // Restore/import-from-mnemonic flow — see branch 1 in the doc-comment
+    // above. Re-entrancy guard: a double-click on "Set Password", or a fast
     // Set-then-Skip, must not fire two overlapping importWallet() calls —
     // the second would re-run Sphere.import() and clear storage the first
     // call just persisted mid-write.
@@ -821,7 +875,7 @@ export function useOnboardingFlow(
       setIsBusy(false);
       isPersistingRef.current = false;
     }
-  }, [importWallet, doFinalizeWallet]);
+  }, [importWallet, doFinalizeWallet, setWalletPassword]);
 
   // Action: Continue from the plan-capabilities screen into the wallet
   const handlePlanCapabilitiesContinue = useCallback(() => {

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -66,7 +66,14 @@ export interface UseOnboardingFlowReturn {
   isProcessingComplete: boolean;
   handleCompleteOnboarding: () => Promise<void>;
   handleMnemonicBackupComplete: () => void;
-  handleDownloadBackup: (password?: string) => Promise<void>;
+  handleDownloadBackup: () => Promise<void>;
+  /**
+   * True once a wallet password was set in this create flow's `setPassword`
+   * step (which now runs BEFORE the backup screen). The SAME password is
+   * what `handleDownloadBackup` threads into the exported backup file, so
+   * this also tells `MnemonicBackupScreen` which label/copy to show.
+   */
+  backupEncrypted: boolean;
   /**
    * Set/Skip handler for `SetPasswordScreen` (#449 / #449 follow-up). Reached
    * from BOTH flows now:
@@ -200,6 +207,15 @@ export function useOnboardingFlow(
   // `doFinalizeWallet`/`setWalletPassword` in-place re-encrypt, never this
   // ref/`importWallet` path — see handleSetPassword).
   const pendingRestoreMnemonicRef = useRef<string | null>(null);
+  // Create flow only (#449 UX refinement): remembers the password chosen on
+  // `setPassword` — which now runs BEFORE the backup screen — purely in
+  // memory (never persisted as its own secret) so `handleDownloadBackup`,
+  // reached moments later on the backup screen, can reuse the SAME password
+  // to encrypt the exported file instead of asking for a second one (the
+  // #450 separate backup-file password is gone). `null` means no password
+  // was set (skipped, or this is the restore/import flow, which has no
+  // backup screen at all).
+  const createBackupPasswordRef = useRef<string | null>(null);
   // #449: re-entrancy guard for handleSetPassword. SetPasswordScreen doesn't
   // disable its Set/Skip buttons while busy, so a double-click (or a fast
   // Set-then-Skip) could otherwise fire two overlapping `importWallet()`
@@ -298,6 +314,7 @@ export function useOnboardingFlow(
     setIsDragging(false);
     importedSphereRef.current = null;
     isCreateFlowRef.current = false;
+    createBackupPasswordRef.current = null;
     setError(null);
     // #449 no-wallet-loss: entered via the lock-escape → never show the
     // generic StartScreen (its "Create New Wallet" would run against storage
@@ -705,12 +722,15 @@ export function useOnboardingFlow(
     finishFinalize();
   }, [sphere, network, finishFinalize]);
 
-  // Auto-transition when processing completes
+  // Auto-transition when processing completes. Create flow ordering (#449
+  // UX refinement): setPassword now runs BEFORE mnemonicBackup, so the one
+  // password chosen there can also encrypt the backup file shown right
+  // after it (see handleSetPassword / handleDownloadBackup).
   useEffect(() => {
     if (isProcessingComplete && step === "processing") {
       const timer = setTimeout(() => {
         if (isCreateFlowRef.current && generatedMnemonic) {
-          setStep("mnemonicBackup");
+          setStep("setPassword");
         } else {
           void doFinalizeWallet();
         }
@@ -724,18 +744,15 @@ export function useOnboardingFlow(
     void doFinalizeWallet();
   }, [doFinalizeWallet]);
 
-  // Action: Confirm mnemonic backup (called after user saves recovery phrase).
-  // The wallet was already created (plaintext) before this screen ran, in
-  // handleMintNametag/handleSkipNametag. #449 follow-up: rather than
-  // finalizing straight away, offer the SAME optional at-rest password the
-  // restore flow offers — the ordering is now
-  // mnemonicBackup → setPassword → planCapabilities → wallet. This is safe
-  // because handleSetPassword's create-flow branch below applies the
-  // password via the reviewed-SAFE in-place re-encrypt (setWalletPassword),
-  // never a second importWallet()/Sphere.import() call.
+  // Action: Confirm mnemonic backup (called after user saves recovery phrase
+  // and optionally downloads the backup file). #449 UX refinement: this is
+  // now the LAST create-flow step — setPassword already ran right after
+  // processing, BEFORE this screen (ordering: processing → setPassword →
+  // mnemonicBackup → planCapabilities → wallet) — so confirming here just
+  // finalizes.
   const handleMnemonicBackupComplete = useCallback(() => {
-    setStep("setPassword");
-  }, []);
+    void doFinalizeWallet();
+  }, [doFinalizeWallet]);
 
   // Action: Set/Skip handler for SetPasswordScreen (#449 / #449 follow-up).
   // Reached from TWO places, each handled by its own branch below:
@@ -746,8 +763,11 @@ export function useOnboardingFlow(
   //     password threads straight into the ONE importWallet call that
   //     creates it; no re-encryption/re-persist step is ever needed.
   //
-  //  2. Create flow (handleMnemonicBackupComplete above; no pending restore
-  //     mnemonic). The wallet was ALREADY persisted (plaintext) moments
+  //  2. Create flow (handleSkipNametag/handleMintNametag's processing
+  //     auto-transition above; no pending restore mnemonic). #449 UX
+  //     refinement: this now runs BEFORE the backup screen (ordering:
+  //     processing → setPassword → mnemonicBackup → planCapabilities →
+  //     wallet). The wallet was ALREADY persisted (plaintext) moments
   //     earlier by createWallet()/createWalletThenRegister() (#448's
   //     create-without-nametag step) — by the time this screen shows, there
   //     is a real wallet on disk with a token DB etc. A SECOND
@@ -769,11 +789,16 @@ export function useOnboardingFlow(
   //     Security: read mnemonic → encrypt → write back to the MNEMONIC key
   //     ONLY, with read-back verify and restore-on-failure. `Sphere.import`/
   //     `Sphere.clear` are never called; the token DB and everything else
-  //     already on disk are untouched. On failure, `setWalletPassword` is
-  //     itself self-restoring (leaves the existing plaintext mnemonic
-  //     intact) — so a rejection here surfaces an error but still lets the
-  //     user proceed into their (now-plaintext) wallet, exactly like Skip,
-  //     rather than stranding them on this screen or losing the wallet.
+  //     already on disk are untouched. On success the password is also
+  //     remembered in `createBackupPasswordRef` (memory-only) so the backup
+  //     screen right after this one can encrypt the exported file with the
+  //     SAME password — see handleDownloadBackup. On failure,
+  //     `setWalletPassword` is itself self-restoring (leaves the existing
+  //     plaintext mnemonic intact), so the wallet is never at risk — but
+  //     unlike Skip, a rejection here does NOT advance: it surfaces the
+  //     error on this screen and lets the user retry or explicitly Skip,
+  //     rather than silently landing them in a wallet they believe is
+  //     password-protected while it's still plaintext (#449 review fix).
   const handleSetPassword = useCallback(async (password?: string) => {
     const restoreMnemonic = pendingRestoreMnemonicRef.current;
     pendingRestoreMnemonicRef.current = null;
@@ -795,20 +820,25 @@ export function useOnboardingFlow(
             await setWalletPassword(password);
           } catch (e) {
             // Self-restoring on failure (see doc-comment above) — the
-            // wallet is never at risk. Surface the failure but still
-            // finalize below so the user isn't stuck on this screen.
+            // wallet is never at risk. Surface the failure and stay on this
+            // screen (do NOT advance to mnemonicBackup) so the user can
+            // retry or explicitly Skip.
             const message = e instanceof Error ? e.message : "Failed to set a wallet password";
             setError(message);
+            return;
           }
+          // Remembered ONLY in memory — never persisted as its own secret —
+          // so handleDownloadBackup can encrypt the backup file with this
+          // SAME password.
+          createBackupPasswordRef.current = password;
+        } else {
+          createBackupPasswordRef.current = null;
         }
+        setStep("mnemonicBackup");
       } finally {
         isPersistingRef.current = false;
         setIsBusy(false);
       }
-      // Finalize regardless of outcome: password set, password skipped, and
-      // password-attempt-failed all converge here — the skip/failure cases
-      // finalize the plaintext wallet exactly as Skip always has.
-      void doFinalizeWallet();
       return;
     }
 
@@ -875,18 +905,22 @@ export function useOnboardingFlow(
       setIsBusy(false);
       isPersistingRef.current = false;
     }
-  }, [importWallet, doFinalizeWallet, setWalletPassword]);
+  }, [importWallet, setWalletPassword]);
 
   // Action: Continue from the plan-capabilities screen into the wallet
   const handlePlanCapabilitiesContinue = useCallback(() => {
     finishFinalize();
   }, [finishFinalize]);
 
-  // Action: Download wallet backup file. Optional password encrypts the file
-  // (like the in-wallet "Save Wallet"); the filename never leaks the handle (#450).
-  const handleDownloadBackup = useCallback(async (password?: string) => {
+  // Action: Download wallet backup file. Reuses the SAME password chosen
+  // moments earlier on the setPassword step (createBackupPasswordRef) to
+  // encrypt the file (like the in-wallet "Save Wallet") — `undefined` when
+  // that step was skipped, producing a plaintext export. The separate #450
+  // backup-file password input is gone; the filename never leaks the handle.
+  const handleDownloadBackup = useCallback(async () => {
     const activeSphere = importedSphereRef.current ?? sphere;
     if (!activeSphere) return;
+    const password = createBackupPasswordRef.current ?? undefined;
     const { fileName, json } = buildWalletBackup(activeSphere, password);
     const blob = new Blob([JSON.stringify(json, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -1061,6 +1095,7 @@ export function useOnboardingFlow(
     handleCompleteOnboarding,
     handleMnemonicBackupComplete,
     handleDownloadBackup,
+    backupEncrypted: createBackupPasswordRef.current !== null,
     handleSetPassword,
 
     // Subscription plan-capabilities state (post-finalize provisioning)

--- a/src/components/wallet/shared/modals/BackupWalletModal.tsx
+++ b/src/components/wallet/shared/modals/BackupWalletModal.tsx
@@ -1,7 +1,9 @@
-import { Download, Key, ShieldCheck } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Download, Key, Lock, ShieldCheck } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { MenuButton, ModalHeader } from '../../ui';
+import { AlertMessage, MenuButton, ModalHeader } from '../../ui';
 import { WalletScreen } from '../../ui/WalletScreen';
+import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
 
 interface BackupWalletModalProps {
   isOpen: boolean;
@@ -11,6 +13,20 @@ interface BackupWalletModalProps {
   hasMnemonic?: boolean;
 }
 
+const inputClass =
+  'w-full px-4 py-2.5 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 ' +
+  'text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-orange-500/60';
+
+/**
+ * Backup Wallet screen (#449): "Export Wallet File" and "Show Recovery
+ * Phrase" both expose the seed, so when the wallet has an at-rest password
+ * set, the user must re-enter it here before either option is revealed.
+ * Verification is read-only (SphereContext.verifyWalletPassword) — it never
+ * mutates the stored mnemonic and the entered password is never persisted,
+ * only held in local component state until the gate is passed or the modal
+ * closes. Wallets with NO password (hasWalletPassword === false) skip the
+ * gate entirely, exactly as before this change.
+ */
 export function BackupWalletModal({
   isOpen,
   onClose,
@@ -18,6 +34,42 @@ export function BackupWalletModal({
   onShowRecoveryPhrase,
   hasMnemonic = true,
 }: BackupWalletModalProps) {
+  const { hasWalletPassword, verifyWalletPassword } = useSphereContext();
+
+  const [authenticated, setAuthenticated] = useState(false);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Re-ask every time the modal is (re)opened — the gate must not stay
+  // "remembered" across separate visits to this screen.
+  useEffect(() => {
+    if (isOpen) {
+      setAuthenticated(false);
+      setPassword('');
+      setError(null);
+      setBusy(false);
+    }
+  }, [isOpen]);
+
+  const locked = hasWalletPassword && !authenticated;
+
+  const handleUnlock = async () => {
+    if (busy || !password) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const ok = await verifyWalletPassword(password);
+      if (ok) {
+        setAuthenticated(true);
+      } else {
+        setError('Incorrect password');
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <WalletScreen isOpen={isOpen} onClose={onClose}>
       <ModalHeader variant="screen" title="Backup Wallet" onClose={onClose} />
@@ -29,46 +81,85 @@ export function BackupWalletModal({
             transition={{ delay: 0.1, type: "spring" }}
             className="w-16 h-16 rounded-full bg-orange-500/10 border border-orange-500/20 flex items-center justify-center mb-4"
           >
-            <ShieldCheck className="w-8 h-8 text-orange-500" />
+            {locked ? (
+              <Lock className="w-8 h-8 text-orange-500" />
+            ) : (
+              <ShieldCheck className="w-8 h-8 text-orange-500" />
+            )}
           </motion.div>
           <p className="text-sm text-neutral-500 dark:text-white/45">
-            Choose how you want to backup your wallet
+            {locked
+              ? 'Enter your wallet password to continue'
+              : 'Choose how you want to backup your wallet'}
           </p>
         </div>
 
-        <div className="space-y-3">
-          <MenuButton
-            icon={Download}
-            color="blue"
-            label="Export Wallet File"
-            subtitle="Download encrypted JSON file"
-            showChevron={false}
-            onClick={() => {
-              onClose();
-              onExportWalletFile();
-            }}
-          />
+        {locked ? (
+          <div className="space-y-3">
+            <input
+              type="password"
+              aria-label="Password"
+              autoFocus
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+              placeholder="Enter your password"
+              className={inputClass}
+            />
 
-          <MenuButton
-            icon={Key}
-            color="orange"
-            label="Show Recovery Phrase"
-            subtitle={hasMnemonic ? 'View 12-word seed phrase' : 'Not available for legacy wallets'}
-            showChevron={false}
-            disabled={!hasMnemonic}
-            onClick={() => {
-              onClose();
-              onShowRecoveryPhrase();
-            }}
-          />
+            {error && <AlertMessage variant="error">{error}</AlertMessage>}
 
-          <button
-            onClick={onClose}
-            className="w-full py-3 text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
-          >
-            Cancel
-          </button>
-        </div>
+            <button
+              onClick={handleUnlock}
+              disabled={busy}
+              className="w-full py-3.5 px-5 rounded-xl bg-linear-to-r from-orange-500 to-orange-600 dark:from-brand-orange dark:to-brand-orange-dark text-white text-sm font-bold disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {busy ? 'Verifying…' : 'Continue'}
+            </button>
+
+            <button
+              onClick={onClose}
+              className="w-full py-3 text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <MenuButton
+              icon={Download}
+              color="blue"
+              label="Export Wallet File"
+              subtitle="Download encrypted JSON file"
+              showChevron={false}
+              onClick={() => {
+                onClose();
+                onExportWalletFile();
+              }}
+            />
+
+            <MenuButton
+              icon={Key}
+              color="orange"
+              label="Show Recovery Phrase"
+              subtitle={hasMnemonic ? 'View 12-word seed phrase' : 'Not available for legacy wallets'}
+              showChevron={false}
+              disabled={!hasMnemonic}
+              onClick={() => {
+                onClose();
+                onShowRecoveryPhrase();
+              }}
+            />
+
+            <button
+              onClick={onClose}
+              className="w-full py-3 text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
     </WalletScreen>
   );

--- a/src/components/wallet/shared/modals/BackupWalletModal.tsx
+++ b/src/components/wallet/shared/modals/BackupWalletModal.tsx
@@ -71,7 +71,9 @@ export function BackupWalletModal({
   };
 
   return (
-    <WalletScreen isOpen={isOpen} onClose={onClose}>
+    // z-20: this screen drills in ON TOP of Settings / Logout (z-10), which stay
+    // mounted behind it — a slide-in over a static parent, no crossing panels.
+    <WalletScreen isOpen={isOpen} onClose={onClose} className="!z-20">
       <ModalHeader variant="screen" title="Backup Wallet" onClose={onClose} />
       <div className="flex-1 flex flex-col justify-center px-6 pb-8">
         <div className="flex flex-col items-center text-center mb-8">
@@ -134,7 +136,8 @@ export function BackupWalletModal({
               subtitle="Download encrypted JSON file"
               showChevron={false}
               onClick={() => {
-                onClose();
+                // Keep this screen mounted (z-20) so the export screen (z-30)
+                // slides in on top instead of crossing a slide-out.
                 onExportWalletFile();
               }}
             />
@@ -147,7 +150,8 @@ export function BackupWalletModal({
               showChevron={false}
               disabled={!hasMnemonic}
               onClick={() => {
-                onClose();
+                // Keep this screen mounted (z-20) so the seed screen (z-30)
+                // slides in on top instead of crossing a slide-out.
                 onShowRecoveryPhrase();
               }}
             />

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -42,6 +42,13 @@ export const STORAGE_KEYS = {
   // Per-wallet aggregator subscription API key (cached; also recoverable
   // from identity via the SGW /auth flow). Cleared on wallet deletion.
   SUBSCRIPTION_API_KEY: 'sphere_subscription_api_key',
+
+  // Idle auto-lock timeout, encrypted at rest with the wallet password
+  // (encodeLockSettings/decodeLockSettings — src/sdk/walletLock/lockSettings.ts)
+  // so cold-storage tampering can't silently disable/shorten it. Written by
+  // the Settings "Security" section (#449, separate task); absent means the
+  // secure default (DEFAULT_AUTO_LOCK_MINUTES).
+  AUTO_LOCK_TIMEOUT: 'sphere_auto_lock_timeout',
 } as const;
 
 const STORAGE_PREFIX = 'sphere_';

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -24,6 +24,15 @@ export interface SphereContextValue {
   walletExists: boolean;
   error: Error | null;
 
+  /** True when an encrypted wallet exists on disk but hasn't been unlocked
+   *  with its password this session (SDK DECRYPTION_ERROR) — locked, not broken. */
+  isLocked: boolean;
+  /** Unlock the existing encrypted wallet with its password. Throws (DECRYPTION_ERROR)
+   *  on a wrong password — the caller (UnlockScreen) shows "wrong password". */
+  unlock: (password: string) => Promise<void>;
+  /** Lock the wallet: destroy the live Sphere instance and require unlock() again. */
+  lock: () => Promise<void>;
+
   /** True while background address discovery is running (post-init) */
   isDiscoveringAddresses: boolean;
 
@@ -71,10 +80,12 @@ export interface SphereContextValue {
 
 export interface CreateWalletOptions {
   nametag?: string;
+  password?: string;
 }
 
 export interface ImportWalletOptions {
   nametag?: string;
+  password?: string;
 }
 
 export interface ImportFromFileOptions {

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -3,6 +3,7 @@ import type { Sphere, PeerInfo, InitProgress } from '@unicitylabs/sphere-sdk';
 import type { BrowserProviders } from '@unicitylabs/sphere-sdk/impl/browser';
 import type { WalletApiProviderExtras } from '@unicitylabs/sphere-sdk/impl/shared/wallet-api';
 import type { SubscriptionKeyStatus } from './subscription/keyStatus';
+import type { AutoLockValue } from './walletLock/lockSettings';
 
 /**
  * The app's provider bundle: the browser base, plus — when the asset path
@@ -32,6 +33,38 @@ export interface SphereContextValue {
   unlock: (password: string) => Promise<void>;
   /** Lock the wallet: destroy the live Sphere instance and require unlock() again. */
   lock: () => Promise<void>;
+
+  /**
+   * Settings → Security (#449): whether the wallet CURRENTLY has an at-rest
+   * password (any wallet — including plaintext create-flow wallets that never
+   * set one). Drives the Set vs Change/Remove UI. Derived from the session
+   * password held in memory, OR (when no session password exists yet, e.g. a
+   * cold-start locked wallet) whether the on-disk mnemonic fails to validate
+   * as plaintext BIP39.
+   */
+  hasWalletPassword: boolean;
+  /**
+   * Set an at-rest password on a wallet that doesn't have one yet (including
+   * existing plaintext wallets). In-place mnemonic re-encryption ONLY — never
+   * Sphere.import()/Sphere.clear() (would wipe the token DB). Arms idle
+   * auto-lock on success.
+   */
+  setWalletPassword: (newPassword: string) => Promise<void>;
+  /**
+   * Change the wallet's at-rest password. Verifies `currentPassword` first —
+   * throws (and changes nothing) on a mismatch.
+   */
+  changeWalletPassword: (currentPassword: string, newPassword: string) => Promise<void>;
+  /**
+   * Remove the wallet's at-rest password, returning it to a plaintext
+   * mnemonic. Verifies `currentPassword` first. Disarms idle auto-lock.
+   */
+  removeWalletPassword: (currentPassword: string) => Promise<void>;
+
+  /** Current auto-lock timeout selection (Settings → Security). Only meaningful while a password is set. */
+  autoLockMinutes: AutoLockValue;
+  /** Set the auto-lock timeout; persists an encrypted blob and re-arms the idle timer. No-op without a session password. */
+  setAutoLockTimeout: (value: AutoLockValue) => void;
 
   /** True while background address discovery is running (post-init) */
   isDiscoveringAddresses: boolean;

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -62,6 +62,15 @@ export interface SphereContextValue {
    * mnemonic. Verifies `currentPassword` first. Disarms idle auto-lock.
    */
   removeWalletPassword: (currentPassword: string) => Promise<void>;
+  /**
+   * In-wallet backup gate (#449): verify a candidate password against the
+   * wallet's CURRENT at-rest mnemonic encryption — read-only, never mutates
+   * storage and never persists the entered password anywhere. Resolves
+   * `true` iff decrypting the stored mnemonic with `password` yields a valid
+   * BIP39 mnemonic; resolves `false` on any mismatch or failure (never
+   * throws to the caller).
+   */
+  verifyWalletPassword: (password: string) => Promise<boolean>;
 
   /** Current auto-lock timeout selection (Settings → Security). Only meaningful while a password is set. */
   autoLockMinutes: AutoLockValue;

--- a/src/sdk/SphereContext.ts
+++ b/src/sdk/SphereContext.ts
@@ -26,10 +26,12 @@ export interface SphereContextValue {
   error: Error | null;
 
   /** True when an encrypted wallet exists on disk but hasn't been unlocked
-   *  with its password this session (SDK DECRYPTION_ERROR) — locked, not broken. */
+   *  with its password this session (SDK throws a decrypt-mnemonic
+   *  STORAGE_ERROR — see isDecryptionError.ts) — locked, not broken. */
   isLocked: boolean;
-  /** Unlock the existing encrypted wallet with its password. Throws (DECRYPTION_ERROR)
-   *  on a wrong password — the caller (UnlockScreen) shows "wrong password". */
+  /** Unlock the existing encrypted wallet with its password. Throws the
+   *  decrypt-mnemonic STORAGE_ERROR on a wrong password — the caller
+   *  (UnlockScreen) shows "wrong password" via isDecryptionError. */
   unlock: (password: string) => Promise<void>;
   /** Lock the wallet: destroy the live Sphere instance and require unlock() again. */
   lock: () => Promise<void>;

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -562,6 +562,19 @@ export function SphereProvider({
         return { mnemonic: generatedMnemonic, sphere: instance };
       } catch (err) {
         setInitProgress(null);
+        // #449 no-wallet-loss guard: Sphere.init({autoGenerate:true}) only
+        // creates a fresh wallet when NONE exists on disk — if the storage
+        // already holds an encrypted wallet, Sphere.init delegates to
+        // Sphere.load(), which throws DECRYPTION_ERROR when (as here) no
+        // password was supplied. That is a LOCKED, still-recoverable wallet,
+        // not a broken create — never run the destructive cleanup for it.
+        // The onboarding UI's lock-escape routing (CreateWalletFlow's
+        // fromLock/goToStart) should prevent "Create New Wallet" from ever
+        // being reachable while such a wallet is present; this is the last
+        // line of defense against a stray/future path reaching it anyway.
+        if (classifyInitFailure(err) === 'locked') {
+          throw err;
+        }
         await cleanupOnError(providers);
         sphereRef.current = null;
         setSphere(null);

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -9,6 +9,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError, getPublicKey } from '@unicitylabs/sphere-sdk';
 import { sendWelcomeDM } from './welcomeDM';
 import { adoptOrDiscardInstance } from './adoptOrDiscardInstance';
+import { classifyInitFailure } from './walletLock/classifyInitFailure';
 import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
 import {
@@ -198,6 +199,10 @@ export function SphereProvider({
   const [isLoading, setIsLoading] = useState(true);
   const [walletExists, setWalletExists] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  // True when an encrypted wallet exists on disk but hasn't been unlocked with
+  // its password this session (SDK DECRYPTION_ERROR on init) — locked, not
+  // broken (#449). Only a real DECRYPTION_ERROR may flip this true.
+  const [isLocked, setIsLocked] = useState(false);
   const [ipfsEnabled, setIpfsEnabled] = useState(isIpfsEnabled);
   const [isDiscoveringAddresses, setIsDiscoveringAddresses] = useState(false);
   const [initProgress, setInitProgress] = useState<InitProgress | null>(null);
@@ -413,12 +418,28 @@ export function SphereProvider({
 
       if (exists) {
         setInitProgress({ step: 'initializing', message: 'Loading wallet...' });
-        const { sphere: instance } = await Sphere.init({
-          ...browserProviders,
-          network, // ensure the SDK configures TokenRegistry for THIS network (not the testnet default)
-          discoverAddresses: false, // Run separately below for UX
-          onProgress: setInitProgress,
-        });
+        // Never pass a `password` on this normal load path — an existing
+        // plaintext wallet must keep loading exactly as before. If the wallet
+        // IS encrypted, this deliberately-passwordless init throws
+        // DECRYPTION_ERROR, which we read as "locked", not a fatal error (#449).
+        let instance: Sphere;
+        try {
+          ({ sphere: instance } = await Sphere.init({
+            ...browserProviders,
+            network, // ensure the SDK configures TokenRegistry for THIS network (not the testnet default)
+            discoverAddresses: false, // Run separately below for UX
+            onProgress: setInitProgress,
+          }));
+        } catch (initErr) {
+          if (classifyInitFailure(initErr) === 'locked') {
+            // A superseded run's lock signal isn't ours to act on — the
+            // latest run (or unmount) already owns the outcome (#453).
+            if (isStale()) return;
+            setIsLocked(true);
+            return;
+          }
+          throw initErr;
+        }
         // Adopt only if we're still the latest init; otherwise destroy the
         // instance we just built so it can't linger as a zombie (#453).
         const outcome = await adoptOrDiscardInstance(instance, isStale, (inst) => {
@@ -527,6 +548,7 @@ export function SphereProvider({
           network,
           autoGenerate: true,
           nametag: options?.nametag,
+          password: options?.password,
           onProgress: setInitProgress,
         });
         setInitProgress(null);
@@ -590,6 +612,7 @@ export function SphereProvider({
         network,
         mnemonic,
         nametag: options?.nametag,
+        password: options?.password,
         onProgress: setInitProgress,
       });
       setInitProgress(null);
@@ -713,6 +736,42 @@ export function SphereProvider({
     await initialize(0, true);
   }, [providers, initialize, queryClient]);
 
+  // Unlock an encrypted wallet with its password. Re-runs Sphere.init WITH the
+  // password (the only place a password is ever passed for an EXISTING
+  // wallet); a wrong password throws DECRYPTION_ERROR, which we let propagate
+  // so the caller (UnlockScreen) can show "wrong password". Reuses the same
+  // initGenRef/adoptOrDiscardInstance re-entrancy guard as initialize() (#453)
+  // so an unlock superseded mid-flight destroys its instance instead of
+  // adopting it.
+  const unlock = useCallback(async (password: string) => {
+    if (!providers) throw new Error('Providers not initialized');
+    const gen = ++initGenRef.current;
+    const { sphere: instance } = await Sphere.init({
+      ...providers,
+      network,
+      password,
+      discoverAddresses: false,
+    });
+    const outcome = await adoptOrDiscardInstance(instance, () => gen !== initGenRef.current, (inst) => {
+      setupIpfsSync(inst, providers);
+      sphereRef.current = inst;
+      setSphere(inst);
+    });
+    if (outcome === 'adopted') setIsLocked(false);
+  }, [providers, network]);
+
+  // Lock the wallet: destroy the live Sphere instance (keys leave memory —
+  // a real lock, not just a UI gate) and require unlock() again.
+  // NOTE: notifying connected dApps (ConnectHost.notifyWalletLocked) is wired
+  // in a later task once SphereProvider has access to the live ConnectHost ref.
+  const lock = useCallback(async () => {
+    initGenRef.current++; // supersede any in-flight init
+    await sphereRef.current?.destroy();
+    sphereRef.current = null;
+    setSphere(null);
+    setIsLocked(true);
+  }, []);
+
   const finalizeWallet = useCallback((importedSphere?: Sphere) => {
     if (importedSphere) {
       if (providers) setupIpfsSync(importedSphere, providers);
@@ -775,6 +834,9 @@ export function SphereProvider({
     isInitialized: !!sphere,
     walletExists,
     error,
+    isLocked,
+    unlock,
+    lock,
     isDiscoveringAddresses,
     initProgress,
     resolveNametag,

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -10,6 +10,10 @@ import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError, getPublicKey } 
 import { sendWelcomeDM } from './welcomeDM';
 import { adoptOrDiscardInstance } from './adoptOrDiscardInstance';
 import { classifyInitFailure } from './walletLock/classifyInitFailure';
+import { useIdleTimer } from './walletLock/useIdleTimer';
+import { decodeLockSettings, autoLockMs, DEFAULT_AUTO_LOCK_MINUTES } from './walletLock/lockSettings';
+import { broadcastLock, subscribeLockBroadcast } from './walletLock/lockBroadcast';
+import { getActiveConnectHost } from './connectHostRegistry';
 import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
 import {
@@ -212,6 +216,32 @@ export function SphereProvider({
     SUBSCRIPTION_ENABLED ? 'provisioning' : 'not-required',
   );
   const sphereRef = useRef<Sphere | null>(null);
+  // Session-only wallet password (#449 Task 8a): held ONLY in memory while the
+  // wallet is unlocked, NEVER persisted anywhere (no localStorage/IndexedDB).
+  // Set on a successful unlock() and on createWallet()/importWallet() when the
+  // caller chose an at-rest password; cleared on lock() and deleteWallet().
+  const passwordRef = useRef<string | null>(null);
+  // Idle-auto-lock config derived from the password, computed ONCE per
+  // setSessionPassword() call rather than on every render: decodeLockSettings
+  // runs a PBKDF2 derivation (100k iterations — see sphere-sdk
+  // core/encryption.ts), deliberately slow, and must not re-run on every
+  // unrelated SphereProvider re-render. CRITICAL invariant: a wallet with NO
+  // password (passwordRef.current falsy) always resolves `enabled: false`
+  // here — see the `null`-password branch below.
+  const [idleLockConfig, setIdleLockConfig] = useState<{ enabled: boolean; timeoutMs: number | null }>({
+    enabled: false,
+    timeoutMs: null,
+  });
+  const setSessionPassword = useCallback((password: string | null) => {
+    passwordRef.current = password;
+    if (!password) {
+      setIdleLockConfig({ enabled: false, timeoutMs: null });
+      return;
+    }
+    const storedBlob = localStorage.getItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT);
+    const minutes = storedBlob ? decodeLockSettings(storedBlob, password) : DEFAULT_AUTO_LOCK_MINUTES;
+    setIdleLockConfig({ enabled: true, timeoutMs: autoLockMs(minutes) });
+  }, []);
   // Monotonic init generation: only the LATEST initialize() run may adopt its
   // Sphere; a run superseded mid-flight (StrictMode double-mount, IPFS/network
   // toggle, unmount) destroys the instance it built instead of leaking it. See
@@ -557,6 +587,11 @@ export function SphereProvider({
           throw new Error('Failed to generate mnemonic');
         }
 
+        // Memory-only (#449 Task 8a) — never persisted. Powers idle auto-lock
+        // for a freshly-created wallet the same way unlock() does for an
+        // existing one; a wallet created with NO password stays un-armed.
+        if (options?.password) setSessionPassword(options.password);
+
         // Don't set walletExists/sphere here — let finalizeWallet() handle it
         // so the onboarding flow can show the completion screen first.
         return { mnemonic: generatedMnemonic, sphere: instance };
@@ -582,7 +617,7 @@ export function SphereProvider({
         throw err;
       }
     },
-    [providers, network],
+    [providers, network, setSessionPassword],
   );
 
   const resolveNametag = useCallback(
@@ -630,11 +665,15 @@ export function SphereProvider({
       });
       setInitProgress(null);
 
+      // Memory-only (#449 Task 8a) — never persisted. Same as createWallet():
+      // an import with NO password stays un-armed for idle auto-lock.
+      if (options?.password) setSessionPassword(options.password);
+
       // Don't setSphere/setWalletExists here — the onboarding flow calls
       // finalizeWallet(sphere) after address selection / nametag are done.
       return instance;
     },
-    [providers, network],
+    [providers, network, setSessionPassword],
   );
 
   const importFromFile = useCallback(
@@ -744,10 +783,15 @@ export function SphereProvider({
     setSphere(null);
     setWalletExists(false);
     setError(null);
+    // The deleted wallet's password (if any) must not linger in memory, and —
+    // just as important — must not leave the idle-lock timer armed against a
+    // wallet that no longer exists (it would otherwise fire mid-onboarding and
+    // wrongly gate the onboarding UI behind an unlock screen). See #449.
+    setSessionPassword(null);
 
     // Reinitialize with fresh providers (skip loading spinner — onboarding UI is already visible)
     await initialize(0, true);
-  }, [providers, initialize, queryClient]);
+  }, [providers, initialize, queryClient, setSessionPassword]);
 
   // Unlock an encrypted wallet with its password. Re-runs Sphere.init WITH the
   // password (the only place a password is ever passed for an EXISTING
@@ -774,6 +818,8 @@ export function SphereProvider({
       setSphere(inst);
     });
     if (outcome !== 'adopted') return;
+    // Memory-only (#449 Task 8a) — never persisted. Powers idle auto-lock.
+    setSessionPassword(password);
     setIsLocked(false);
 
     // Mirror initialize()'s existing-wallet success branch (review parity, #449):
@@ -797,19 +843,53 @@ export function SphereProvider({
     }).finally(() => {
       setIsDiscoveringAddresses(false);
     });
-  }, [providers, network, setupSubscriptionKey]);
+  }, [providers, network, setupSubscriptionKey, setSessionPassword]);
 
   // Lock the wallet: destroy the live Sphere instance (keys leave memory —
   // a real lock, not just a UI gate) and require unlock() again.
-  // NOTE: notifying connected dApps (ConnectHost.notifyWalletLocked) is wired
-  // in a later task once SphereProvider has access to the live ConnectHost ref.
   const lock = useCallback(async () => {
     initGenRef.current++; // supersede any in-flight init
+    // Notify the connected dApp (if any) BEFORE destroying the instance, so it
+    // gets a clean LOCKED event instead of NOT_CONNECTED errors on its next
+    // request. `getActiveConnectHost()` reads the module-scoped mirror in
+    // connectHostRegistry.ts — SphereProvider is an ANCESTOR of ConnectProvider
+    // in the tree (see main.tsx), so it can't `useConnectContext()` directly;
+    // see that file for why. This was deferred from Task 4 (#449).
+    getActiveConnectHost()?.notifyWalletLocked();
     await sphereRef.current?.destroy();
     sphereRef.current = null;
     setSphere(null);
+    // Memory-only password never survives a lock (#449).
+    setSessionPassword(null);
     setIsLocked(true);
-  }, []);
+  }, [setSessionPassword]);
+
+  useIdleTimer({
+    timeoutMs: idleLockConfig.timeoutMs,
+    // CRITICAL invariant: a wallet with NO password (existing plaintext
+    // wallets, or a fresh create/import where the user skipped the password
+    // step) must NEVER auto-lock — `idleLockConfig.enabled` is only ever set
+    // true inside setSessionPassword()'s truthy-password branch, and is
+    // forced back to false by lock()/deleteWallet() (via setSessionPassword
+    // (null)) and by the initial state. `!isLocked` is redundant-but-safe:
+    // every path that sets isLocked true (lock(), and initialize()'s
+    // DECRYPTION_ERROR classification) also clears/never-set the password.
+    enabled: idleLockConfig.enabled && !isLocked,
+    onIdle: () => {
+      // Tell every other tab to lock too, THEN lock this one (order doesn't
+      // matter for correctness — subscribeLockBroadcast below ignores our own
+      // broadcastLock() since it's a fresh BroadcastChannel instance per call
+      // and this tab isn't subscribed to its own post — but keeping broadcast
+      // first means other tabs start locking sooner).
+      broadcastLock();
+      void lock();
+    },
+  });
+
+  // Cross-tab lock (#449 Task 8a): a lock triggered in ANY tab — idle timeout
+  // or an explicit lock() — must lock this one too, so a decrypted Sphere
+  // instance never stays alive in one tab after another tab locked.
+  useEffect(() => subscribeLockBroadcast(undefined, () => { void lock(); }), [lock]);
 
   const finalizeWallet = useCallback((importedSphere?: Sphere) => {
     if (importedSphere) {

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -806,6 +806,12 @@ export function SphereProvider({
       sendWelcomeDM(importedSphere);
     }
     setWalletExists(true);
+    // Clear a stale lock flag: finalizeWallet() is also the exit of the
+    // UnlockScreen's "forgot password → restore from recovery phrase" path
+    // (#449). Without this, isLocked would stay true forever after a
+    // successful restore and the shell gate would keep showing the lock
+    // screen instead of the freshly-restored wallet.
+    setIsLocked(false);
     // The onboarding oracle was built KEYLESS. Wire the subscription key onto this
     // live instance exactly like initialize() does for an existing wallet: resolve
     // / provision it + apply via setOracleApiKey (no full re-init), attach the

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -746,6 +746,9 @@ export function SphereProvider({
   const unlock = useCallback(async (password: string) => {
     if (!providers) throw new Error('Providers not initialized');
     const gen = ++initGenRef.current;
+    // Snapshot the resolved oracle key exactly like initialize() does, for the
+    // post-adopt subscription-key wiring below.
+    const oracleApiKey = getActiveOracleApiKey();
     const { sphere: instance } = await Sphere.init({
       ...providers,
       network,
@@ -757,8 +760,31 @@ export function SphereProvider({
       sphereRef.current = inst;
       setSphere(inst);
     });
-    if (outcome === 'adopted') setIsLocked(false);
-  }, [providers, network]);
+    if (outcome !== 'adopted') return;
+    setIsLocked(false);
+
+    // Mirror initialize()'s existing-wallet success branch (review parity, #449):
+    // the destroyed instance took its `identity:changed` reconcile listener with
+    // it, so without re-attaching it here a post-unlock address switch would
+    // silently stop reconciling the per-wallet subscription key. Deliberately
+    // does NOT call sendWelcomeDM — a re-unlock must not re-welcome the user.
+    setSubscriptionKeyStatus(
+      !SUBSCRIPTION_ENABLED ? 'not-required' : oracleApiKey ? 'ready' : 'provisioning',
+    );
+    setupSubscriptionKey(instance, oracleApiKey);
+
+    // Run address discovery in background after wallet is visible, same as initialize().
+    setIsDiscoveringAddresses(true);
+    instance.discoverAddresses({ autoTrack: true }).then(result => {
+      if (result.addresses.length > 0) {
+        logger.debug('SphereProvider', `Discovered ${result.addresses.length} address(es)`);
+      }
+    }).catch(err => {
+      logger.warn('SphereProvider', 'Address discovery failed', err);
+    }).finally(() => {
+      setIsDiscoveringAddresses(false);
+    });
+  }, [providers, network, setupSubscriptionKey]);
 
   // Lock the wallet: destroy the live Sphere instance (keys leave memory —
   // a real lock, not just a UI gate) and require unlock() again.

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -15,6 +15,7 @@ import {
   getPublicKey,
   STORAGE_KEYS_GLOBAL,
   validateMnemonic,
+  decryptMnemonic,
 } from '@unicitylabs/sphere-sdk';
 import { sendWelcomeDM } from './welcomeDM';
 import { adoptOrDiscardInstance } from './adoptOrDiscardInstance';
@@ -1031,6 +1032,26 @@ export function SphereProvider({
     });
   }, [providers, setSessionPassword]);
 
+  // In-wallet backup gate (#449): read-only password check used by
+  // BackupWalletModal before it reveals "Export Wallet File" / "Show
+  // Recovery Phrase" (both expose the seed). Deliberately independent of
+  // passwordRef/setSessionPassword — this must work purely by re-deriving
+  // from on-disk storage, never mutates anything, and never persists the
+  // candidate password anywhere. Any failure (missing providers, no stored
+  // mnemonic, wrong password, corrupt blob) resolves false — never throws to
+  // the caller.
+  const verifyWalletPassword = useCallback(async (password: string): Promise<boolean> => {
+    if (!providers) return false;
+    try {
+      const stored = await providers.storage.get(STORAGE_KEYS_GLOBAL.MNEMONIC);
+      if (!stored) return false;
+      const decrypted = decryptMnemonic(stored, password);
+      return validateMnemonic(decrypted);
+    } catch {
+      return false;
+    }
+  }, [providers]);
+
   // Settings → Security auto-lock timeout selector. Only meaningful while a
   // session password is held (the persisted blob is encrypted with it) — a
   // no-op without one, since there's nothing to arm.
@@ -1156,6 +1177,7 @@ export function SphereProvider({
     setWalletPassword,
     changeWalletPassword,
     removeWalletPassword,
+    verifyWalletPassword,
     autoLockMinutes,
     setAutoLockTimeout,
     isDiscoveringAddresses,

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -260,8 +260,10 @@ export function SphereProvider({
   const [walletExists, setWalletExists] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   // True when an encrypted wallet exists on disk but hasn't been unlocked with
-  // its password this session (SDK DECRYPTION_ERROR on init) — locked, not
-  // broken (#449). Only a real DECRYPTION_ERROR may flip this true.
+  // its password this session — locked, not broken (#449). The SDK signals
+  // this as SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR') on a
+  // passwordless init of an encrypted wallet (see isDecryptionError.ts for the
+  // code-verified detail); only that real signal may flip this true.
   const [isLocked, setIsLocked] = useState(false);
   const [ipfsEnabled, setIpfsEnabled] = useState(isIpfsEnabled);
   const [isDiscoveringAddresses, setIsDiscoveringAddresses] = useState(false);
@@ -538,7 +540,8 @@ export function SphereProvider({
         // Never pass a `password` on this normal load path — an existing
         // plaintext wallet must keep loading exactly as before. If the wallet
         // IS encrypted, this deliberately-passwordless init throws
-        // DECRYPTION_ERROR, which we read as "locked", not a fatal error (#449).
+        // SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR'), which we
+        // read as "locked", not a fatal error (#449) — see isDecryptionError.ts.
         let instance: Sphere;
         try {
           ({ sphere: instance } = await Sphere.init({
@@ -554,9 +557,9 @@ export function SphereProvider({
             if (isStale()) return;
             setIsLocked(true);
             // The wallet is definitely password-protected (that's WHY the
-            // passwordless init just threw DECRYPTION_ERROR) — no need for
-            // the storage round-trip, but reuse the shared setter for a
-            // single source of truth.
+            // passwordless init just threw the decrypt-mnemonic STORAGE_ERROR)
+            // — no need for the storage round-trip, but reuse the shared
+            // setter for a single source of truth.
             void refreshHasWalletPassword(browserProviders.storage);
             return;
           }
@@ -693,8 +696,9 @@ export function SphereProvider({
         // #449 no-wallet-loss guard: Sphere.init({autoGenerate:true}) only
         // creates a fresh wallet when NONE exists on disk — if the storage
         // already holds an encrypted wallet, Sphere.init delegates to
-        // Sphere.load(), which throws DECRYPTION_ERROR when (as here) no
-        // password was supplied. That is a LOCKED, still-recoverable wallet,
+        // Sphere.load(), which throws SphereError('Failed to decrypt
+        // mnemonic', 'STORAGE_ERROR') when (as here) no password was
+        // supplied. That is a LOCKED, still-recoverable wallet,
         // not a broken create — never run the destructive cleanup for it.
         // The onboarding UI's lock-escape routing (CreateWalletFlow's
         // fromLock/goToStart) should prevent "Create New Wallet" from ever
@@ -891,8 +895,9 @@ export function SphereProvider({
 
   // Unlock an encrypted wallet with its password. Re-runs Sphere.init WITH the
   // password (the only place a password is ever passed for an EXISTING
-  // wallet); a wrong password throws DECRYPTION_ERROR, which we let propagate
-  // so the caller (UnlockScreen) can show "wrong password". Reuses the same
+  // wallet); a wrong password throws the same decrypt-mnemonic STORAGE_ERROR
+  // as the cold-start check, which we let propagate so the caller
+  // (UnlockScreen) can show "wrong password" via isDecryptionError. Reuses the same
   // initGenRef/adoptOrDiscardInstance re-entrancy guard as initialize() (#453)
   // so an unlock superseded mid-flight destroys its instance instead of
   // adopting it.
@@ -1046,7 +1051,8 @@ export function SphereProvider({
     // forced back to false by lock()/deleteWallet() (via setSessionPassword
     // (null)) and by the initial state. `!isLocked` is redundant-but-safe:
     // every path that sets isLocked true (lock(), and initialize()'s
-    // DECRYPTION_ERROR classification) also clears/never-set the password.
+    // classifyInitFailure() === 'locked' branch) also clears/never-set the
+    // password.
     enabled: idleLockConfig.enabled && !isLocked,
     onIdle: () => {
       // Tell every other tab to lock too, THEN lock this one. Order doesn't

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -200,6 +200,46 @@ async function cleanupOnError(providers: BrowserProviders): Promise<void> {
   await Promise.race([clearDone, new Promise(r => setTimeout(r, 3000))]);
 }
 
+/**
+ * Read the auto-lock timeout currently in effect so it can be carried across
+ * a Set/Change password operation (#449 review fix — correctness). The
+ * persisted blob (STORAGE_KEYS.AUTO_LOCK_TIMEOUT) is encrypted with whatever
+ * password was active BEFORE the change, so decoding it needs THAT password,
+ * not the new one. `oldPassword` is `null` for Set (no session password
+ * exists yet — the wallet was plaintext), in which case there is nothing
+ * decryptable and this simply returns the secure default, same as
+ * decodeLockSettings' own fallback.
+ */
+function readCurrentAutoLockMinutes(oldPassword: string | null): AutoLockValue {
+  if (!oldPassword) return DEFAULT_AUTO_LOCK_MINUTES;
+  const blob = localStorage.getItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT);
+  return blob ? decodeLockSettings(blob, oldPassword) : DEFAULT_AUTO_LOCK_MINUTES;
+}
+
+/**
+ * Serialize Set/Change/Remove password operations (#449 review fix —
+ * re-entrancy): reencryptStoredMnemonic does a non-atomic read → write →
+ * read-back-verify cycle against the SAME storage key, so two overlapping
+ * calls (a rapid double-submit / Enter-mash getting past the UI's `busy`
+ * guard) could interleave and stomp on each other. This ref-based mutex is
+ * the actual load-bearing guarantee, independent of any UI guard: it rejects
+ * a second call outright instead of letting it run concurrently.
+ */
+async function withPasswordOpLock(
+  busyRef: { current: boolean },
+  fn: () => Promise<void>,
+): Promise<void> {
+  if (busyRef.current) {
+    throw new Error('A password change is already in progress');
+  }
+  busyRef.current = true;
+  try {
+    await fn();
+  } finally {
+    busyRef.current = false;
+  }
+}
+
 // =============================================================================
 // Provider component
 // =============================================================================
@@ -237,6 +277,9 @@ export function SphereProvider({
   // Set on a successful unlock() and on createWallet()/importWallet() when the
   // caller chose an at-rest password; cleared on lock() and deleteWallet().
   const passwordRef = useRef<string | null>(null);
+  // Re-entrancy guard for setWalletPassword/changeWalletPassword/
+  // removeWalletPassword (#449 review fix) — see withPasswordOpLock above.
+  const passwordOpBusyRef = useRef(false);
   // Idle-auto-lock config derived from the password, computed ONCE per
   // setSessionPassword() call rather than on every render: decodeLockSettings
   // runs a PBKDF2 derivation (100k iterations — see sphere-sdk
@@ -926,35 +969,61 @@ export function SphereProvider({
   // wipe the token DB. This touches ONLY the mnemonic storage key.
   const setWalletPassword = useCallback(async (newPassword: string) => {
     if (!providers) throw new Error('Providers not initialized');
-    await reencryptStoredMnemonic(providers.storage, {
-      currentPassword: passwordRef.current,
-      newPassword,
+    await withPasswordOpLock(passwordOpBusyRef, async () => {
+      // Read BEFORE re-encrypting: preserve whatever auto-lock timeout is
+      // currently in effect so it survives this password change instead of
+      // silently resetting to the default (#449 review fix). There is no
+      // session password yet on the Set path (passwordRef.current is null),
+      // so this resolves to the secure default unless a stray blob exists.
+      const preservedMinutes = readCurrentAutoLockMinutes(passwordRef.current);
+      await reencryptStoredMnemonic(providers.storage, {
+        currentPassword: passwordRef.current,
+        newPassword,
+      });
+      // Re-persist the preserved timeout under the NEW password BEFORE
+      // arming the session, so setSessionPassword's own blob read below
+      // decodes correctly on the first try instead of falling back to the
+      // default (order matters here).
+      localStorage.setItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT, encodeLockSettings(preservedMinutes, newPassword));
+      setSessionPassword(newPassword); // memory-only; arms idle auto-lock with the preserved value
+      setHasWalletPassword(true);
     });
-    setSessionPassword(newPassword); // memory-only; arms idle auto-lock
-    setHasWalletPassword(true);
   }, [providers, setSessionPassword]);
 
   const changeWalletPassword = useCallback(async (currentPassword: string, newPassword: string) => {
     if (!providers) throw new Error('Providers not initialized');
-    // reencryptStoredMnemonic itself verifies currentPassword (decrypts +
-    // validateMnemonic) and throws "Incorrect current password" on mismatch —
-    // nothing is written unless it matches.
-    await reencryptStoredMnemonic(providers.storage, {
-      currentPassword,
-      newPassword,
+    await withPasswordOpLock(passwordOpBusyRef, async () => {
+      // Same preserve-across-change fix as setWalletPassword, using the
+      // caller-verified currentPassword to decode the existing blob (#449
+      // review fix).
+      const preservedMinutes = readCurrentAutoLockMinutes(currentPassword);
+      // reencryptStoredMnemonic itself verifies currentPassword (decrypts +
+      // validateMnemonic) and throws "Incorrect current password" on mismatch —
+      // nothing is written unless it matches.
+      await reencryptStoredMnemonic(providers.storage, {
+        currentPassword,
+        newPassword,
+      });
+      localStorage.setItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT, encodeLockSettings(preservedMinutes, newPassword));
+      setSessionPassword(newPassword); // re-arms the idle timer with the preserved value
+      setHasWalletPassword(true);
     });
-    setSessionPassword(newPassword);
-    setHasWalletPassword(true);
   }, [providers, setSessionPassword]);
 
   const removeWalletPassword = useCallback(async (currentPassword: string) => {
     if (!providers) throw new Error('Providers not initialized');
-    await reencryptStoredMnemonic(providers.storage, {
-      currentPassword,
-      newPassword: null,
+    await withPasswordOpLock(passwordOpBusyRef, async () => {
+      await reencryptStoredMnemonic(providers.storage, {
+        currentPassword,
+        newPassword: null,
+      });
+      // Deliberately does NOT preserve the auto-lock timeout blob: removing
+      // the password disarms auto-lock entirely (no password left to
+      // encrypt it with), so the stale blob is simply orphaned until a
+      // future Set writes a fresh one.
+      setSessionPassword(null); // memory-only; disarms idle auto-lock
+      setHasWalletPassword(false);
     });
-    setSessionPassword(null); // memory-only; disarms idle auto-lock
-    setHasWalletPassword(false);
   }, [providers, setSessionPassword]);
 
   // Settings → Security auto-lock timeout selector. Only meaningful while a

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -876,11 +876,17 @@ export function SphereProvider({
     // DECRYPTION_ERROR classification) also clears/never-set the password.
     enabled: idleLockConfig.enabled && !isLocked,
     onIdle: () => {
-      // Tell every other tab to lock too, THEN lock this one (order doesn't
-      // matter for correctness — subscribeLockBroadcast below ignores our own
-      // broadcastLock() since it's a fresh BroadcastChannel instance per call
-      // and this tab isn't subscribed to its own post — but keeping broadcast
-      // first means other tabs start locking sooner).
+      // Tell every other tab to lock too, THEN lock this one. Order doesn't
+      // matter for correctness, but NOTE: a same-name BroadcastChannel DOES
+      // receive its own tab's postMessage (it's a fresh instance per call,
+      // but same-tab loopback still happens) — so subscribeLockBroadcast
+      // below will ALSO fire for this tab's own broadcastLock(), meaning
+      // lock() can run twice here in the triggering tab. That's safe only
+      // because lock() and notifyWalletLocked() are intentionally idempotent
+      // (destroying an already-null sphereRef, re-notifying an already-locked
+      // dApp, etc. are all harmless no-ops/re-sends) — do not remove those
+      // guards. Keeping broadcast first just means other tabs start locking
+      // sooner.
       broadcastLock();
       void lock();
     },

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -6,13 +6,29 @@ import {
   type ReactNode,
 } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError, getPublicKey } from '@unicitylabs/sphere-sdk';
+import {
+  Sphere,
+  TokenRegistry,
+  NETWORKS,
+  logger,
+  isSphereError,
+  getPublicKey,
+  STORAGE_KEYS_GLOBAL,
+  validateMnemonic,
+} from '@unicitylabs/sphere-sdk';
 import { sendWelcomeDM } from './welcomeDM';
 import { adoptOrDiscardInstance } from './adoptOrDiscardInstance';
 import { classifyInitFailure } from './walletLock/classifyInitFailure';
 import { useIdleTimer } from './walletLock/useIdleTimer';
-import { decodeLockSettings, autoLockMs, DEFAULT_AUTO_LOCK_MINUTES } from './walletLock/lockSettings';
+import {
+  decodeLockSettings,
+  encodeLockSettings,
+  autoLockMs,
+  DEFAULT_AUTO_LOCK_MINUTES,
+  type AutoLockValue,
+} from './walletLock/lockSettings';
 import { broadcastLock, subscribeLockBroadcast } from './walletLock/lockBroadcast';
+import { reencryptStoredMnemonic } from './walletLock/reencryptMnemonic';
 import { getActiveConnectHost } from './connectHostRegistry';
 import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
@@ -232,15 +248,43 @@ export function SphereProvider({
     enabled: false,
     timeoutMs: null,
   });
+  // Settings → Security (#449 Task 8b): whether the wallet CURRENTLY has an
+  // at-rest password. True the instant a session password is held
+  // (passwordRef), OR — for the cold-start/locked case where no session
+  // password exists yet — when the on-disk mnemonic itself isn't a valid
+  // plaintext mnemonic (i.e. it's the SDK's encrypted form). Kept as its own
+  // state (not derived inline) because the storage check is async.
+  const [hasWalletPassword, setHasWalletPassword] = useState(false);
+  // Auto-lock timeout shown/edited in Settings → Security. Only meaningful
+  // while a session password is held (the stored blob is encrypted with it);
+  // reset to the secure default whenever there is no password.
+  const [autoLockMinutes, setAutoLockMinutesState] = useState<AutoLockValue>(DEFAULT_AUTO_LOCK_MINUTES);
   const setSessionPassword = useCallback((password: string | null) => {
     passwordRef.current = password;
     if (!password) {
       setIdleLockConfig({ enabled: false, timeoutMs: null });
+      setAutoLockMinutesState(DEFAULT_AUTO_LOCK_MINUTES);
       return;
     }
     const storedBlob = localStorage.getItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT);
     const minutes = storedBlob ? decodeLockSettings(storedBlob, password) : DEFAULT_AUTO_LOCK_MINUTES;
     setIdleLockConfig({ enabled: true, timeoutMs: autoLockMs(minutes) });
+    setAutoLockMinutesState(minutes);
+  }, []);
+  // Recompute hasWalletPassword from the on-disk mnemonic — used at cold
+  // start (initialize()) where no session password exists yet to short-circuit
+  // on. A truthy passwordRef always wins without touching storage.
+  const refreshHasWalletPassword = useCallback(async (storage: { get(key: string): Promise<string | null> }) => {
+    if (passwordRef.current) {
+      setHasWalletPassword(true);
+      return;
+    }
+    try {
+      const stored = await storage.get(STORAGE_KEYS_GLOBAL.MNEMONIC);
+      setHasWalletPassword(!!stored && !validateMnemonic(stored));
+    } catch {
+      setHasWalletPassword(false);
+    }
   }, []);
   // Monotonic init generation: only the LATEST initialize() run may adopt its
   // Sphere; a run superseded mid-flight (StrictMode double-mount, IPFS/network
@@ -466,6 +510,11 @@ export function SphereProvider({
             // latest run (or unmount) already owns the outcome (#453).
             if (isStale()) return;
             setIsLocked(true);
+            // The wallet is definitely password-protected (that's WHY the
+            // passwordless init just threw DECRYPTION_ERROR) — no need for
+            // the storage round-trip, but reuse the shared setter for a
+            // single source of truth.
+            void refreshHasWalletPassword(browserProviders.storage);
             return;
           }
           throw initErr;
@@ -479,6 +528,7 @@ export function SphereProvider({
         });
         if (outcome === 'discarded') return;
         setInitProgress(null);
+        void refreshHasWalletPassword(browserProviders.storage);
 
         // Readiness for the send gate: 'ready' iff this oracle was built WITH a
         // subscription key. With no key yet we provision below and stay
@@ -551,7 +601,7 @@ export function SphereProvider({
         setIsLoading(false);
       }
     }
-  }, [network, setupSubscriptionKey]);
+  }, [network, setupSubscriptionKey, refreshHasWalletPassword]);
 
   useEffect(() => {
     initialize();
@@ -788,6 +838,9 @@ export function SphereProvider({
     // wallet that no longer exists (it would otherwise fire mid-onboarding and
     // wrongly gate the onboarding UI behind an unlock screen). See #449.
     setSessionPassword(null);
+    // The deleted wallet's on-disk password state is gone with it — a fresh
+    // onboarding starts with no password until the user (re-)sets one.
+    setHasWalletPassword(false);
 
     // Reinitialize with fresh providers (skip loading spinner — onboarding UI is already visible)
     await initialize(0, true);
@@ -821,6 +874,8 @@ export function SphereProvider({
     // Memory-only (#449 Task 8a) — never persisted. Powers idle auto-lock.
     setSessionPassword(password);
     setIsLocked(false);
+    // A successful unlock proves the wallet has a password (that's WHY it was locked).
+    setHasWalletPassword(true);
 
     // Mirror initialize()'s existing-wallet success branch (review parity, #449):
     // the destroyed instance took its `identity:changed` reconcile listener with
@@ -862,6 +917,55 @@ export function SphereProvider({
     // Memory-only password never survives a lock (#449).
     setSessionPassword(null);
     setIsLocked(true);
+  }, [setSessionPassword]);
+
+  // Settings → Security (#449 Task 8b): set/change/remove the wallet's at-rest
+  // password via the VERIFIED-SAFE in-place mnemonic re-encryption
+  // (reencryptStoredMnemonic — src/sdk/walletLock/reencryptMnemonic.ts).
+  // CRITICAL: never call Sphere.import()/Sphere.clear() to do this — those
+  // wipe the token DB. This touches ONLY the mnemonic storage key.
+  const setWalletPassword = useCallback(async (newPassword: string) => {
+    if (!providers) throw new Error('Providers not initialized');
+    await reencryptStoredMnemonic(providers.storage, {
+      currentPassword: passwordRef.current,
+      newPassword,
+    });
+    setSessionPassword(newPassword); // memory-only; arms idle auto-lock
+    setHasWalletPassword(true);
+  }, [providers, setSessionPassword]);
+
+  const changeWalletPassword = useCallback(async (currentPassword: string, newPassword: string) => {
+    if (!providers) throw new Error('Providers not initialized');
+    // reencryptStoredMnemonic itself verifies currentPassword (decrypts +
+    // validateMnemonic) and throws "Incorrect current password" on mismatch —
+    // nothing is written unless it matches.
+    await reencryptStoredMnemonic(providers.storage, {
+      currentPassword,
+      newPassword,
+    });
+    setSessionPassword(newPassword);
+    setHasWalletPassword(true);
+  }, [providers, setSessionPassword]);
+
+  const removeWalletPassword = useCallback(async (currentPassword: string) => {
+    if (!providers) throw new Error('Providers not initialized');
+    await reencryptStoredMnemonic(providers.storage, {
+      currentPassword,
+      newPassword: null,
+    });
+    setSessionPassword(null); // memory-only; disarms idle auto-lock
+    setHasWalletPassword(false);
+  }, [providers, setSessionPassword]);
+
+  // Settings → Security auto-lock timeout selector. Only meaningful while a
+  // session password is held (the persisted blob is encrypted with it) — a
+  // no-op without one, since there's nothing to arm.
+  const setAutoLockTimeout = useCallback((value: AutoLockValue) => {
+    const password = passwordRef.current;
+    if (!password) return;
+    localStorage.setItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT, encodeLockSettings(value, password));
+    // Re-read the (now-updated) blob and re-arm the idle timer with it.
+    setSessionPassword(password);
   }, [setSessionPassword]);
 
   useIdleTimer({
@@ -911,6 +1015,11 @@ export function SphereProvider({
     // successful restore and the shell gate would keep showing the lock
     // screen instead of the freshly-restored wallet.
     setIsLocked(false);
+    // Reflect whatever createWallet()/importWallet() decided: they already
+    // called setSessionPassword() (passwordRef) iff the user chose a password
+    // during onboarding/import — mirror that into hasWalletPassword now that
+    // the wallet is live in Settings.
+    setHasWalletPassword(!!passwordRef.current);
     // The onboarding oracle was built KEYLESS. Wire the subscription key onto this
     // live instance exactly like initialize() does for an existing wallet: resolve
     // / provision it + apply via setOracleApiKey (no full re-init), attach the
@@ -968,6 +1077,12 @@ export function SphereProvider({
     isLocked,
     unlock,
     lock,
+    hasWalletPassword,
+    setWalletPassword,
+    changeWalletPassword,
+    removeWalletPassword,
+    autoLockMinutes,
+    setAutoLockTimeout,
     isDiscoveringAddresses,
     initProgress,
     resolveNametag,

--- a/src/sdk/connectHostRegistry.ts
+++ b/src/sdk/connectHostRegistry.ts
@@ -1,0 +1,24 @@
+import type { ConnectHost } from '@unicitylabs/sphere-sdk/connect';
+
+/**
+ * Bridges the live ConnectHost instance up to `SphereProvider.lock()` (#449
+ * Task 8a: dApp notify on lock).
+ *
+ * `ConnectHost` is created and owned by `ConnectProvider`
+ * (src/components/connect/ConnectProvider.tsx), which is mounted as a
+ * DESCENDANT of `SphereProvider` in the app tree (see src/main.tsx). React
+ * context only flows downward, so `SphereProvider` cannot `useContext` a
+ * context provided further down the tree — this tiny module-scoped mirror is
+ * the bridge instead. `ConnectProvider.setConnectHost()` keeps it in sync;
+ * `SphereProvider.lock()` reads it to notify the connected dApp (if any)
+ * BEFORE destroying the Sphere instance.
+ */
+let activeConnectHost: ConnectHost | null = null;
+
+export function setActiveConnectHost(host: ConnectHost | null): void {
+  activeConnectHost = host;
+}
+
+export function getActiveConnectHost(): ConnectHost | null {
+  return activeConnectHost;
+}

--- a/src/sdk/walletLock/classifyInitFailure.ts
+++ b/src/sdk/walletLock/classifyInitFailure.ts
@@ -1,0 +1,6 @@
+import { isDecryptionError } from './isDecryptionError';
+
+/** A DECRYPTION_ERROR means the wallet is encrypted and locked, not broken. */
+export function classifyInitFailure(err: unknown): 'locked' | 'error' {
+  return isDecryptionError(err) ? 'locked' : 'error';
+}

--- a/src/sdk/walletLock/isDecryptionError.ts
+++ b/src/sdk/walletLock/isDecryptionError.ts
@@ -1,0 +1,13 @@
+/**
+ * True when an error is the SDK's DECRYPTION_ERROR — i.e. an encrypted wallet
+ * was opened with a wrong/missing password. This is a "wallet is locked"
+ * signal, not a failure. See #449.
+ */
+export function isDecryptionError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === 'DECRYPTION_ERROR'
+  );
+}

--- a/src/sdk/walletLock/isDecryptionError.ts
+++ b/src/sdk/walletLock/isDecryptionError.ts
@@ -1,13 +1,37 @@
+import { isSphereError } from '@unicitylabs/sphere-sdk';
+
 /**
- * True when an error is the SDK's DECRYPTION_ERROR — i.e. an encrypted wallet
- * was opened with a wrong/missing password. This is a "wallet is locked"
- * signal, not a failure. See #449.
+ * True when an error is a "wallet is locked" signal — i.e. an encrypted
+ * wallet was opened with a wrong/missing password — not a failure. See #449.
+ *
+ * CODE-VERIFIED against @unicitylabs/sphere-sdk@0.12.0
+ * (node_modules/@unicitylabs/sphere-sdk/dist/core/index.cjs): a mnemonic
+ * decrypt failure does NOT throw `DECRYPTION_ERROR`. `Sphere#decrypt()`
+ * swallows the internal DECRYPTION_ERROR itself (`catch { return null }`),
+ * and `loadIdentityFromStorage()` (the loader both the passwordless
+ * cold-start check AND unlock(password) run through — Sphere.init() delegates
+ * to Sphere.load() → loadIdentityFromStorage() for an existing wallet) then
+ * re-throws:
+ *   throw new SphereError("Failed to decrypt mnemonic", "STORAGE_ERROR");
+ * So the REAL signal is a SphereError with code STORAGE_ERROR whose message
+ * names a mnemonic-decrypt failure — matched by message text, not code alone,
+ * so a GENUINE IndexedDB STORAGE_ERROR (no decrypt-mnemonic message) is never
+ * misclassified as "locked".
+ *
+ * The literal `code === 'DECRYPTION_ERROR'` check is kept too, defensively,
+ * in case a future SDK version throws that code directly for this case.
  */
 export function isDecryptionError(err: unknown): boolean {
-  return (
+  if (
     typeof err === 'object' &&
     err !== null &&
     'code' in err &&
     (err as { code?: unknown }).code === 'DECRYPTION_ERROR'
-  );
+  ) {
+    return true;
+  }
+  if (isSphereError(err) && err.code === 'STORAGE_ERROR') {
+    return /decrypt/i.test(err.message) && /mnemonic/i.test(err.message);
+  }
+  return false;
 }

--- a/src/sdk/walletLock/lockBroadcast.ts
+++ b/src/sdk/walletLock/lockBroadcast.ts
@@ -1,0 +1,35 @@
+/**
+ * Cross-tab lock signal (#449 Task 8a). Idle auto-lock and an explicit
+ * `lock()` in one tab must lock every other open tab immediately — otherwise
+ * a tab that's still "active" (no local idle timer firing) would keep a
+ * decrypted Sphere instance alive in memory after another tab decided to
+ * lock. Pure module, no React: BroadcastChannel only, guarded for
+ * environments where it doesn't exist.
+ */
+const DEFAULT_CHANNEL_NAME = 'sphere-wallet-lock';
+const LOCK_MESSAGE = 'lock';
+
+/** Tell every other tab to lock. No-op where BroadcastChannel is unavailable. */
+export function broadcastLock(channelName: string = DEFAULT_CHANNEL_NAME): void {
+  if (typeof BroadcastChannel === 'undefined') return;
+  const channel = new BroadcastChannel(channelName);
+  channel.postMessage(LOCK_MESSAGE);
+  channel.close();
+}
+
+/**
+ * Call `onLock` whenever another tab broadcasts a lock. Returns an
+ * unsubscribe function. No-op subscription (unsubscribe is still safe to
+ * call) where BroadcastChannel is unavailable.
+ */
+export function subscribeLockBroadcast(
+  channelName: string = DEFAULT_CHANNEL_NAME,
+  onLock: () => void,
+): () => void {
+  if (typeof BroadcastChannel === 'undefined') return () => {};
+  const channel = new BroadcastChannel(channelName);
+  channel.onmessage = (event: MessageEvent) => {
+    if (event.data === LOCK_MESSAGE) onLock();
+  };
+  return () => channel.close();
+}

--- a/src/sdk/walletLock/lockSettings.ts
+++ b/src/sdk/walletLock/lockSettings.ts
@@ -1,0 +1,32 @@
+import { encrypt, decryptJson } from '@unicitylabs/sphere-sdk';
+
+/**
+ * Auto-lock timeout, persisted encrypted with the wallet password so a
+ * cold-storage/localStorage tamper can't silently disable or shorten it. See #449.
+ */
+export const AUTO_LOCK_OPTIONS = [1, 5, 15, 30, 'never'] as const;
+export type AutoLockValue = (typeof AUTO_LOCK_OPTIONS)[number];
+export const DEFAULT_AUTO_LOCK_MINUTES = 15;
+
+function isValid(v: unknown): v is AutoLockValue {
+  return v === 'never' || (typeof v === 'number' && [1, 5, 15, 30].includes(v));
+}
+
+/** Encrypt the timeout with the wallet password so it can't be tampered from cold storage. */
+export function encodeLockSettings(minutes: AutoLockValue, password: string): string {
+  return JSON.stringify(encrypt({ autoLockMinutes: minutes }, password));
+}
+
+/** Decrypt the timeout; any failure or invalid value → the secure default. */
+export function decodeLockSettings(blob: string, password: string): AutoLockValue {
+  try {
+    const data = decryptJson<{ autoLockMinutes: unknown }>(JSON.parse(blob), password);
+    return isValid(data.autoLockMinutes) ? data.autoLockMinutes : DEFAULT_AUTO_LOCK_MINUTES;
+  } catch {
+    return DEFAULT_AUTO_LOCK_MINUTES;
+  }
+}
+
+export function autoLockMs(minutes: AutoLockValue): number | null {
+  return minutes === 'never' ? null : minutes * 60 * 1000;
+}

--- a/src/sdk/walletLock/reencryptMnemonic.ts
+++ b/src/sdk/walletLock/reencryptMnemonic.ts
@@ -1,0 +1,81 @@
+import {
+  STORAGE_KEYS_GLOBAL,
+  encryptMnemonic,
+  decryptMnemonic,
+  validateMnemonic,
+  type StorageProvider,
+} from '@unicitylabs/sphere-sdk';
+
+/**
+ * VERIFIED-SAFE in-place re-encryption of the wallet mnemonic (#449 Settings →
+ * Security: Set/Change/Remove password). This is the ONLY sanctioned mechanism
+ * for changing a wallet's at-rest password — it touches ONLY the mnemonic key
+ * at `STORAGE_KEYS_GLOBAL.MNEMONIC`; the token DB, transaction history and
+ * everything else are never read or written. There is deliberately NO
+ * `Sphere.clear()` / `Sphere.import()` involved (those would wipe the token DB).
+ *
+ * Why this is safe: the SDK's own `Sphere` class persists the mnemonic as
+ * `this.encrypt(mnemonic)`, where internally
+ * `encrypt = (data) => password ? encryptSimple(data, password) : data` — i.e.
+ * plaintext when there's no password, AES-encrypted (via `encryptSimple`) when
+ * there is. The exported `encryptMnemonic`/`decryptMnemonic` are literally
+ * `encryptSimple`/`decryptSimple` (see sphere-sdk core/encryption.ts) — the
+ * SAME format the SDK reads back on `Sphere.init`/`Sphere.load`. So writing
+ * `encryptMnemonic(mnemonic, newPassword)` (or the bare mnemonic when removing
+ * the password) to that one key reproduces exactly what the SDK itself would
+ * have written, and the wallet loads unchanged next time.
+ */
+export async function reencryptStoredMnemonic(
+  storage: Pick<StorageProvider, 'get' | 'set'>,
+  opts: { currentPassword: string | null; newPassword: string | null },
+): Promise<void> {
+  const stored = await storage.get(STORAGE_KEYS_GLOBAL.MNEMONIC);
+  if (!stored) {
+    throw new Error('No wallet mnemonic found in storage — nothing to protect');
+  }
+
+  // Recover the plaintext mnemonic.
+  let mnemonic: string;
+  if (opts.currentPassword === null) {
+    // No current password: the stored value must already be a plaintext
+    // mnemonic (mirrors the SDK's own decrypt() fallback — see
+    // core/encryption.ts: no password + validateMnemonic(encrypted) => as-is).
+    if (!validateMnemonic(stored)) {
+      throw new Error('Wallet is password-protected — the current password is required');
+    }
+    mnemonic = stored;
+  } else {
+    let decrypted: string;
+    try {
+      decrypted = decryptMnemonic(stored, opts.currentPassword);
+    } catch {
+      throw new Error('Incorrect current password');
+    }
+    if (!validateMnemonic(decrypted)) {
+      throw new Error('Incorrect current password');
+    }
+    mnemonic = decrypted;
+  }
+
+  const newValue = opts.newPassword ? encryptMnemonic(mnemonic, opts.newPassword) : mnemonic;
+  await storage.set(STORAGE_KEYS_GLOBAL.MNEMONIC, newValue);
+
+  // READ-BACK VERIFY (wallet-loss safety, non-negotiable): re-read the key we
+  // just wrote and confirm it decrypts back to the EXACT SAME mnemonic before
+  // trusting the write. If anything about this check fails — a storage layer
+  // that silently dropped the write, a corrupted value, a wrong assumption
+  // about the on-disk format — RESTORE the original stored value and throw.
+  // The mnemonic key must never be left in a state nothing can read back.
+  try {
+    const readBack = await storage.get(STORAGE_KEYS_GLOBAL.MNEMONIC);
+    if (readBack === null) throw new Error('read-back returned no value');
+    const recovered = opts.newPassword ? decryptMnemonic(readBack, opts.newPassword) : readBack;
+    if (recovered !== mnemonic || !validateMnemonic(recovered)) {
+      throw new Error('read-back mnemonic does not match');
+    }
+  } catch (verifyErr) {
+    await storage.set(STORAGE_KEYS_GLOBAL.MNEMONIC, stored);
+    const reason = verifyErr instanceof Error ? verifyErr.message : String(verifyErr);
+    throw new Error(`Password change verification failed — original wallet data restored (${reason})`);
+  }
+}

--- a/src/sdk/walletLock/useIdleTimer.ts
+++ b/src/sdk/walletLock/useIdleTimer.ts
@@ -23,7 +23,8 @@ export function useIdleTimer(opts: {
     const channelName = opts.channelName ?? 'sphere-wallet-activity';
 
     let timer: ReturnType<typeof setTimeout>;
-    let lastBroadcast = 0;
+    // -Infinity so the very first activity is never throttle-gated (see #449 review).
+    let lastBroadcast = -Infinity;
     const channel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(channelName) : null;
 
     const arm = () => {

--- a/src/sdk/walletLock/useIdleTimer.ts
+++ b/src/sdk/walletLock/useIdleTimer.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+
+const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'click', 'touchstart', 'scroll'] as const;
+const THROTTLE_MS = 1000;
+
+/**
+ * Fires `onIdle` after `timeoutMs` with no user activity in ANY tab. Activity is
+ * shared across tabs via BroadcastChannel so an idle background tab never locks
+ * an actively-used one. No-op when disabled or timeoutMs is null. See #449.
+ */
+export function useIdleTimer(opts: {
+  timeoutMs: number | null;
+  enabled: boolean;
+  onIdle: () => void;
+  channelName?: string;
+}): void {
+  const onIdleRef = useRef(opts.onIdle);
+  onIdleRef.current = opts.onIdle;
+
+  useEffect(() => {
+    if (!opts.enabled || opts.timeoutMs == null) return;
+    const timeoutMs = opts.timeoutMs;
+    const channelName = opts.channelName ?? 'sphere-wallet-activity';
+
+    let timer: ReturnType<typeof setTimeout>;
+    let lastBroadcast = 0;
+    const channel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(channelName) : null;
+
+    const arm = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => onIdleRef.current(), timeoutMs);
+    };
+    // Local activity: rearm + tell other tabs (throttled).
+    const onLocalActivity = () => {
+      arm();
+      const now = performance.now();
+      if (channel && now - lastBroadcast > THROTTLE_MS) {
+        lastBroadcast = now;
+        channel.postMessage('activity');
+      }
+    };
+    // Remote activity (another tab): rearm only, don't rebroadcast.
+    if (channel) channel.onmessage = () => arm();
+
+    ACTIVITY_EVENTS.forEach((e) => window.addEventListener(e, onLocalActivity, { passive: true }));
+    arm();
+
+    return () => {
+      clearTimeout(timer);
+      ACTIVITY_EVENTS.forEach((e) => window.removeEventListener(e, onLocalActivity));
+      channel?.close();
+    };
+  }, [opts.enabled, opts.timeoutMs, opts.channelName]);
+}

--- a/tests/unit/components/backupWalletModal.test.tsx
+++ b/tests/unit/components/backupWalletModal.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * #449: BackupWalletModal must gate "Export Wallet File" / "Show Recovery
+ * Phrase" (both expose the seed) behind a password prompt whenever the
+ * wallet has an at-rest password (hasWalletPassword === true). Wallets with
+ * no password must see the two options immediately, unchanged.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const sphereMock = vi.hoisted(() => ({
+  hasWalletPassword: true,
+  verifyWalletPassword: vi.fn(),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    hasWalletPassword: sphereMock.hasWalletPassword,
+    verifyWalletPassword: sphereMock.verifyWalletPassword,
+  }),
+}));
+
+import { BackupWalletModal } from '../../../src/components/wallet/shared/modals/BackupWalletModal';
+
+function renderModal() {
+  return render(
+    <BackupWalletModal
+      isOpen
+      onClose={vi.fn()}
+      onExportWalletFile={vi.fn()}
+      onShowRecoveryPhrase={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  sphereMock.hasWalletPassword = true;
+  sphereMock.verifyWalletPassword.mockReset();
+});
+
+describe('BackupWalletModal — password gate (#449)', () => {
+  it('shows a password prompt (not the backup options) when the wallet has a password', () => {
+    renderModal();
+
+    expect(screen.getByLabelText('Password')).toBeDefined();
+    expect(screen.queryByText('Export Wallet File')).toBeNull();
+    expect(screen.queryByText('Show Recovery Phrase')).toBeNull();
+  });
+
+  it('shows "Incorrect password" and stays gated on a wrong password', async () => {
+    sphereMock.verifyWalletPassword.mockResolvedValue(false);
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => expect(screen.getByText(/incorrect password/i)).toBeDefined());
+    expect(sphereMock.verifyWalletPassword).toHaveBeenCalledWith('wrong');
+    expect(screen.queryByText('Export Wallet File')).toBeNull();
+    expect(screen.queryByText('Show Recovery Phrase')).toBeNull();
+  });
+
+  it('reveals the two backup options after a correct password', async () => {
+    sphereMock.verifyWalletPassword.mockResolvedValue(true);
+    renderModal();
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'correct-horse' } });
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => expect(screen.getByText('Export Wallet File')).toBeDefined());
+    expect(screen.getByText('Show Recovery Phrase')).toBeDefined();
+    expect(screen.queryByLabelText('Password')).toBeNull();
+  });
+
+  it('shows the two backup options immediately with no prompt when there is no wallet password', () => {
+    sphereMock.hasWalletPassword = false;
+    renderModal();
+
+    expect(screen.getByText('Export Wallet File')).toBeDefined();
+    expect(screen.getByText('Show Recovery Phrase')).toBeDefined();
+    expect(screen.queryByLabelText('Password')).toBeNull();
+  });
+});

--- a/tests/unit/components/createFlowMnemonicConfirm.test.tsx
+++ b/tests/unit/components/createFlowMnemonicConfirm.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * #449 create-flow reorder: show -> confirm -> password -> download. This is
+ * the real backup-VERIFICATION requirement: after the recovery phrase is
+ * shown, the user must re-enter it and it must match before the flow can
+ * proceed. Covers:
+ *  - the full step order (show → confirm → password → download)
+ *  - the confirm step REJECTS a wrong phrase (stays put, does not advance)
+ *  - the confirm step ACCEPTS the correct phrase (advances to setPassword)
+ *  - "Back" from confirm returns to the show screen to re-view the words
+ *  - skip-password still finalizes a plaintext wallet after a verified backup
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../../../src/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('../../../src/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: false,
+}));
+
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const ctx = vi.hoisted(() => ({
+  importWallet: vi.fn(async () => ({
+    getAllTrackedAddresses: () => [],
+    identity: { nametag: null },
+  })),
+  createWallet: vi.fn(async () => ({
+    mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    sphere: { registerNametag: vi.fn(async () => {}), exportToJSON: vi.fn((opts: unknown) => ({ opts })) },
+  })),
+  finalizeWallet: vi.fn(),
+  resolveNametag: vi.fn(async () => null),
+  importFromFile: vi.fn(),
+  setWalletPassword: vi.fn(async () => {}),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    sphere: null,
+    network: 'testnet2',
+    createWallet: ctx.createWallet,
+    resolveNametag: ctx.resolveNametag,
+    importWallet: ctx.importWallet,
+    importFromFile: ctx.importFromFile,
+    finalizeWallet: ctx.finalizeWallet,
+    walletExists: false,
+    initProgress: null,
+    setWalletPassword: ctx.setWalletPassword,
+  }),
+}));
+
+import { CreateWalletFlow } from '../../../src/components/wallet/onboarding/CreateWalletFlow';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+async function driveToMnemonicShow() {
+  render(<CreateWalletFlow />, { wrapper: Wrapper });
+  fireEvent.click(screen.getByRole('button', { name: /create new wallet/i }));
+  await waitFor(() => expect(screen.getByRole('button', { name: /skip for now/i })).toBeDefined());
+  fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+  await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
+  await waitFor(
+    () => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined(),
+    { timeout: 3000 },
+  );
+}
+
+beforeEach(() => {
+  ctx.importWallet.mockClear();
+  ctx.createWallet.mockClear();
+  ctx.finalizeWallet.mockClear();
+  ctx.setWalletPassword.mockClear();
+  ctx.setWalletPassword.mockImplementation(async () => {});
+});
+
+describe('create flow mnemonic confirmation (#449)', () => {
+  it('proves the full order: show -> confirm -> password -> download -> finalize', async () => {
+    await driveToMnemonicShow();
+
+    // Show step.
+    expect(screen.queryByText(/confirm recovery phrase/i)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    // Confirm step.
+    await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
+    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+
+    // Password step.
+    await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
+    expect(screen.queryByText(/download wallet backup/i)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    // Download step.
+    await waitFor(() => expect(screen.getByText(/download wallet backup/i)).toBeDefined());
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+
+    // Finalize.
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+  });
+
+  it('rejects a wrong phrase on the confirm step — stays put, does not advance to setPassword', async () => {
+    await driveToMnemonicShow();
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+    fireEvent.change(screen.getByLabelText(/recovery phrase/i), {
+      target: { value: 'wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+
+    await waitFor(() => expect(screen.getByText(/doesn't match/i)).toBeDefined());
+    // Still on the confirm screen — never reached setPassword or finalized.
+    expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined();
+    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+    expect(ctx.setWalletPassword).not.toHaveBeenCalled();
+  });
+
+  it('accepts the correct phrase after a prior wrong attempt', async () => {
+    await driveToMnemonicShow();
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: 'nope nope nope' } });
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await waitFor(() => expect(screen.getByText(/doesn't match/i)).toBeDefined());
+
+    // Retry with the correct phrase (also exercises whitespace/case tolerance).
+    fireEvent.change(screen.getByLabelText(/recovery phrase/i), {
+      target: { value: `  ${MNEMONIC.toUpperCase()}  ` },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+
+    await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
+    expect(screen.queryByText(/doesn't match/i)).toBeNull();
+  });
+
+  it('"Back" from the confirm step returns to the show screen to re-view the words', async () => {
+    await driveToMnemonicShow();
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }));
+
+    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
+    // The actual words are shown again (the last, unique word of the mnemonic).
+    expect(screen.getByText('about')).toBeDefined();
+  });
+
+  it('skip-password still finalizes a plaintext wallet after a verified backup', async () => {
+    await driveToMnemonicShow();
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+
+    await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    await waitFor(() => expect(screen.getByText(/download wallet backup/i)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+    expect(ctx.setWalletPassword).not.toHaveBeenCalled();
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+    expect(ctx.createWallet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/createFlowMnemonicConfirm.test.tsx
+++ b/tests/unit/components/createFlowMnemonicConfirm.test.tsx
@@ -74,6 +74,13 @@ async function driveToMnemonicShow() {
   );
 }
 
+// The confirm step is a 12-word cell grid; pasting the phrase into the first
+// cell fills every cell at once.
+function pasteConfirmPhrase(phrase: string) {
+  const cells = screen.getAllByPlaceholderText('word');
+  fireEvent.paste(cells[0], { clipboardData: { getData: () => phrase } });
+}
+
 beforeEach(() => {
   ctx.importWallet.mockClear();
   ctx.createWallet.mockClear();
@@ -93,7 +100,7 @@ describe('create flow mnemonic confirmation (#449)', () => {
     // Confirm step.
     await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
     expect(screen.queryByText(/protect your wallet/i)).toBeNull();
-    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+    pasteConfirmPhrase(MNEMONIC);
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
     // Password step.
@@ -115,9 +122,7 @@ describe('create flow mnemonic confirmation (#449)', () => {
     fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
 
     await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
-    fireEvent.change(screen.getByLabelText(/recovery phrase/i), {
-      target: { value: 'wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong' },
-    });
+    pasteConfirmPhrase('wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong');
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
     await waitFor(() => expect(screen.getByText(/doesn't match/i)).toBeDefined());
@@ -133,14 +138,12 @@ describe('create flow mnemonic confirmation (#449)', () => {
     fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
 
     await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
-    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: 'nope nope nope' } });
+    pasteConfirmPhrase('zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo');
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
     await waitFor(() => expect(screen.getByText(/doesn't match/i)).toBeDefined());
 
     // Retry with the correct phrase (also exercises whitespace/case tolerance).
-    fireEvent.change(screen.getByLabelText(/recovery phrase/i), {
-      target: { value: `  ${MNEMONIC.toUpperCase()}  ` },
-    });
+    pasteConfirmPhrase(`  ${MNEMONIC.toUpperCase()}  `);
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
     await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
@@ -164,7 +167,7 @@ describe('create flow mnemonic confirmation (#449)', () => {
     fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
 
     await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
-    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+    pasteConfirmPhrase(MNEMONIC);
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
     await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());

--- a/tests/unit/components/createFlowPassword.test.tsx
+++ b/tests/unit/components/createFlowPassword.test.tsx
@@ -103,9 +103,11 @@ async function driveToSetPasswordScreen() {
   );
   fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
 
-  // Confirm step — re-enter the correct phrase to advance.
+  // Confirm step — re-enter the correct phrase (12-word grid). Pasting the
+  // whole phrase into the first cell fills every cell.
   await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
-  fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+  const confirmCells = screen.getAllByPlaceholderText('word');
+  fireEvent.paste(confirmCells[0], { clipboardData: { getData: () => MNEMONIC } });
   fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
   await waitFor(

--- a/tests/unit/components/createFlowPassword.test.tsx
+++ b/tests/unit/components/createFlowPassword.test.tsx
@@ -1,22 +1,25 @@
 /**
- * #449 follow-up: the CREATE onboarding flow now offers the SAME optional
- * at-rest password step the restore/import flow offers, right after the
- * mnemonic-backup screen and before plan-capabilities — new ordering:
- * mnemonicBackup → setPassword → planCapabilities → wallet.
+ * #449 UX refinement: the CREATE onboarding flow now asks for the optional
+ * at-rest password BEFORE the mnemonic-backup screen (not after) — new
+ * ordering: processing → setPassword → mnemonicBackup → planCapabilities →
+ * wallet. The ONE password chosen here also encrypts the downloaded backup
+ * file (the separate #450 backup-file password input is gone).
  *
  * This is safe (unlike the original #449 bug — see
  * createFlowSinglePersist.test.tsx) because the wallet is ALREADY persisted
- * (plaintext) by createWallet() before the backup screen shows, and a chosen
+ * (plaintext) by createWallet() before this screen shows, and a chosen
  * password is applied via the reviewed-SAFE in-place re-encrypt
  * (`setWalletPassword`, which wraps `reencryptStoredMnemonic`) — never a
  * second `importWallet()`/`Sphere.import()` call.
  *
  * Covers:
- *  - the step transition (backup-complete → setPassword)
- *  - choosing a password calls setWalletPassword (never importWallet)
- *  - skipping finalizes without calling setWalletPassword
- *  - a setWalletPassword rejection still lets the user finalize (the wallet
- *    is never lost/stuck)
+ *  - setPassword shows right after processing, BEFORE the backup screen
+ *  - choosing a password calls setWalletPassword (never importWallet), then
+ *    advances to the backup screen — not finalized yet
+ *  - the SAME password threads into the downloaded backup file
+ *  - skipping leaves the backup file plaintext and still finalizes
+ *  - a setWalletPassword rejection surfaces an error and does NOT advance
+ *    past setPassword — the wallet is never lost/stuck (still skippable)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -31,21 +34,25 @@ vi.mock('../../../src/config/subscription', async (orig) => ({
   SUBSCRIPTION_ENABLED: false,
 }));
 
-const ctx = vi.hoisted(() => ({
-  importWallet: vi.fn(async () => ({
-    getAllTrackedAddresses: () => [],
-    identity: { nametag: null },
-  })),
-  createWallet: vi.fn(async () => ({
-    mnemonic:
-      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
-    sphere: { registerNametag: vi.fn(async () => {}) },
-  })),
-  finalizeWallet: vi.fn(),
-  resolveNametag: vi.fn(async () => null),
-  importFromFile: vi.fn(),
-  setWalletPassword: vi.fn(async () => {}),
-}));
+const ctx = vi.hoisted(() => {
+  const exportToJSON = vi.fn((opts: unknown) => ({ opts }));
+  return {
+    importWallet: vi.fn(async () => ({
+      getAllTrackedAddresses: () => [],
+      identity: { nametag: null },
+    })),
+    exportToJSON,
+    createWallet: vi.fn(async () => ({
+      mnemonic:
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+      sphere: { registerNametag: vi.fn(async () => {}), exportToJSON },
+    })),
+    finalizeWallet: vi.fn(),
+    resolveNametag: vi.fn(async () => null),
+    importFromFile: vi.fn(),
+    setWalletPassword: vi.fn(async () => {}),
+  };
+});
 
 vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
   useSphereContext: () => ({
@@ -71,9 +78,8 @@ function Wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
 }
 
-/** Drives the create flow (skip-nametag) up to the mnemonic-backup screen's
- *  "Saved My Recovery Phrase" confirmation, then clicks it — landing on
- *  the new setPassword step. */
+/** Drives the create flow (skip-nametag) up to the new setPassword screen —
+ *  now the FIRST post-processing step, right before the backup screen. */
 async function driveToSetPasswordScreen() {
   render(<CreateWalletFlow />, { wrapper: Wrapper });
 
@@ -85,13 +91,9 @@ async function driveToSetPasswordScreen() {
   await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
 
   await waitFor(
-    () => expect(screen.getByRole('button', { name: /saved my recovery phrase/i })).toBeDefined(),
+    () => expect(screen.getByText(/protect your wallet/i)).toBeDefined(),
     { timeout: 3000 },
   );
-
-  fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
-
-  await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
 }
 
 beforeEach(() => {
@@ -100,17 +102,19 @@ beforeEach(() => {
   ctx.finalizeWallet.mockClear();
   ctx.setWalletPassword.mockClear();
   ctx.setWalletPassword.mockImplementation(async () => {});
+  ctx.exportToJSON.mockClear();
 });
 
-describe('create flow optional password step (#449 follow-up)', () => {
-  it('shows setPassword right after the backup-complete confirmation', async () => {
+describe('create flow optional password step (#449 UX refinement: ask BEFORE backup)', () => {
+  it('shows setPassword right after processing completes, before the backup screen', async () => {
     await driveToSetPasswordScreen();
 
     expect(screen.getByText(/protect your wallet/i)).toBeDefined();
+    expect(screen.queryByText(/back up recovery phrase/i)).toBeNull();
     expect(ctx.finalizeWallet).not.toHaveBeenCalled();
   });
 
-  it('choosing a password calls setWalletPassword (never importWallet) and then finalizes', async () => {
+  it('choosing a password calls setWalletPassword (never importWallet), advances to the backup screen (not finalized), and the SAME password encrypts the downloaded backup', async () => {
     await driveToSetPasswordScreen();
 
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'my-secret-1' } });
@@ -119,24 +123,46 @@ describe('create flow optional password step (#449 follow-up)', () => {
 
     await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
 
-    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
-
+    // Advances to the mnemonic-backup screen next — NOT finalized yet.
+    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
     expect(ctx.importWallet).not.toHaveBeenCalled();
+
+    // The single #450 backup-file password input is gone — the button
+    // itself now reflects that the wallet password will be reused.
+    expect(screen.queryByPlaceholderText(/backup file password/i)).toBeNull();
+    const downloadButton = screen.getByRole('button', { name: /download encrypted backup/i });
+    fireEvent.click(downloadButton);
+    expect(ctx.exportToJSON).toHaveBeenCalledWith(
+      expect.objectContaining({ password: 'my-secret-1' }),
+    );
+
+    // Confirming the backup finalizes.
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
     expect(ctx.createWallet).toHaveBeenCalledTimes(1);
   });
 
-  it('skipping finalizes without ever calling setWalletPassword', async () => {
+  it('skipping leaves the backup file plaintext and finalizes without ever calling setWalletPassword', async () => {
     await driveToSetPasswordScreen();
 
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
 
+    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
+    const downloadButton = screen.getByRole('button', { name: /^download backup file$/i });
+    fireEvent.click(downloadButton);
+    expect(ctx.exportToJSON).toHaveBeenCalledWith(
+      expect.objectContaining({ password: undefined }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
 
     expect(ctx.setWalletPassword).not.toHaveBeenCalled();
     expect(ctx.importWallet).not.toHaveBeenCalled();
   });
 
-  it('a setWalletPassword rejection still lets the user finalize — the wallet is never lost', async () => {
+  it('a setWalletPassword rejection surfaces an error and does NOT advance past setPassword — the wallet is never lost, and Skip still works', async () => {
     ctx.setWalletPassword.mockImplementation(async () => {
       throw new Error('re-encrypt failed');
     });
@@ -149,9 +175,18 @@ describe('create flow optional password step (#449 follow-up)', () => {
 
     await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
 
-    // Despite the rejection, the user still reaches the wallet — never
-    // re-runs importWallet, and never gets stuck on this screen.
-    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+    // Stays on setPassword with the error surfaced — must NOT silently
+    // advance to a plaintext wallet believing it's protected.
+    await waitFor(() => expect(screen.getByText(/re-encrypt failed/i)).toBeDefined());
+    expect(screen.getByText(/protect your wallet/i)).toBeDefined();
+    expect(screen.queryByText(/back up recovery phrase/i)).toBeNull();
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
     expect(ctx.importWallet).not.toHaveBeenCalled();
+
+    // The user can still Skip from here — never stuck, never wiped.
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
   });
 });

--- a/tests/unit/components/createFlowPassword.test.tsx
+++ b/tests/unit/components/createFlowPassword.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * #449 follow-up: the CREATE onboarding flow now offers the SAME optional
+ * at-rest password step the restore/import flow offers, right after the
+ * mnemonic-backup screen and before plan-capabilities — new ordering:
+ * mnemonicBackup → setPassword → planCapabilities → wallet.
+ *
+ * This is safe (unlike the original #449 bug — see
+ * createFlowSinglePersist.test.tsx) because the wallet is ALREADY persisted
+ * (plaintext) by createWallet() before the backup screen shows, and a chosen
+ * password is applied via the reviewed-SAFE in-place re-encrypt
+ * (`setWalletPassword`, which wraps `reencryptStoredMnemonic`) — never a
+ * second `importWallet()`/`Sphere.import()` call.
+ *
+ * Covers:
+ *  - the step transition (backup-complete → setPassword)
+ *  - choosing a password calls setWalletPassword (never importWallet)
+ *  - skipping finalizes without calling setWalletPassword
+ *  - a setWalletPassword rejection still lets the user finalize (the wallet
+ *    is never lost/stuck)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Keep this test deterministic and network-free: doFinalizeWallet only
+// short-circuits straight to finishFinalize() when subscriptions are off —
+// otherwise it would race a real subscriptionApi HTTP call.
+vi.mock('../../../src/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('../../../src/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: false,
+}));
+
+const ctx = vi.hoisted(() => ({
+  importWallet: vi.fn(async () => ({
+    getAllTrackedAddresses: () => [],
+    identity: { nametag: null },
+  })),
+  createWallet: vi.fn(async () => ({
+    mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    sphere: { registerNametag: vi.fn(async () => {}) },
+  })),
+  finalizeWallet: vi.fn(),
+  resolveNametag: vi.fn(async () => null),
+  importFromFile: vi.fn(),
+  setWalletPassword: vi.fn(async () => {}),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    sphere: null,
+    network: 'testnet2',
+    createWallet: ctx.createWallet,
+    resolveNametag: ctx.resolveNametag,
+    importWallet: ctx.importWallet,
+    importFromFile: ctx.importFromFile,
+    finalizeWallet: ctx.finalizeWallet,
+    walletExists: false,
+    initProgress: null,
+    setWalletPassword: ctx.setWalletPassword,
+  }),
+}));
+
+import { CreateWalletFlow } from '../../../src/components/wallet/onboarding/CreateWalletFlow';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+/** Drives the create flow (skip-nametag) up to the mnemonic-backup screen's
+ *  "Saved My Recovery Phrase" confirmation, then clicks it — landing on
+ *  the new setPassword step. */
+async function driveToSetPasswordScreen() {
+  render(<CreateWalletFlow />, { wrapper: Wrapper });
+
+  fireEvent.click(screen.getByRole('button', { name: /create new wallet/i }));
+
+  await waitFor(() => expect(screen.getByRole('button', { name: /skip for now/i })).toBeDefined());
+  fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+  await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
+
+  await waitFor(
+    () => expect(screen.getByRole('button', { name: /saved my recovery phrase/i })).toBeDefined(),
+    { timeout: 3000 },
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+  await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
+}
+
+beforeEach(() => {
+  ctx.importWallet.mockClear();
+  ctx.createWallet.mockClear();
+  ctx.finalizeWallet.mockClear();
+  ctx.setWalletPassword.mockClear();
+  ctx.setWalletPassword.mockImplementation(async () => {});
+});
+
+describe('create flow optional password step (#449 follow-up)', () => {
+  it('shows setPassword right after the backup-complete confirmation', async () => {
+    await driveToSetPasswordScreen();
+
+    expect(screen.getByText(/protect your wallet/i)).toBeDefined();
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+  });
+
+  it('choosing a password calls setWalletPassword (never importWallet) and then finalizes', async () => {
+    await driveToSetPasswordScreen();
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'my-secret-1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'my-secret-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /^set password$/i }));
+
+    await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
+
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+    expect(ctx.createWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('skipping finalizes without ever calling setWalletPassword', async () => {
+    await driveToSetPasswordScreen();
+
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+
+    expect(ctx.setWalletPassword).not.toHaveBeenCalled();
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+  });
+
+  it('a setWalletPassword rejection still lets the user finalize — the wallet is never lost', async () => {
+    ctx.setWalletPassword.mockImplementation(async () => {
+      throw new Error('re-encrypt failed');
+    });
+
+    await driveToSetPasswordScreen();
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'my-secret-1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'my-secret-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /^set password$/i }));
+
+    await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
+
+    // Despite the rejection, the user still reaches the wallet — never
+    // re-runs importWallet, and never gets stuck on this screen.
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/createFlowPassword.test.tsx
+++ b/tests/unit/components/createFlowPassword.test.tsx
@@ -1,21 +1,24 @@
 /**
- * #449 UX refinement: the CREATE onboarding flow now asks for the optional
- * at-rest password BEFORE the mnemonic-backup screen (not after) — new
- * ordering: processing → setPassword → mnemonicBackup → planCapabilities →
- * wallet. The ONE password chosen here also encrypts the downloaded backup
- * file (the separate #450 backup-file password input is gone).
+ * #449 create-flow reorder: show -> confirm -> password -> download. The
+ * CREATE onboarding flow now displays the recovery phrase, makes the user
+ * re-enter it to VERIFY the backup (ConfirmMnemonicScreen), THEN asks for
+ * the optional at-rest password, and only THEN offers the backup-file
+ * download — new ordering: processing → mnemonicShow → mnemonicConfirm →
+ * setPassword → backupDownload → planCapabilities → wallet. The ONE password
+ * chosen on setPassword also encrypts the downloaded backup file.
  *
  * This is safe (unlike the original #449 bug — see
  * createFlowSinglePersist.test.tsx) because the wallet is ALREADY persisted
- * (plaintext) by createWallet() before this screen shows, and a chosen
- * password is applied via the reviewed-SAFE in-place re-encrypt
+ * (plaintext) by createWallet() before any of these screens show, and a
+ * chosen password is applied via the reviewed-SAFE in-place re-encrypt
  * (`setWalletPassword`, which wraps `reencryptStoredMnemonic`) — never a
  * second `importWallet()`/`Sphere.import()` call.
  *
  * Covers:
- *  - setPassword shows right after processing, BEFORE the backup screen
+ *  - setPassword shows only AFTER mnemonicShow + mnemonicConfirm, and BEFORE
+ *    the backup-download screen
  *  - choosing a password calls setWalletPassword (never importWallet), then
- *    advances to the backup screen — not finalized yet
+ *    advances to the backup-download screen — not finalized yet
  *  - the SAME password threads into the downloaded backup file
  *  - skipping leaves the backup file plaintext and still finalizes
  *  - a setWalletPassword rejection surfaces an error and does NOT advance
@@ -33,6 +36,9 @@ vi.mock('../../../src/config/subscription', async (orig) => ({
   ...(await orig<typeof import('../../../src/config/subscription')>()),
   SUBSCRIPTION_ENABLED: false,
 }));
+
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
 const ctx = vi.hoisted(() => {
   const exportToJSON = vi.fn((opts: unknown) => ({ opts }));
@@ -78,8 +84,8 @@ function Wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
 }
 
-/** Drives the create flow (skip-nametag) up to the new setPassword screen —
- *  now the FIRST post-processing step, right before the backup screen. */
+/** Drives the create flow (skip-nametag) all the way through the mnemonic
+ *  show + confirm screens up to the new setPassword screen. */
 async function driveToSetPasswordScreen() {
   render(<CreateWalletFlow />, { wrapper: Wrapper });
 
@@ -89,6 +95,18 @@ async function driveToSetPasswordScreen() {
   fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
 
   await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
+
+  // Show step first.
+  await waitFor(
+    () => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined(),
+    { timeout: 3000 },
+  );
+  fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+  // Confirm step — re-enter the correct phrase to advance.
+  await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+  fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+  fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
   await waitFor(
     () => expect(screen.getByText(/protect your wallet/i)).toBeDefined(),
@@ -105,16 +123,16 @@ beforeEach(() => {
   ctx.exportToJSON.mockClear();
 });
 
-describe('create flow optional password step (#449 UX refinement: ask BEFORE backup)', () => {
-  it('shows setPassword right after processing completes, before the backup screen', async () => {
+describe('create flow ordering: show -> confirm -> password -> download (#449)', () => {
+  it('shows setPassword only after mnemonicShow + mnemonicConfirm, before the backup-download screen', async () => {
     await driveToSetPasswordScreen();
 
     expect(screen.getByText(/protect your wallet/i)).toBeDefined();
-    expect(screen.queryByText(/back up recovery phrase/i)).toBeNull();
+    expect(screen.queryByText(/download wallet backup/i)).toBeNull();
     expect(ctx.finalizeWallet).not.toHaveBeenCalled();
   });
 
-  it('choosing a password calls setWalletPassword (never importWallet), advances to the backup screen (not finalized), and the SAME password encrypts the downloaded backup', async () => {
+  it('choosing a password calls setWalletPassword (never importWallet), advances to the backup-download screen (not finalized), and the SAME password encrypts the downloaded backup', async () => {
     await driveToSetPasswordScreen();
 
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'my-secret-1' } });
@@ -123,8 +141,8 @@ describe('create flow optional password step (#449 UX refinement: ask BEFORE bac
 
     await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
 
-    // Advances to the mnemonic-backup screen next — NOT finalized yet.
-    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
+    // Advances to the backup-download screen next — NOT finalized yet.
+    await waitFor(() => expect(screen.getByText(/download wallet backup/i)).toBeDefined());
     expect(ctx.finalizeWallet).not.toHaveBeenCalled();
     expect(ctx.importWallet).not.toHaveBeenCalled();
 
@@ -137,8 +155,8 @@ describe('create flow optional password step (#449 UX refinement: ask BEFORE bac
       expect.objectContaining({ password: 'my-secret-1' }),
     );
 
-    // Confirming the backup finalizes.
-    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    // Continuing from the download screen finalizes.
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
     expect(ctx.createWallet).toHaveBeenCalledTimes(1);
   });
@@ -148,14 +166,14 @@ describe('create flow optional password step (#449 UX refinement: ask BEFORE bac
 
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
 
-    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
+    await waitFor(() => expect(screen.getByText(/download wallet backup/i)).toBeDefined());
     const downloadButton = screen.getByRole('button', { name: /^download backup file$/i });
     fireEvent.click(downloadButton);
     expect(ctx.exportToJSON).toHaveBeenCalledWith(
       expect.objectContaining({ password: undefined }),
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
 
     expect(ctx.setWalletPassword).not.toHaveBeenCalled();
@@ -179,14 +197,14 @@ describe('create flow optional password step (#449 UX refinement: ask BEFORE bac
     // advance to a plaintext wallet believing it's protected.
     await waitFor(() => expect(screen.getByText(/re-encrypt failed/i)).toBeDefined());
     expect(screen.getByText(/protect your wallet/i)).toBeDefined();
-    expect(screen.queryByText(/back up recovery phrase/i)).toBeNull();
+    expect(screen.queryByText(/download wallet backup/i)).toBeNull();
     expect(ctx.finalizeWallet).not.toHaveBeenCalled();
     expect(ctx.importWallet).not.toHaveBeenCalled();
 
     // The user can still Skip from here — never stuck, never wiped.
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
-    await waitFor(() => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined());
-    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    await waitFor(() => expect(screen.getByText(/download wallet backup/i)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
   });
 });

--- a/tests/unit/components/createFlowSinglePersist.test.tsx
+++ b/tests/unit/components/createFlowSinglePersist.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * #449 CRITICAL no-wallet-loss regression: the create flow used to route
+ * through SetPasswordScreen (after the mnemonic-backup screen) and, if the
+ * user chose a password, run a SECOND `importWallet()` call on the wallet
+ * `createWallet()` had already persisted moments earlier. `importWallet`
+ * wraps the SDK's `Sphere.import()`, which unconditionally `Sphere.clear()`s
+ * any already-persisted wallet before rebuilding it — if that rebuild then
+ * failed (a network hiccup during identity/nametag sync, etc.), storage was
+ * left cleared while the app kept using the in-memory instance for the rest
+ * of the session, so on next reload the wallet could show unexpectedly
+ * LOCKED or vanish entirely. It also raced the just-published Nostr nametag
+ * binding from createWalletThenRegister (#448), risking permanently burning
+ * it.
+ *
+ * Fixed by removing the create flow's use of SetPasswordScreen entirely: the
+ * create flow now persists its (plaintext) wallet exactly ONCE, via
+ * `createWallet()`, and finalizes straight from the mnemonic-backup screen.
+ * This test asserts `importWallet` is never invoked anywhere in the
+ * skip-nametag create path, `createWallet` runs exactly once, and the
+ * SetPasswordScreen ("Protect Your Wallet") never appears in that flow.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Keep this test deterministic and network-free: doFinalizeWallet only
+// short-circuits straight to finishFinalize() when subscriptions are off —
+// otherwise it would race a real subscriptionApi HTTP call.
+vi.mock('../../../src/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('../../../src/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: false,
+}));
+
+const ctx = vi.hoisted(() => ({
+  importWallet: vi.fn(async () => ({
+    getAllTrackedAddresses: () => [],
+    identity: { nametag: null },
+  })),
+  createWallet: vi.fn(async () => ({
+    mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    sphere: { registerNametag: vi.fn(async () => {}) },
+  })),
+  finalizeWallet: vi.fn(),
+  resolveNametag: vi.fn(async () => null),
+  importFromFile: vi.fn(),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    sphere: null,
+    network: 'testnet2',
+    createWallet: ctx.createWallet,
+    resolveNametag: ctx.resolveNametag,
+    importWallet: ctx.importWallet,
+    importFromFile: ctx.importFromFile,
+    finalizeWallet: ctx.finalizeWallet,
+    walletExists: false,
+    initProgress: null,
+  }),
+}));
+
+import { CreateWalletFlow } from '../../../src/components/wallet/onboarding/CreateWalletFlow';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('create flow persists the wallet exactly once (#449)', () => {
+  it('never calls importWallet; createWallet() is the ONLY persisting call and the backup screen finalizes directly', async () => {
+    render(<CreateWalletFlow />, { wrapper: Wrapper });
+
+    // Start → "Create New Wallet"
+    fireEvent.click(screen.getByRole('button', { name: /create new wallet/i }));
+
+    // Nametag screen → skip
+    await waitFor(() => expect(screen.getByRole('button', { name: /skip for now/i })).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    // createWallet() persists the (plaintext) wallet exactly once.
+    await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
+
+    // Processing screen auto-transitions to the mnemonic backup screen.
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: /saved my recovery phrase/i })).toBeDefined(),
+      { timeout: 3000 },
+    );
+
+    // The create flow must NOT offer a SetPasswordScreen anywhere.
+    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
+
+    // Confirming the backup finalizes directly — no intervening setPassword step.
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1), { timeout: 3000 });
+
+    // The critical assertion: importWallet — the SDK call that would
+    // Sphere.clear() the wallet createWallet() just persisted — is never
+    // invoked anywhere in this flow, and createWallet ran exactly once.
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+    expect(ctx.createWallet).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
+  });
+});

--- a/tests/unit/components/createFlowSinglePersist.test.tsx
+++ b/tests/unit/components/createFlowSinglePersist.test.tsx
@@ -13,15 +13,18 @@
  * also raced the just-published Nostr nametag binding from
  * createWalletThenRegister (#448), risking permanently burning it.
  *
- * The #449 follow-up brought SetPasswordScreen BACK into the create flow
- * (ordering: mnemonicBackup → setPassword → planCapabilities → wallet), but
- * applies a chosen password via the reviewed-SAFE in-place re-encrypt
- * (`setWalletPassword`, not `importWallet`) — see
- * tests/unit/components/createFlowPassword.test.tsx for that path. This test
- * keeps guarding the ORIGINAL regression: the create flow still persists its
- * (plaintext) wallet exactly ONCE via `createWallet()`, and Skipping the new
- * password step still never calls `importWallet` — the SDK call that would
- * `Sphere.clear()` the wallet `createWallet()` just persisted.
+ * The #449 follow-up brought SetPasswordScreen BACK into the create flow, and
+ * a later UX refinement reordered it to ask BEFORE the backup screen
+ * (ordering: processing → setPassword → mnemonicBackup → planCapabilities →
+ * wallet — so the one chosen password can also encrypt the downloaded
+ * backup file). Either way, a chosen password is applied via the
+ * reviewed-SAFE in-place re-encrypt (`setWalletPassword`, not
+ * `importWallet`) — see tests/unit/components/createFlowPassword.test.tsx
+ * for that path. This test keeps guarding the ORIGINAL regression: the
+ * create flow still persists its (plaintext) wallet exactly ONCE via
+ * `createWallet()`, and Skipping the password step still never calls
+ * `importWallet` — the SDK call that would `Sphere.clear()` the wallet
+ * `createWallet()` just persisted.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -90,20 +93,23 @@ describe('create flow persists the wallet exactly once (#449)', () => {
     // createWallet() persists the (plaintext) wallet exactly once.
     await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
 
-    // Processing screen auto-transitions to the mnemonic backup screen.
+    // Processing screen auto-transitions straight to the optional
+    // SetPasswordScreen (UX refinement: ask BEFORE the backup screen) — it
+    // must NOT finalize directly.
     await waitFor(
-      () => expect(screen.getByRole('button', { name: /saved my recovery phrase/i })).toBeDefined(),
+      () => expect(screen.getByText(/protect your wallet/i)).toBeDefined(),
       { timeout: 3000 },
     );
-
-    // Confirming the backup now leads to the optional SetPasswordScreen
-    // (#449 follow-up) — it must NOT finalize directly anymore.
-    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
-    await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
     expect(ctx.finalizeWallet).not.toHaveBeenCalled();
 
     // Skip the optional password.
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    // Lands on the mnemonic-backup screen next — still not finalized.
+    await waitFor(() => expect(screen.getByRole('button', { name: /saved my recovery phrase/i })).toBeDefined());
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
 
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1), { timeout: 3000 });
 

--- a/tests/unit/components/createFlowSinglePersist.test.tsx
+++ b/tests/unit/components/createFlowSinglePersist.test.tsx
@@ -108,8 +108,10 @@ describe('create flow persists the wallet exactly once (#449)', () => {
     fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
 
     // Confirm step: re-entering the correct phrase is required to advance.
+    // The confirm screen is a 12-word cell grid; pasting the phrase into the
+    // first cell fills every cell.
     await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
-    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+    fireEvent.paste(screen.getAllByPlaceholderText('word')[0], { clipboardData: { getData: () => MNEMONIC } });
     fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
 
     // Lands on the optional SetPasswordScreen next — still not finalized.

--- a/tests/unit/components/createFlowSinglePersist.test.tsx
+++ b/tests/unit/components/createFlowSinglePersist.test.tsx
@@ -1,23 +1,24 @@
 /**
  * #449 CRITICAL no-wallet-loss regression (guard kept green through the #449
- * follow-up that re-introduced SetPasswordScreen in the create flow): the
- * create flow used to route through SetPasswordScreen (after the
- * mnemonic-backup screen) and, if the user chose a password, run a SECOND
- * `importWallet()` call on the wallet `createWallet()` had already persisted
- * moments earlier. `importWallet` wraps the SDK's `Sphere.import()`, which
- * unconditionally `Sphere.clear()`s any already-persisted wallet before
- * rebuilding it — if that rebuild then failed (a network hiccup during
- * identity/nametag sync, etc.), storage was left cleared while the app kept
- * using the in-memory instance for the rest of the session, so on next
- * reload the wallet could show unexpectedly LOCKED or vanish entirely. It
- * also raced the just-published Nostr nametag binding from
- * createWalletThenRegister (#448), risking permanently burning it.
+ * follow-up that re-introduced SetPasswordScreen in the create flow, and the
+ * later reorder that inserted a real mnemonic show/confirm verification
+ * before it): the create flow used to route through SetPasswordScreen and,
+ * if the user chose a password, run a SECOND `importWallet()` call on the
+ * wallet `createWallet()` had already persisted moments earlier.
+ * `importWallet` wraps the SDK's `Sphere.import()`, which unconditionally
+ * `Sphere.clear()`s any already-persisted wallet before rebuilding it — if
+ * that rebuild then failed (a network hiccup during identity/nametag sync,
+ * etc.), storage was left cleared while the app kept using the in-memory
+ * instance for the rest of the session, so on next reload the wallet could
+ * show unexpectedly LOCKED or vanish entirely. It also raced the
+ * just-published Nostr nametag binding from createWalletThenRegister (#448),
+ * risking permanently burning it.
  *
  * The #449 follow-up brought SetPasswordScreen BACK into the create flow, and
- * a later UX refinement reordered it to ask BEFORE the backup screen
- * (ordering: processing → setPassword → mnemonicBackup → planCapabilities →
- * wallet — so the one chosen password can also encrypt the downloaded
- * backup file). Either way, a chosen password is applied via the
+ * a later reorder (show -> confirm -> password -> download) inserted a real
+ * mnemonic re-entry verification (ConfirmMnemonicScreen) before it, so the
+ * one chosen password can still encrypt the downloaded backup file shown
+ * right after it. Either way, a chosen password is applied via the
  * reviewed-SAFE in-place re-encrypt (`setWalletPassword`, not
  * `importWallet`) — see tests/unit/components/createFlowPassword.test.tsx
  * for that path. This test keeps guarding the ORIGINAL regression: the
@@ -79,6 +80,9 @@ function Wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
 }
 
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
 describe('create flow persists the wallet exactly once (#449)', () => {
   it('never calls importWallet; createWallet() is the ONLY persisting call, and skipping the password step finalizes with no re-encrypt', async () => {
     render(<CreateWalletFlow />, { wrapper: Wrapper });
@@ -93,9 +97,22 @@ describe('create flow persists the wallet exactly once (#449)', () => {
     // createWallet() persists the (plaintext) wallet exactly once.
     await waitFor(() => expect(ctx.createWallet).toHaveBeenCalledTimes(1));
 
-    // Processing screen auto-transitions straight to the optional
-    // SetPasswordScreen (UX refinement: ask BEFORE the backup screen) — it
-    // must NOT finalize directly.
+    // Processing screen auto-transitions to the mnemonic SHOW screen first
+    // (ordering: show → confirm → setPassword → backupDownload → finalize)
+    // — it must NOT finalize directly.
+    await waitFor(
+      () => expect(screen.getByText(/back up recovery phrase/i)).toBeDefined(),
+      { timeout: 3000 },
+    );
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+
+    // Confirm step: re-entering the correct phrase is required to advance.
+    await waitFor(() => expect(screen.getByText(/confirm recovery phrase/i)).toBeDefined());
+    fireEvent.change(screen.getByLabelText(/recovery phrase/i), { target: { value: MNEMONIC } });
+    fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+
+    // Lands on the optional SetPasswordScreen next — still not finalized.
     await waitFor(
       () => expect(screen.getByText(/protect your wallet/i)).toBeDefined(),
       { timeout: 3000 },
@@ -105,11 +122,11 @@ describe('create flow persists the wallet exactly once (#449)', () => {
     // Skip the optional password.
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
 
-    // Lands on the mnemonic-backup screen next — still not finalized.
-    await waitFor(() => expect(screen.getByRole('button', { name: /saved my recovery phrase/i })).toBeDefined());
+    // Lands on the backup-download screen next — still not finalized.
+    await waitFor(() => expect(screen.getByRole('button', { name: /^continue$/i })).toBeDefined());
     expect(ctx.finalizeWallet).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1), { timeout: 3000 });
 

--- a/tests/unit/components/createFlowSinglePersist.test.tsx
+++ b/tests/unit/components/createFlowSinglePersist.test.tsx
@@ -1,23 +1,27 @@
 /**
- * #449 CRITICAL no-wallet-loss regression: the create flow used to route
- * through SetPasswordScreen (after the mnemonic-backup screen) and, if the
- * user chose a password, run a SECOND `importWallet()` call on the wallet
- * `createWallet()` had already persisted moments earlier. `importWallet`
- * wraps the SDK's `Sphere.import()`, which unconditionally `Sphere.clear()`s
- * any already-persisted wallet before rebuilding it — if that rebuild then
- * failed (a network hiccup during identity/nametag sync, etc.), storage was
- * left cleared while the app kept using the in-memory instance for the rest
- * of the session, so on next reload the wallet could show unexpectedly
- * LOCKED or vanish entirely. It also raced the just-published Nostr nametag
- * binding from createWalletThenRegister (#448), risking permanently burning
- * it.
+ * #449 CRITICAL no-wallet-loss regression (guard kept green through the #449
+ * follow-up that re-introduced SetPasswordScreen in the create flow): the
+ * create flow used to route through SetPasswordScreen (after the
+ * mnemonic-backup screen) and, if the user chose a password, run a SECOND
+ * `importWallet()` call on the wallet `createWallet()` had already persisted
+ * moments earlier. `importWallet` wraps the SDK's `Sphere.import()`, which
+ * unconditionally `Sphere.clear()`s any already-persisted wallet before
+ * rebuilding it — if that rebuild then failed (a network hiccup during
+ * identity/nametag sync, etc.), storage was left cleared while the app kept
+ * using the in-memory instance for the rest of the session, so on next
+ * reload the wallet could show unexpectedly LOCKED or vanish entirely. It
+ * also raced the just-published Nostr nametag binding from
+ * createWalletThenRegister (#448), risking permanently burning it.
  *
- * Fixed by removing the create flow's use of SetPasswordScreen entirely: the
- * create flow now persists its (plaintext) wallet exactly ONCE, via
- * `createWallet()`, and finalizes straight from the mnemonic-backup screen.
- * This test asserts `importWallet` is never invoked anywhere in the
- * skip-nametag create path, `createWallet` runs exactly once, and the
- * SetPasswordScreen ("Protect Your Wallet") never appears in that flow.
+ * The #449 follow-up brought SetPasswordScreen BACK into the create flow
+ * (ordering: mnemonicBackup → setPassword → planCapabilities → wallet), but
+ * applies a chosen password via the reviewed-SAFE in-place re-encrypt
+ * (`setWalletPassword`, not `importWallet`) — see
+ * tests/unit/components/createFlowPassword.test.tsx for that path. This test
+ * keeps guarding the ORIGINAL regression: the create flow still persists its
+ * (plaintext) wallet exactly ONCE via `createWallet()`, and Skipping the new
+ * password step still never calls `importWallet` — the SDK call that would
+ * `Sphere.clear()` the wallet `createWallet()` just persisted.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -45,6 +49,7 @@ const ctx = vi.hoisted(() => ({
   finalizeWallet: vi.fn(),
   resolveNametag: vi.fn(async () => null),
   importFromFile: vi.fn(),
+  setWalletPassword: vi.fn(async () => {}),
 }));
 
 vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
@@ -58,6 +63,7 @@ vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
     finalizeWallet: ctx.finalizeWallet,
     walletExists: false,
     initProgress: null,
+    setWalletPassword: ctx.setWalletPassword,
   }),
 }));
 
@@ -71,7 +77,7 @@ function Wrapper({ children }: { children: ReactNode }) {
 }
 
 describe('create flow persists the wallet exactly once (#449)', () => {
-  it('never calls importWallet; createWallet() is the ONLY persisting call and the backup screen finalizes directly', async () => {
+  it('never calls importWallet; createWallet() is the ONLY persisting call, and skipping the password step finalizes with no re-encrypt', async () => {
     render(<CreateWalletFlow />, { wrapper: Wrapper });
 
     // Start → "Create New Wallet"
@@ -90,19 +96,23 @@ describe('create flow persists the wallet exactly once (#449)', () => {
       { timeout: 3000 },
     );
 
-    // The create flow must NOT offer a SetPasswordScreen anywhere.
-    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
-
-    // Confirming the backup finalizes directly — no intervening setPassword step.
+    // Confirming the backup now leads to the optional SetPasswordScreen
+    // (#449 follow-up) — it must NOT finalize directly anymore.
     fireEvent.click(screen.getByRole('button', { name: /saved my recovery phrase/i }));
+    await waitFor(() => expect(screen.getByText(/protect your wallet/i)).toBeDefined());
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+
+    // Skip the optional password.
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
 
     await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1), { timeout: 3000 });
 
     // The critical assertion: importWallet — the SDK call that would
     // Sphere.clear() the wallet createWallet() just persisted — is never
     // invoked anywhere in this flow, and createWallet ran exactly once.
+    // Skipping the password step must also never call setWalletPassword.
     expect(ctx.importWallet).not.toHaveBeenCalled();
     expect(ctx.createWallet).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
+    expect(ctx.setWalletPassword).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/components/importPassword.test.tsx
+++ b/tests/unit/components/importPassword.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * #449 Task C: offer a password when IMPORTING a wallet (restore-from-
+ * recovery-phrase OR wallet file), applied via the SAFE in-place
+ * `setWalletPassword` (never `Sphere.import`/`Sphere.clear`). Covers:
+ *
+ *  (a) restore-from-mnemonic: the wallet imports PLAINTEXT immediately (no
+ *      password threaded into `importWallet`), and only AFTER address
+ *      selection + nametag does the SAME optional SetPasswordScreen the
+ *      create flow uses appear. Setting a password calls `setWalletPassword`
+ *      (never a second `importWallet` call); Skip finalizes plaintext.
+ *  (b) an ENCRYPTED file import auto-applies the file's own decrypt
+ *      password as the wallet's at-rest password via `setWalletPassword`,
+ *      and skips the optional SetPasswordScreen entirely (already
+ *      protected).
+ *  (c) a `setWalletPassword` rejection (on the optional, non-auto step)
+ *      surfaces an error and does NOT lose the wallet — Skip still works.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Keep this deterministic and network-free: doFinalizeWallet only
+// short-circuits straight to finishFinalize() when subscriptions are off.
+vi.mock('../../../src/config/subscription', async (orig) => ({
+  ...(await orig<typeof import('../../../src/config/subscription')>()),
+  SUBSCRIPTION_ENABLED: false,
+}));
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const ctx = vi.hoisted(() => ({
+  importWallet: vi.fn(async () => ({
+    getAllTrackedAddresses: () => [],
+    identity: { nametag: null },
+  })),
+  createWallet: vi.fn(async () => ({ mnemonic: 'never called', sphere: {} })),
+  finalizeWallet: vi.fn(),
+  resolveNametag: vi.fn(async () => null),
+  importFromFile: vi.fn(),
+  setWalletPassword: vi.fn(async () => {}),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    sphere: null,
+    network: 'testnet2',
+    createWallet: ctx.createWallet,
+    resolveNametag: ctx.resolveNametag,
+    importWallet: ctx.importWallet,
+    importFromFile: ctx.importFromFile,
+    finalizeWallet: ctx.finalizeWallet,
+    walletExists: false,
+    initProgress: null,
+    setWalletPassword: ctx.setWalletPassword,
+  }),
+}));
+
+import { CreateWalletFlow } from '../../../src/components/wallet/onboarding/CreateWalletFlow';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function fillSeedWords(phrase: string) {
+  const inputs = screen.getAllByPlaceholderText('word');
+  phrase.split(' ').forEach((w, i) => fireEvent.change(inputs[i], { target: { value: w } }));
+}
+
+/** Drives the restore-from-mnemonic flow (plaintext import mocked to return
+ *  zero tracked addresses / no nametag) through nametag-skip up to the
+ *  optional SetPasswordScreen. */
+async function driveRestoreToSetPassword() {
+  render(<CreateWalletFlow initialStep="restore" />, { wrapper: Wrapper });
+
+  fillSeedWords(VALID_MNEMONIC);
+  fireEvent.click(screen.getByRole('button', { name: /^restore$/i }));
+
+  // Imported PLAINTEXT immediately — no password option threaded in.
+  await waitFor(() => expect(ctx.importWallet).toHaveBeenCalledWith(VALID_MNEMONIC));
+  expect(ctx.importWallet.mock.calls[0]).toHaveLength(1);
+
+  // No addresses / no nametag on the mocked instance → nametag screen next.
+  await waitFor(() => expect(screen.getByText(/choose unicity id/i)).toBeDefined());
+  fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+  await waitFor(
+    () => expect(screen.getByText(/protect your wallet/i)).toBeDefined(),
+    { timeout: 3000 },
+  );
+}
+
+beforeEach(() => {
+  ctx.importWallet.mockClear();
+  ctx.importWallet.mockImplementation(async () => ({
+    getAllTrackedAddresses: () => [],
+    identity: { nametag: null },
+  }));
+  ctx.createWallet.mockClear();
+  ctx.finalizeWallet.mockClear();
+  ctx.resolveNametag.mockClear();
+  ctx.importFromFile.mockClear();
+  ctx.setWalletPassword.mockClear();
+  ctx.setWalletPassword.mockImplementation(async () => {});
+});
+
+describe('restore-from-mnemonic offers the optional password AFTER import (#449 Task C)', () => {
+  it('imports plaintext immediately, reaches SetPasswordScreen after nametag, and Set calls setWalletPassword (never a second importWallet)', async () => {
+    await driveRestoreToSetPassword();
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'my-secret-1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'my-secret-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /^set password$/i }));
+
+    await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
+
+    // Import flow has no backup-download screen — finalizes directly.
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+
+    // The critical assertion: importWallet was called exactly ONCE, with NO
+    // password/options argument — the password is applied via the in-place
+    // re-encrypt, never a second Sphere.import()-backed call.
+    expect(ctx.importWallet).toHaveBeenCalledTimes(1);
+    expect(ctx.importWallet).toHaveBeenCalledWith(VALID_MNEMONIC);
+  });
+
+  it('Skip finalizes a plaintext wallet without ever calling setWalletPassword', async () => {
+    await driveRestoreToSetPassword();
+
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+    expect(ctx.setWalletPassword).not.toHaveBeenCalled();
+    expect(ctx.importWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('a setWalletPassword rejection surfaces an error, does NOT lose the wallet, and Skip still finalizes it', async () => {
+    ctx.setWalletPassword.mockImplementation(async () => {
+      throw new Error('re-encrypt failed');
+    });
+
+    await driveRestoreToSetPassword();
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'my-secret-1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'my-secret-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /^set password$/i }));
+
+    await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('my-secret-1'));
+
+    // Stays on setPassword with the error surfaced — never silently
+    // finalizes a wallet the user believes is protected while it's plaintext.
+    await waitFor(() => expect(screen.getByText(/re-encrypt failed/i)).toBeDefined());
+    expect(screen.getByText(/protect your wallet/i)).toBeDefined();
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+    expect(ctx.importWallet).toHaveBeenCalledTimes(1);
+
+    // The wallet is never lost/stuck — Skip still finalizes it (plaintext).
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('encrypted file import auto-applies its decrypt password (#449 Task C)', () => {
+  function makeEncryptedJsonFile() {
+    const content = JSON.stringify({ type: 'sphere-wallet', version: '1.0', encrypted: { mnemonic: 'x' } });
+    const file = new File([content], 'wallet.json', { type: 'application/json' });
+    // jsdom's File/Blob doesn't implement `.text()` in this environment —
+    // handleFileSelect awaits it for any non-.dat file. Stub it directly.
+    (file as unknown as { text: () => Promise<string> }).text = async () => content;
+    return file;
+  }
+
+  async function selectAndImportEncryptedFile() {
+    const { container } = render(<CreateWalletFlow initialStep="importFile" />, { wrapper: Wrapper });
+
+    const file = makeEncryptedJsonFile();
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    // Encrypted detection happens after the async file read — wait for the
+    // selected-file UI (and its "Import" button) to appear.
+    await waitFor(() => expect(screen.getByRole('button', { name: /^import$/i })).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /^import$/i }));
+
+    // Encrypted → password prompt (no importFromFile call yet).
+    await waitFor(() => expect(screen.getByText(/enter password/i)).toBeDefined());
+    expect(ctx.importFromFile).not.toHaveBeenCalled();
+  }
+
+  it('applies the SAME password used to decrypt as the new at-rest password, and skips the optional SetPasswordScreen entirely', async () => {
+    ctx.importFromFile.mockResolvedValue({
+      success: true,
+      sphere: { getAllTrackedAddresses: () => [], identity: { nametag: null } },
+    });
+
+    await selectAndImportEncryptedFile();
+
+    fireEvent.change(screen.getByPlaceholderText(/wallet password/i), { target: { value: 'file-pw-123' } });
+    fireEvent.click(screen.getByRole('button', { name: /^unlock$/i }));
+
+    await waitFor(() =>
+      expect(ctx.importFromFile).toHaveBeenCalledWith(
+        expect.objectContaining({ fileName: 'wallet.json', password: 'file-pw-123' }),
+      ),
+    );
+
+    // Auto-applied via the SAME password used to decrypt the file.
+    await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('file-pw-123'));
+
+    // No addresses / no nametag → nametag screen next.
+    await waitFor(() => expect(screen.getByText(/choose unicity id/i)).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    // Already protected — the optional SetPasswordScreen never shows, and
+    // the flow finalizes directly.
+    await waitFor(() => expect(ctx.finalizeWallet).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/protect your wallet/i)).toBeNull();
+  });
+
+  it('gracefully skips the auto-apply (no scary error) when the import has no mnemonic to protect, and still offers the optional SetPasswordScreen', async () => {
+    ctx.importFromFile.mockResolvedValue({
+      success: true,
+      // Master-key-only legacy import — no mnemonic recovered.
+      sphere: { getAllTrackedAddresses: () => [], identity: { nametag: null } },
+    });
+    ctx.setWalletPassword.mockImplementation(async () => {
+      throw new Error('No wallet mnemonic found in storage — nothing to protect');
+    });
+
+    await selectAndImportEncryptedFile();
+
+    fireEvent.change(screen.getByPlaceholderText(/wallet password/i), { target: { value: 'file-pw-123' } });
+    fireEvent.click(screen.getByRole('button', { name: /^unlock$/i }));
+
+    await waitFor(() => expect(ctx.setWalletPassword).toHaveBeenCalledWith('file-pw-123'));
+
+    // No scary error surfaced for the automatic attempt — the password
+    // prompt / decrypt flow just proceeds normally to the nametag screen.
+    await waitFor(() => expect(screen.getByText(/choose unicity id/i)).toBeDefined());
+    expect(screen.queryByText(/no wallet mnemonic found/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /skip for now/i }));
+
+    // Not auto-applied (it threw) — the optional SetPasswordScreen IS shown.
+    await waitFor(
+      () => expect(screen.getByText(/protect your wallet/i)).toBeDefined(),
+      { timeout: 3000 },
+    );
+    expect(ctx.finalizeWallet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/restoreFromLock.test.tsx
+++ b/tests/unit/components/restoreFromLock.test.tsx
@@ -96,16 +96,16 @@ describe('restore-from-lock guard (#449)', () => {
     fillSeedWords(VALID_MNEMONIC);
     fireEvent.click(screen.getByRole('button', { name: /^restore$/i }));
 
-    // #449: a valid mnemonic now proceeds to the same optional
-    // SetPasswordScreen the create flow offers, BEFORE importWallet is ever
-    // called — nothing has been persisted yet at this point.
-    await waitFor(() => expect(screen.getByRole('button', { name: /^skip$/i })).toBeDefined());
-    expect(screen.queryByText(/invalid recovery phrase/i)).toBeNull();
-    expect(ctx.importWallet).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
-
+    // #449 Task C: a valid mnemonic now imports PLAINTEXT immediately (no
+    // password threaded into the call) — the optional password step (same
+    // SetPasswordScreen the create flow offers) is deferred to the END of
+    // the flow, after address selection/nametag. With this mock returning no
+    // tracked addresses and no nametag, that lands on the nametag screen
+    // next.
     await waitFor(() => expect(ctx.importWallet).toHaveBeenCalledWith(VALID_MNEMONIC));
+    expect(screen.queryByText(/invalid recovery phrase/i)).toBeNull();
+
+    await waitFor(() => expect(screen.getByText(/choose unicity id/i)).toBeDefined());
   });
 
   it('gates both restore options behind an explicit erase-confirmation when entered from the lock screen', () => {

--- a/tests/unit/components/restoreFromLock.test.tsx
+++ b/tests/unit/components/restoreFromLock.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * #449 CRITICAL no-wallet-loss regression: the UnlockScreen's "forgot
+ * password → restore from recovery phrase" lock-escape must never destroy a
+ * REAL, still-recoverable (locked) wallet before a valid replacement is
+ * confirmed. This covers the two destructive paths that were fixed:
+ *
+ *  1. An invalid/typo'd mnemonic must be rejected in-app (Sphere.validateMnemonic)
+ *     BEFORE `importWallet` — which wraps the SDK's `Sphere.import()`, which
+ *     clears existing storage BEFORE it validates the mnemonic internally —
+ *     is ever called. A wrong phrase must never touch storage.
+ *  2. The lock-escape's "Back" action must exit back to the UnlockScreen
+ *     (via `onExitToUnlock`), never fall through to the generic StartScreen,
+ *     whose "Create New Wallet" button would call `createWallet()` against
+ *     storage that still holds the locked wallet.
+ *
+ * Also covers the erase-confirmation gate (both restore options are disabled
+ * until the user explicitly acknowledges the wallet on this device will be
+ * replaced).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const ctx = vi.hoisted(() => ({
+  importWallet: vi.fn(async () => ({
+    getAllTrackedAddresses: () => [],
+    identity: { nametag: null },
+  })),
+  createWallet: vi.fn(async () => ({ mnemonic: 'never called', sphere: {} })),
+  finalizeWallet: vi.fn(),
+  resolveNametag: vi.fn(async () => null),
+  importFromFile: vi.fn(),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    sphere: null,
+    network: 'testnet2',
+    createWallet: ctx.createWallet,
+    resolveNametag: ctx.resolveNametag,
+    importWallet: ctx.importWallet,
+    importFromFile: ctx.importFromFile,
+    finalizeWallet: ctx.finalizeWallet,
+    walletExists: false,
+    initProgress: null,
+  }),
+}));
+
+import { CreateWalletFlow } from '../../../src/components/wallet/onboarding/CreateWalletFlow';
+
+// Well-known, checksum-valid BIP39 test vector ("abandon..." x11 + "about"),
+// used across the industry (e.g. Ethereum test suites) as a canonical valid
+// 12-word mnemonic.
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+// Not BIP39 wordlist words at all — guaranteed to fail the checksum.
+const INVALID_MNEMONIC =
+  'wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong wrong';
+
+function fillSeedWords(phrase: string) {
+  const inputs = screen.getAllByPlaceholderText('word');
+  phrase.split(' ').forEach((w, i) => fireEvent.change(inputs[i], { target: { value: w } }));
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function renderFlow(props: Parameters<typeof CreateWalletFlow>[0]) {
+  return render(<CreateWalletFlow {...props} />, { wrapper: Wrapper });
+}
+
+describe('restore-from-lock guard (#449)', () => {
+  it('blocks an invalid mnemonic BEFORE importWallet/Sphere.import ever runs — nothing is wiped', async () => {
+    renderFlow({ initialStep: 'restore', fromLock: true, onExitToUnlock: vi.fn() });
+
+    fillSeedWords(INVALID_MNEMONIC);
+    fireEvent.click(screen.getByRole('button', { name: /^restore$/i }));
+
+    await waitFor(() => expect(screen.getByText(/invalid recovery phrase/i)).toBeDefined());
+
+    // The destructive path — importWallet (which wraps Sphere.import, which
+    // clears storage BEFORE validating the mnemonic) — must never run, and
+    // createWallet (the other destructive entry point) must never run either.
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+    expect(ctx.createWallet).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to import once a valid mnemonic is entered', async () => {
+    renderFlow({ initialStep: 'restore', fromLock: true, onExitToUnlock: vi.fn() });
+
+    fillSeedWords(VALID_MNEMONIC);
+    fireEvent.click(screen.getByRole('button', { name: /^restore$/i }));
+
+    await waitFor(() => expect(ctx.importWallet).toHaveBeenCalledWith(VALID_MNEMONIC));
+    expect(screen.queryByText(/invalid recovery phrase/i)).toBeNull();
+  });
+
+  it('gates both restore options behind an explicit erase-confirmation when entered from the lock screen', () => {
+    renderFlow({ initialStep: 'restoreMethod', fromLock: true, onExitToUnlock: vi.fn() });
+
+    const mnemonicOption = screen.getByRole('button', { name: /recovery phrase/i }) as HTMLButtonElement;
+    const fileOption = screen.getByRole('button', { name: /import from file/i }) as HTMLButtonElement;
+    expect(mnemonicOption.disabled).toBe(true);
+    expect(fileOption.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(mnemonicOption.disabled).toBe(false);
+    expect(fileOption.disabled).toBe(false);
+  });
+
+  it('does NOT gate restore options behind the erase-confirmation in normal (non-locked) onboarding', () => {
+    renderFlow({ initialStep: 'restoreMethod' });
+
+    const mnemonicOption = screen.getByRole('button', { name: /recovery phrase/i }) as HTMLButtonElement;
+    expect(mnemonicOption.disabled).toBe(false);
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('exits to the UnlockScreen (not the generic StartScreen) when backing out of the lock-escape', () => {
+    const onExitToUnlock = vi.fn();
+    renderFlow({ initialStep: 'restoreMethod', fromLock: true, onExitToUnlock });
+
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }));
+
+    expect(onExitToUnlock).toHaveBeenCalledTimes(1);
+    // "Create New Wallet" (StartScreen) must never render for this exit —
+    // it would call createWallet() against storage still holding the locked
+    // wallet.
+    expect(screen.queryByText(/create new wallet/i)).toBeNull();
+    expect(ctx.createWallet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/restoreFromLock.test.tsx
+++ b/tests/unit/components/restoreFromLock.test.tsx
@@ -96,8 +96,16 @@ describe('restore-from-lock guard (#449)', () => {
     fillSeedWords(VALID_MNEMONIC);
     fireEvent.click(screen.getByRole('button', { name: /^restore$/i }));
 
-    await waitFor(() => expect(ctx.importWallet).toHaveBeenCalledWith(VALID_MNEMONIC));
+    // #449: a valid mnemonic now proceeds to the same optional
+    // SetPasswordScreen the create flow offers, BEFORE importWallet is ever
+    // called — nothing has been persisted yet at this point.
+    await waitFor(() => expect(screen.getByRole('button', { name: /^skip$/i })).toBeDefined());
     expect(screen.queryByText(/invalid recovery phrase/i)).toBeNull();
+    expect(ctx.importWallet).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    await waitFor(() => expect(ctx.importWallet).toHaveBeenCalledWith(VALID_MNEMONIC));
   });
 
   it('gates both restore options behind an explicit erase-confirmation when entered from the lock screen', () => {

--- a/tests/unit/components/securityModalReentrancy.test.tsx
+++ b/tests/unit/components/securityModalReentrancy.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * #449 review-fix regression: SecurityModal's submit/Enter handlers must not
+ * launch a second concurrent password operation on a rapid double-submit or
+ * Enter-mash. Before the fix, handleSet/handleChange/handleRemove didn't
+ * check `busy` at all, so two overlapping reencryptStoredMnemonic calls
+ * could race against the SAME mnemonic storage key.
+ *
+ * The provider (setWalletPassword/changeWalletPassword/removeWalletPassword)
+ * is mocked here — this file exercises ONLY the modal's own re-entrancy
+ * guard. See SphereProvider.tsx's withPasswordOpLock for the provider-level
+ * backstop, and passwordChangeTimeoutPreservation.test.tsx for the other
+ * #449 review fix (auto-lock timeout preservation).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const sphereMock = vi.hoisted(() => ({
+  hasWalletPassword: true,
+  setWalletPassword: vi.fn(),
+  changeWalletPassword: vi.fn(),
+  removeWalletPassword: vi.fn(),
+  setAutoLockTimeout: vi.fn(),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    hasWalletPassword: sphereMock.hasWalletPassword,
+    setWalletPassword: sphereMock.setWalletPassword,
+    changeWalletPassword: sphereMock.changeWalletPassword,
+    removeWalletPassword: sphereMock.removeWalletPassword,
+    autoLockMinutes: 15,
+    setAutoLockTimeout: sphereMock.setAutoLockTimeout,
+  }),
+}));
+
+import { SecurityModal } from '../../../src/components/wallet/L3/modals/SecurityModal';
+
+/** A promise the test controls the resolution of, to hold a submit "in flight". */
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function renderModal() {
+  return render(<SecurityModal isOpen onClose={vi.fn()} />);
+}
+
+function fillChangePasswordForm() {
+  fireEvent.click(screen.getByRole('button', { name: 'Change Password' }));
+  fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'old-pw-123' } });
+  fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'new-password-1' } });
+  fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'new-password-1' } });
+}
+
+beforeEach(() => {
+  sphereMock.hasWalletPassword = true;
+  sphereMock.setWalletPassword.mockReset();
+  sphereMock.changeWalletPassword.mockReset();
+  sphereMock.removeWalletPassword.mockReset();
+});
+
+describe('SecurityModal — re-entrancy guard (#449 review fix)', () => {
+  it('a rapid double-click on Change Password only invokes the provider once', () => {
+    const gate = deferred();
+    sphereMock.changeWalletPassword.mockReturnValue(gate.promise);
+
+    renderModal();
+    fillChangePasswordForm();
+
+    const submit = screen.getByRole('button', { name: 'Change Password' });
+    fireEvent.click(submit);
+    fireEvent.click(submit); // re-entrant click while the first call is still pending
+
+    expect(sphereMock.changeWalletPassword).toHaveBeenCalledTimes(1);
+    gate.resolve();
+  });
+
+  it('Enter-mashing the confirm-password field only invokes the provider once', () => {
+    const gate = deferred();
+    sphereMock.changeWalletPassword.mockReturnValue(gate.promise);
+
+    renderModal();
+    fillChangePasswordForm();
+
+    const confirm = screen.getByLabelText('Confirm new password');
+    fireEvent.keyDown(confirm, { key: 'Enter' });
+    fireEvent.keyDown(confirm, { key: 'Enter' }); // Enter-mash while the first call is still pending
+
+    expect(sphereMock.changeWalletPassword).toHaveBeenCalledTimes(1);
+    gate.resolve();
+  });
+
+  it('a rapid double-click on Set Password only invokes the provider once', () => {
+    sphereMock.hasWalletPassword = false; // Set mode is only offered without an existing password
+    const gate = deferred();
+    sphereMock.setWalletPassword.mockReturnValue(gate.promise);
+
+    renderModal();
+    // The Set-Password MenuButton also has a subtitle, so its accessible
+    // name includes that text — match the label text itself instead.
+    fireEvent.click(screen.getByText('Set Password'));
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'new-password-1' } });
+    fireEvent.change(screen.getByLabelText('Confirm new password'), { target: { value: 'new-password-1' } });
+
+    const submit = screen.getByRole('button', { name: 'Set Password' });
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+
+    expect(sphereMock.setWalletPassword).toHaveBeenCalledTimes(1);
+    gate.resolve();
+  });
+
+  it('a rapid double-submit on Remove Password only invokes the provider once', () => {
+    const gate = deferred();
+    sphereMock.removeWalletPassword.mockReturnValue(gate.promise);
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Password' }));
+    fireEvent.change(screen.getByLabelText('Current password'), { target: { value: 'old-pw-123' } });
+
+    const submit = screen.getByRole('button', { name: 'Remove Password' });
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+
+    expect(sphereMock.removeWalletPassword).toHaveBeenCalledTimes(1);
+    gate.resolve();
+  });
+
+  it('Enter-mashing the current-password field in Remove mode only invokes the provider once', () => {
+    const gate = deferred();
+    sphereMock.removeWalletPassword.mockReturnValue(gate.promise);
+
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Password' }));
+    const current = screen.getByLabelText('Current password');
+    fireEvent.change(current, { target: { value: 'old-pw-123' } });
+
+    fireEvent.keyDown(current, { key: 'Enter' });
+    fireEvent.keyDown(current, { key: 'Enter' });
+
+    expect(sphereMock.removeWalletPassword).toHaveBeenCalledTimes(1);
+    gate.resolve();
+  });
+});

--- a/tests/unit/components/setPasswordScreen.test.tsx
+++ b/tests/unit/components/setPasswordScreen.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SetPasswordScreen } from '../../../src/components/wallet/onboarding/components/SetPasswordScreen';
+
+describe('SetPasswordScreen', () => {
+  it('calls onSet when password matches and is long enough', () => {
+    const onSet = vi.fn();
+    render(<SetPasswordScreen onSet={onSet} onSkip={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'password1' } });
+    fireEvent.click(screen.getByRole('button', { name: /set password/i }));
+    expect(onSet).toHaveBeenCalledWith('password1');
+  });
+  it('blocks mismatched passwords', () => {
+    const onSet = vi.fn();
+    render(<SetPasswordScreen onSet={onSet} onSkip={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'password2' } });
+    fireEvent.click(screen.getByRole('button', { name: /set password/i }));
+    expect(onSet).not.toHaveBeenCalled();
+    expect(screen.getByText(/don't match/i)).toBeDefined();
+  });
+  it('blocks passwords shorter than 8 characters', () => {
+    const onSet = vi.fn();
+    render(<SetPasswordScreen onSet={onSet} onSkip={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'short1' } });
+    fireEvent.change(screen.getByLabelText(/confirm/i), { target: { value: 'short1' } });
+    fireEvent.click(screen.getByRole('button', { name: /set password/i }));
+    expect(onSet).not.toHaveBeenCalled();
+    expect(screen.getByText(/at least 8/i)).toBeDefined();
+  });
+  it('skips', () => {
+    const onSkip = vi.fn();
+    render(<SetPasswordScreen onSet={vi.fn()} onSkip={onSkip} />);
+    fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+    expect(onSkip).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/setPasswordScreen.test.tsx
+++ b/tests/unit/components/setPasswordScreen.test.tsx
@@ -35,4 +35,8 @@ describe('SetPasswordScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: /skip/i }));
     expect(onSkip).toHaveBeenCalled();
   });
+  it('renders an external error (e.g. a failed setWalletPassword) without needing local validation to trigger it', () => {
+    render(<SetPasswordScreen onSet={vi.fn()} onSkip={vi.fn()} error="Failed to set a wallet password" />);
+    expect(screen.getByText('Failed to set a wallet password')).toBeDefined();
+  });
 });

--- a/tests/unit/components/settingsLockWallet.test.tsx
+++ b/tests/unit/components/settingsLockWallet.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * #449: A manual "Lock Wallet" action in Settings. It calls the context's
+ * lock() and closes Settings. CRITICAL no-wallet-loss invariant: the button
+ * is shown ONLY when the wallet has an at-rest password
+ * (hasWalletPassword === true). Locking a password-less wallet would leave it
+ * requiring an unlock password that doesn't exist — the user could only
+ * recover from seed. So a password-less wallet must never see this button.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const sphereMock = vi.hoisted(() => ({
+  hasWalletPassword: true,
+  lock: vi.fn(async () => {}),
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({
+    hasWalletPassword: sphereMock.hasWalletPassword,
+    lock: sphereMock.lock,
+  }),
+}));
+
+// Isolate SettingsModal from the heavy child screens and their own hooks.
+vi.mock('../../../src/components/upgrade', () => ({ useUpgrade: () => ({ openUpgrade: vi.fn() }) }));
+vi.mock('../../../src/sdk/hooks/subscription', () => ({ useUtilization: () => ({ data: undefined }) }));
+vi.mock('../../../src/components/wallet/L3/modals/LookupModal', () => ({ LookupModal: () => null }));
+vi.mock('../../../src/components/wallet/L3/modals/AddressManagerModal', () => ({ AddressManagerModal: () => null }));
+vi.mock('../../../src/components/wallet/L3/modals/ConnectedSitesModal', () => ({ ConnectedSitesModal: () => null }));
+vi.mock('../../../src/components/wallet/L3/modals/SubscriptionModal', () => ({ SubscriptionModal: () => null }));
+vi.mock('../../../src/components/wallet/L3/modals/SecurityModal', () => ({ SecurityModal: () => null }));
+
+import { SettingsModal } from '../../../src/components/wallet/L3/modals/SettingsModal';
+
+function renderSettings(overrides: { onClose?: () => void } = {}) {
+  return render(
+    <SettingsModal
+      isOpen
+      onClose={overrides.onClose ?? vi.fn()}
+      onBackupWallet={vi.fn()}
+      onLogout={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  sphereMock.hasWalletPassword = true;
+  sphereMock.lock.mockReset();
+  sphereMock.lock.mockResolvedValue(undefined);
+});
+
+describe('SettingsModal — manual Lock Wallet (#449)', () => {
+  it('shows "Lock Wallet" and calls lock() + onClose when a password is set', () => {
+    const onClose = vi.fn();
+    renderSettings({ onClose });
+
+    const lockBtn = screen.getByRole('button', { name: /lock wallet/i });
+    fireEvent.click(lockBtn);
+
+    expect(sphereMock.lock).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides "Lock Wallet" when the wallet has no password (would strand the user)', () => {
+    sphereMock.hasWalletPassword = false;
+    renderSettings();
+
+    expect(screen.queryByRole('button', { name: /lock wallet/i })).toBeNull();
+    expect(sphereMock.lock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/unlockScreen.test.tsx
+++ b/tests/unit/components/unlockScreen.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SphereError } from '@unicitylabs/sphere-sdk';
 
 const unlock = vi.hoisted(() => ({ fn: vi.fn(async () => {}) }));
 vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
@@ -15,11 +16,21 @@ describe('UnlockScreen', () => {
     await waitFor(() => expect(unlock.fn).toHaveBeenCalledWith('pw'));
   });
   it('shows an error on a wrong password', async () => {
-    unlock.fn.mockRejectedValueOnce(Object.assign(new Error('x'), { code: 'DECRYPTION_ERROR' }));
+    // The REAL SDK signal (@unicitylabs/sphere-sdk@0.12.0, code-verified) for
+    // a wrong password on unlock(): SphereError('Failed to decrypt mnemonic',
+    // 'STORAGE_ERROR') — see src/sdk/walletLock/isDecryptionError.ts.
+    unlock.fn.mockRejectedValueOnce(new SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR'));
     render(<UnlockScreen onRestore={vi.fn()} />);
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'bad' } });
     fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
     await waitFor(() => expect(screen.getByText(/incorrect password/i)).toBeDefined());
+  });
+  it('shows a generic error (not "incorrect password") on a real storage failure', async () => {
+    unlock.fn.mockRejectedValueOnce(new SphereError('IndexedDB transaction failed', 'STORAGE_ERROR'));
+    render(<UnlockScreen onRestore={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'whatever' } });
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
+    await waitFor(() => expect(screen.getByText(/could not unlock/i)).toBeDefined());
   });
   it('offers restore-from-recovery-phrase', () => {
     const onRestore = vi.fn();

--- a/tests/unit/components/unlockScreen.test.tsx
+++ b/tests/unit/components/unlockScreen.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const unlock = vi.hoisted(() => ({ fn: vi.fn(async () => {}) }));
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ unlock: unlock.fn, isLocked: true }),
+}));
+import { UnlockScreen } from '../../../src/components/wallet/onboarding/components/UnlockScreen';
+
+describe('UnlockScreen', () => {
+  it('calls unlock with the entered password', async () => {
+    render(<UnlockScreen onRestore={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pw' } });
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
+    await waitFor(() => expect(unlock.fn).toHaveBeenCalledWith('pw'));
+  });
+  it('shows an error on a wrong password', async () => {
+    unlock.fn.mockRejectedValueOnce(Object.assign(new Error('x'), { code: 'DECRYPTION_ERROR' }));
+    render(<UnlockScreen onRestore={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'bad' } });
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
+    await waitFor(() => expect(screen.getByText(/incorrect password/i)).toBeDefined());
+  });
+  it('offers restore-from-recovery-phrase', () => {
+    const onRestore = vi.fn();
+    render(<UnlockScreen onRestore={onRestore} />);
+    fireEvent.click(screen.getByText(/recovery phrase/i));
+    expect(onRestore).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sdk/walletLock/autoLockWiring.test.tsx
+++ b/tests/unit/sdk/walletLock/autoLockWiring.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * #449 Task 8a integration coverage: the idle-auto-lock WIRING inside
+ * SphereProvider (as opposed to the unit-level useIdleTimer/lockBroadcast
+ * tests, which don't touch the provider at all).
+ *
+ * Covers the two load-bearing behaviors:
+ *  - A wallet unlocked WITH a password arms the idle timer (idleLockConfig
+ *    goes enabled), and an idle timeout actually locks the wallet AND
+ *    notifies the registered ConnectHost via notifyWalletLocked().
+ *  - A wallet that never had a password (this session) — the plaintext
+ *    regression, from the OTHER side of the invariant — never arms the idle
+ *    timer, no matter how long the user is "idle" for.
+ *
+ * See also plaintextWalletLoads.test.tsx (init-path plaintext regression)
+ * and useIdleTimer.test.tsx / lockBroadcast.test.ts (unit-level timer/
+ * broadcast mechanics).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ConnectHost } from '@unicitylabs/sphere-sdk/connect';
+import type { SphereContextValue } from '../../../../src/sdk/SphereContext';
+
+const PUBKEY = '02' + 'ab'.repeat(32);
+
+const initSpy = vi.hoisted(() => ({ calls: [] as Record<string, unknown>[] }));
+// Toggles the mocked Sphere.init behavior between the two wallet shapes this
+// file exercises: an existing wallet stored WITHOUT a password (Sphere.init
+// always succeeds, like plaintextWalletLoads.test.tsx) vs one stored WITH a
+// password (the passwordless load throws DECRYPTION_ERROR — "locked" — and
+// only a call carrying the right password succeeds, mirroring unlock()).
+const mockState = vi.hoisted(() => ({ mode: 'plaintext' as 'plaintext' | 'encrypted' }));
+
+function makeFakeSphere() {
+  return {
+    identity: { chainPubkey: PUBKEY },
+    // SphereProvider's existing-wallet / unlock() success paths only ever
+    // call these on the adopted instance — keep in sync with SphereProvider.
+    on: vi.fn(() => () => {}),
+    destroy: vi.fn(async () => {}),
+    discoverAddresses: vi.fn(async () => ({ addresses: [] })),
+  };
+}
+
+vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk')>();
+  return {
+    ...actual,
+    Sphere: {
+      ...actual.Sphere,
+      exists: vi.fn(async () => true),
+      init: vi.fn(async (opts: Record<string, unknown>) => {
+        initSpy.calls.push(opts);
+        if (mockState.mode === 'encrypted' && !opts.password) {
+          throw { code: 'DECRYPTION_ERROR' };
+        }
+        return { sphere: makeFakeSphere() };
+      }),
+    },
+  };
+});
+
+// The real browser provider bundle opens IndexedDB/Nostr/network connections
+// that are irrelevant here — stub it with a minimal, inert bundle (shape:
+// BrowserProviders), same as plaintextWalletLoads.test.tsx.
+vi.mock('@unicitylabs/sphere-sdk/impl/browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk/impl/browser')>();
+  return {
+    ...actual,
+    createBrowserProviders: vi.fn(() => ({
+      storage: {
+        get: vi.fn(async () => null),
+        set: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+      },
+      transport: {
+        isConnected: () => false,
+        connect: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+        setIdentity: vi.fn(async () => {}),
+      },
+      oracle: {},
+      tokenStorage: { disconnect: vi.fn(async () => {}) },
+      ipfsTokenStorage: undefined,
+      groupChat: true,
+      market: true,
+    })),
+  };
+});
+
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+import { SphereProvider } from '../../../../src/sdk/SphereProvider';
+import { useSphereContext } from '../../../../src/sdk/hooks/core/useSphere';
+import { setActiveConnectHost } from '../../../../src/sdk/connectHostRegistry';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+// Captures the live context so the test can call unlock()/etc. imperatively
+// — this file needs to DRIVE the provider (not just observe it), which a
+// display-only Probe (as in plaintextWalletLoads.test.tsx) can't do.
+let ctx: SphereContextValue | null = null;
+function Probe() {
+  ctx = useSphereContext();
+  const { isLocked, isLoading, sphere } = ctx;
+  return (
+    <div>
+      <div data-testid="loading">{String(isLoading)}</div>
+      <div data-testid="sphere">{sphere ? 'present' : 'null'}</div>
+      <div data-testid="locked">{String(isLocked)}</div>
+    </div>
+  );
+}
+
+function renderProvider() {
+  render(
+    <Wrapper>
+      <SphereProvider>
+        <Probe />
+      </SphereProvider>
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  initSpy.calls.length = 0;
+  mockState.mode = 'plaintext';
+  ctx = null;
+  // SphereProvider calls the real TokenRegistry.configure() as part of its
+  // normal init flow; with a cache miss that fetches its remote token list
+  // for real. Stub fetch so this test never makes a real network call.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network disabled in test');
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  setActiveConnectHost(null);
+  // TokenRegistry is a process-wide singleton that starts a background
+  // refresh timer on configure() — reset it so it doesn't leak into (or slow
+  // down) other test files.
+  TokenRegistry.resetInstance();
+});
+
+describe('idle auto-lock wiring (#449 Task 8a)', () => {
+  it('a wallet WITH a password arms auto-lock, and idle locks it + notifies the connected dApp', async () => {
+    mockState.mode = 'encrypted';
+    renderProvider();
+
+    // Mount-time initialize() runs the passwordless load path first, which
+    // throws DECRYPTION_ERROR for this wallet shape — real timers here, this
+    // part is plain async resolution (see plaintextWalletLoads.test.tsx).
+    await waitFor(() => expect(screen.getByTestId('locked').textContent).toBe('true'));
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+    expect(screen.getByTestId('sphere').textContent).toBe('null');
+
+    const fakeHost = { notifyWalletLocked: vi.fn() };
+    setActiveConnectHost(fakeHost as unknown as ConnectHost);
+
+    // Fake timers from here on — the idle timer's setTimeout must be armed by
+    // unlock()'s setSessionPassword(password) call, and we need to fast-forward
+    // past it deterministically.
+    vi.useFakeTimers();
+    await act(async () => {
+      await ctx!.unlock('correct horse battery staple');
+    });
+
+    // Unlock succeeded: the wallet is live and no longer locked.
+    expect(screen.getByTestId('locked').textContent).toBe('false');
+    expect(screen.getByTestId('sphere').textContent).toBe('present');
+    expect(fakeHost.notifyWalletLocked).not.toHaveBeenCalled();
+
+    // Default auto-lock timeout (no stored settings blob → DEFAULT_AUTO_LOCK_MINUTES,
+    // 15 minutes — src/sdk/walletLock/lockSettings.ts) — advance just past it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000 + 5000);
+    });
+
+    // Idle timeout fired: the provider locked itself and told the dApp.
+    expect(screen.getByTestId('locked').textContent).toBe('true');
+    expect(screen.getByTestId('sphere').textContent).toBe('null');
+    // At least once — the same-tab BroadcastChannel loopback (see the onIdle
+    // comment in SphereProvider.tsx) can legitimately drive lock() a second
+    // time in this very tab; lock()/notifyWalletLocked() are idempotent, so
+    // this test asserts the load-bearing fact (the dApp WAS told) rather than
+    // an exact call count that depends on that loopback timing.
+    expect(fakeHost.notifyWalletLocked).toHaveBeenCalled();
+  });
+
+  it('a wallet with NO password never arms auto-lock, even far past any timeout', async () => {
+    mockState.mode = 'plaintext';
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+    expect(screen.getByTestId('sphere').textContent).toBe('present');
+    expect(screen.getByTestId('locked').textContent).toBe('false');
+
+    const fakeHost = { notifyWalletLocked: vi.fn() };
+    setActiveConnectHost(fakeHost as unknown as ConnectHost);
+
+    vi.useFakeTimers();
+    // Ten times the longest configurable auto-lock option (30 min) — if the
+    // no-password invariant ever regressed, this would be more than enough
+    // time to observe a false lock.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 30 * 60 * 1000);
+    });
+
+    expect(screen.getByTestId('locked').textContent).toBe('false');
+    expect(screen.getByTestId('sphere').textContent).toBe('present');
+    expect(fakeHost.notifyWalletLocked).not.toHaveBeenCalled();
+
+    // The existing-wallet load path must still never have passed a password —
+    // this is a plaintext wallet throughout (mirrors plaintextWalletLoads.test.tsx).
+    expect(initSpy.calls.length).toBeGreaterThan(0);
+    expect(initSpy.calls.every((c) => c.password === undefined)).toBe(true);
+  });
+});

--- a/tests/unit/sdk/walletLock/autoLockWiring.test.tsx
+++ b/tests/unit/sdk/walletLock/autoLockWiring.test.tsx
@@ -53,7 +53,10 @@ vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
       init: vi.fn(async (opts: Record<string, unknown>) => {
         initSpy.calls.push(opts);
         if (mockState.mode === 'encrypted' && !opts.password) {
-          throw { code: 'DECRYPTION_ERROR' };
+          // The REAL SDK signal (@unicitylabs/sphere-sdk@0.12.0, code-verified)
+          // for an encrypted wallet opened without/with the wrong password —
+          // see src/sdk/walletLock/isDecryptionError.ts.
+          throw new actual.SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR');
         }
         return { sphere: makeFakeSphere() };
       }),

--- a/tests/unit/sdk/walletLock/classifyInitFailure.test.ts
+++ b/tests/unit/sdk/walletLock/classifyInitFailure.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect } from 'vitest';
+import { SphereError } from '@unicitylabs/sphere-sdk';
 import { classifyInitFailure } from '../../../../src/sdk/walletLock/classifyInitFailure';
 
 describe('classifyInitFailure', () => {
-  it('maps DECRYPTION_ERROR to "locked" (not a fatal error)', () => {
+  // The REAL SDK signal (@unicitylabs/sphere-sdk@0.12.0, code-verified — see
+  // isDecryptionError.test.ts) for "encrypted wallet, wrong/missing password".
+  it('maps the real SDK decrypt-mnemonic STORAGE_ERROR to "locked" (not a fatal error)', () => {
+    const e = new SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR');
+    expect(classifyInitFailure(e)).toBe('locked');
+  });
+
+  // Defensive: kept in case a future SDK version throws this literal code directly.
+  it('maps a literal DECRYPTION_ERROR code to "locked" too (defensive)', () => {
     expect(classifyInitFailure({ code: 'DECRYPTION_ERROR' })).toBe('locked');
+  });
+
+  // CRITICAL: a genuine IndexedDB STORAGE_ERROR (no decrypt-mnemonic message)
+  // must stay "error" so it still hits the real storage retry/error screen —
+  // it must NEVER masquerade as a locked wallet.
+  it('maps a generic STORAGE_ERROR (real IndexedDB fault) to "error"', () => {
+    const e = new SphereError('IndexedDB transaction failed', 'STORAGE_ERROR');
+    expect(classifyInitFailure(e)).toBe('error');
   });
   it('maps everything else to "error"', () => {
     expect(classifyInitFailure({ code: 'STORAGE_ERROR' })).toBe('error');

--- a/tests/unit/sdk/walletLock/classifyInitFailure.test.ts
+++ b/tests/unit/sdk/walletLock/classifyInitFailure.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { classifyInitFailure } from '../../../../src/sdk/walletLock/classifyInitFailure';
+
+describe('classifyInitFailure', () => {
+  it('maps DECRYPTION_ERROR to "locked" (not a fatal error)', () => {
+    expect(classifyInitFailure({ code: 'DECRYPTION_ERROR' })).toBe('locked');
+  });
+  it('maps everything else to "error"', () => {
+    expect(classifyInitFailure({ code: 'STORAGE_ERROR' })).toBe('error');
+    expect(classifyInitFailure(new Error('x'))).toBe('error');
+  });
+});

--- a/tests/unit/sdk/walletLock/isDecryptionError.test.ts
+++ b/tests/unit/sdk/walletLock/isDecryptionError.test.ts
@@ -1,16 +1,48 @@
 import { describe, it, expect } from 'vitest';
+import { SphereError } from '@unicitylabs/sphere-sdk';
 import { isDecryptionError } from '../../../../src/sdk/walletLock/isDecryptionError';
 
 describe('isDecryptionError', () => {
-  it('is true for a Sphere DECRYPTION_ERROR', () => {
+  // The REAL signal thrown by @unicitylabs/sphere-sdk@0.12.0 on a
+  // mnemonic-decrypt failure (wrong/missing password on an encrypted wallet).
+  // Code-verified in node_modules/@unicitylabs/sphere-sdk/dist/core/index.cjs
+  // (loadIdentityFromStorage): `throw new SphereError("Failed to decrypt
+  // mnemonic", "STORAGE_ERROR")`. See src/sdk/walletLock/isDecryptionError.ts.
+  it('is true for the real SDK signal: SphereError STORAGE_ERROR "Failed to decrypt mnemonic"', () => {
+    const e = new SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR');
+    expect(isDecryptionError(e)).toBe(true);
+  });
+
+  it('is true regardless of message case (case-insensitive match)', () => {
+    const e = new SphereError('FAILED TO DECRYPT MNEMONIC', 'STORAGE_ERROR');
+    expect(isDecryptionError(e)).toBe(true);
+  });
+
+  // Defensive: kept in case a future SDK version throws this literal code directly.
+  it('is true for a literal DECRYPTION_ERROR code (defensive, future-proofing)', () => {
     expect(isDecryptionError({ code: 'DECRYPTION_ERROR' })).toBe(true);
   });
-  it('is true for an Error carrying the code property', () => {
+  it('is true for an Error carrying the DECRYPTION_ERROR code property', () => {
     const e = Object.assign(new Error('bad password'), { code: 'DECRYPTION_ERROR' });
     expect(isDecryptionError(e)).toBe(true);
   });
-  it('is false for other Sphere errors', () => {
+
+  // CRITICAL: a GENERIC STORAGE_ERROR (real IndexedDB fault, no decrypt-mnemonic
+  // message) must NEVER be classified as "locked" — that would mask a genuine
+  // storage failure as a solvable password prompt.
+  it('is false for a generic STORAGE_ERROR with no decrypt-mnemonic message', () => {
+    const e = new SphereError('IndexedDB transaction failed', 'STORAGE_ERROR');
+    expect(isDecryptionError(e)).toBe(false);
+  });
+  it('is false for a plain object with STORAGE_ERROR code (not a real SphereError, no message)', () => {
     expect(isDecryptionError({ code: 'STORAGE_ERROR' })).toBe(false);
+  });
+  it('is false for a STORAGE_ERROR mentioning "decrypt" but not "mnemonic" (e.g. master key)', () => {
+    const e = new SphereError('Failed to decrypt master key', 'STORAGE_ERROR');
+    expect(isDecryptionError(e)).toBe(false);
+  });
+  it('is false for other Sphere errors', () => {
+    expect(isDecryptionError(new SphereError('Identity not set', 'NOT_INITIALIZED'))).toBe(false);
   });
   it('is false for non-error values', () => {
     expect(isDecryptionError(null)).toBe(false);

--- a/tests/unit/sdk/walletLock/isDecryptionError.test.ts
+++ b/tests/unit/sdk/walletLock/isDecryptionError.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { isDecryptionError } from '../../../../src/sdk/walletLock/isDecryptionError';
+
+describe('isDecryptionError', () => {
+  it('is true for a Sphere DECRYPTION_ERROR', () => {
+    expect(isDecryptionError({ code: 'DECRYPTION_ERROR' })).toBe(true);
+  });
+  it('is true for an Error carrying the code property', () => {
+    const e = Object.assign(new Error('bad password'), { code: 'DECRYPTION_ERROR' });
+    expect(isDecryptionError(e)).toBe(true);
+  });
+  it('is false for other Sphere errors', () => {
+    expect(isDecryptionError({ code: 'STORAGE_ERROR' })).toBe(false);
+  });
+  it('is false for non-error values', () => {
+    expect(isDecryptionError(null)).toBe(false);
+    expect(isDecryptionError('DECRYPTION_ERROR')).toBe(false);
+  });
+});

--- a/tests/unit/sdk/walletLock/lockBroadcast.test.ts
+++ b/tests/unit/sdk/walletLock/lockBroadcast.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure cross-tab lock signal (#449 Task 8a): `broadcastLock()` tells every
+ * OTHER tab to lock immediately (idle auto-lock or an explicit lock in one
+ * tab must lock all of them). Real BroadcastChannel is available under
+ * vitest/jsdom; delivery across separate channel instances is asynchronous,
+ * so tests await a short tick instead of asserting synchronously.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { broadcastLock, subscribeLockBroadcast } from '../../../../src/sdk/walletLock/lockBroadcast';
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe('lockBroadcast', () => {
+  it('delivers a broadcastLock() post to a subscriber on another channel instance', async () => {
+    const channelName = `lock-test-${Math.random().toString(36).slice(2)}`;
+    const onLock = vi.fn();
+    const unsubscribe = subscribeLockBroadcast(channelName, onLock);
+
+    broadcastLock(channelName);
+    await sleep(50);
+
+    expect(onLock).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it('stops delivery after unsubscribe', async () => {
+    const channelName = `lock-test-${Math.random().toString(36).slice(2)}`;
+    const onLock = vi.fn();
+    const unsubscribe = subscribeLockBroadcast(channelName, onLock);
+
+    unsubscribe();
+    broadcastLock(channelName);
+    await sleep(50);
+
+    expect(onLock).not.toHaveBeenCalled();
+  });
+
+  it('uses the shared default channel name when none is given, so a same-process default subscriber still receives it', async () => {
+    const onLock = vi.fn();
+    const unsubscribe = subscribeLockBroadcast(undefined, onLock);
+
+    broadcastLock();
+    await sleep(50);
+
+    expect(onLock).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it('is a no-op when BroadcastChannel is unavailable (e.g. very old browsers)', () => {
+    const original = globalThis.BroadcastChannel;
+    // @ts-expect-error deliberately simulating an environment without BroadcastChannel
+    delete globalThis.BroadcastChannel;
+    try {
+      expect(() => broadcastLock('whatever')).not.toThrow();
+      const unsubscribe = subscribeLockBroadcast('whatever', vi.fn());
+      expect(() => unsubscribe()).not.toThrow();
+    } finally {
+      globalThis.BroadcastChannel = original;
+    }
+  });
+});

--- a/tests/unit/sdk/walletLock/lockSettings.test.ts
+++ b/tests/unit/sdk/walletLock/lockSettings.test.ts
@@ -4,6 +4,13 @@ import {
   DEFAULT_AUTO_LOCK_MINUTES,
 } from '../../../../src/sdk/walletLock/lockSettings';
 
+// These tests run real PBKDF2 encryption (via encodeLockSettings/decodeLockSettings)
+// which is intentionally slow. Under full-suite parallelism that can intermittently
+// exceed vitest's default 5s per-test timeout even though each test passes fine in
+// isolation — give the crypto-touching tests a generous timeout so they're reliably
+// green under `npm run test:run` (#449 review). Assertions are unchanged.
+const SLOW_CRYPTO_TIMEOUT_MS = 20000;
+
 describe('lockSettings', () => {
   it('round-trips the timeout through password encryption', () => {
     const blob = encodeLockSettings(5, 'pw');
@@ -12,19 +19,19 @@ describe('lockSettings', () => {
     // iv/salt/ciphertext hex/base64 coincidentally contains the digit '5' most runs.)
     expect(blob).not.toContain('"autoLockMinutes":5');
     expect(decodeLockSettings(blob, 'pw')).toBe(5);
-  });
+  }, SLOW_CRYPTO_TIMEOUT_MS);
   it('round-trips "never"', () => {
     expect(decodeLockSettings(encodeLockSettings('never', 'pw'), 'pw')).toBe('never');
-  });
+  }, SLOW_CRYPTO_TIMEOUT_MS);
   it('falls back to the default when decryption fails (wrong password / tampered blob)', () => {
     const blob = encodeLockSettings(5, 'pw');
     expect(decodeLockSettings(blob, 'WRONG')).toBe(DEFAULT_AUTO_LOCK_MINUTES);
     expect(decodeLockSettings('garbage', 'pw')).toBe(DEFAULT_AUTO_LOCK_MINUTES);
-  });
+  }, SLOW_CRYPTO_TIMEOUT_MS);
   it('falls back to the default for an out-of-range value', () => {
     const blob = encodeLockSettings(999 as unknown as number, 'pw');
     expect(decodeLockSettings(blob, 'pw')).toBe(DEFAULT_AUTO_LOCK_MINUTES);
-  });
+  }, SLOW_CRYPTO_TIMEOUT_MS);
   it('autoLockMs maps minutes to ms and "never" to null', () => {
     expect(autoLockMs(15)).toBe(15 * 60 * 1000);
     expect(autoLockMs('never')).toBeNull();

--- a/tests/unit/sdk/walletLock/lockSettings.test.ts
+++ b/tests/unit/sdk/walletLock/lockSettings.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeLockSettings, decodeLockSettings, autoLockMs,
+  DEFAULT_AUTO_LOCK_MINUTES,
+} from '../../../../src/sdk/walletLock/lockSettings';
+
+describe('lockSettings', () => {
+  it('round-trips the timeout through password encryption', () => {
+    const blob = encodeLockSettings(5, 'pw');
+    // Encrypted, not plaintext: the literal plaintext JSON substring must never appear.
+    // (A raw `.not.toContain('5')` check is flaky — the encrypted envelope's random
+    // iv/salt/ciphertext hex/base64 coincidentally contains the digit '5' most runs.)
+    expect(blob).not.toContain('"autoLockMinutes":5');
+    expect(decodeLockSettings(blob, 'pw')).toBe(5);
+  });
+  it('round-trips "never"', () => {
+    expect(decodeLockSettings(encodeLockSettings('never', 'pw'), 'pw')).toBe('never');
+  });
+  it('falls back to the default when decryption fails (wrong password / tampered blob)', () => {
+    const blob = encodeLockSettings(5, 'pw');
+    expect(decodeLockSettings(blob, 'WRONG')).toBe(DEFAULT_AUTO_LOCK_MINUTES);
+    expect(decodeLockSettings('garbage', 'pw')).toBe(DEFAULT_AUTO_LOCK_MINUTES);
+  });
+  it('falls back to the default for an out-of-range value', () => {
+    const blob = encodeLockSettings(999 as unknown as number, 'pw');
+    expect(decodeLockSettings(blob, 'pw')).toBe(DEFAULT_AUTO_LOCK_MINUTES);
+  });
+  it('autoLockMs maps minutes to ms and "never" to null', () => {
+    expect(autoLockMs(15)).toBe(15 * 60 * 1000);
+    expect(autoLockMs('never')).toBeNull();
+  });
+});

--- a/tests/unit/sdk/walletLock/lockedWalletColdStart.test.tsx
+++ b/tests/unit/sdk/walletLock/lockedWalletColdStart.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * #449 CRITICAL regression guard (ship-blocking bug fix): cold-start/reload of
+ * a PASSWORD-PROTECTED wallet must land on the UnlockScreen (isLocked ===
+ * true), never on the "Initialization error" screen and never stuck retrying.
+ *
+ * Root cause this guards against: @unicitylabs/sphere-sdk@0.12.0 does NOT
+ * throw `DECRYPTION_ERROR` on a mnemonic-decrypt failure — it throws
+ * `SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR')` (code-verified
+ * in node_modules/@unicitylabs/sphere-sdk/dist/core/index.cjs,
+ * loadIdentityFromStorage — see src/sdk/walletLock/isDecryptionError.ts).
+ * Before the fix, `isDecryptionError`/`classifyInitFailure` only matched a
+ * literal `code === 'DECRYPTION_ERROR'`, so this real error fell through to
+ * `classifyInitFailure() === 'error'`, re-threw out of the inner try/catch in
+ * SphereProvider.initialize(), and was caught by the OUTER catch's
+ * `isSphereError(err) && err.code === 'STORAGE_ERROR'` IndexedDB-retry guard
+ * — which retried once (Sphere.init called TWICE) and then surfaced a fatal
+ * `error`, stranding a password-protected wallet with no way to unlock.
+ *
+ * This test fails without the fix: it asserts isLocked ends true, error stays
+ * null, and — the sharpest guard against "retried, then errored" — Sphere.init
+ * is called exactly ONCE (the outer STORAGE_ERROR retry never fires).
+ *
+ * See also plaintextWalletLoads.test.tsx (the other side of the invariant —
+ * an existing PLAINTEXT wallet must keep loading straight through) and
+ * autoLockWiring.test.tsx (broader idle-lock integration, same wallet shape).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SphereContextValue } from '../../../../src/sdk/SphereContext';
+
+const PUBKEY = '02' + 'ab'.repeat(32);
+
+const initSpy = vi.hoisted(() => ({ calls: [] as Record<string, unknown>[] }));
+
+function makeFakeSphere() {
+  return {
+    identity: { chainPubkey: PUBKEY },
+    on: vi.fn(() => () => {}),
+    destroy: vi.fn(async () => {}),
+    discoverAddresses: vi.fn(async () => ({ addresses: [] })),
+  };
+}
+
+vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk')>();
+  return {
+    ...actual,
+    Sphere: {
+      ...actual.Sphere,
+      exists: vi.fn(async () => true),
+      init: vi.fn(async (opts: Record<string, unknown>) => {
+        initSpy.calls.push(opts);
+        // The password-protected wallet, opened passwordlessly on cold start —
+        // the REAL SDK signal, not the DECRYPTION_ERROR the old (buggy)
+        // predicate looked for.
+        if (!opts.password) {
+          throw new actual.SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR');
+        }
+        return { sphere: makeFakeSphere() };
+      }),
+    },
+  };
+});
+
+// The real browser provider bundle opens IndexedDB/Nostr/network connections
+// that are irrelevant here — stub it with a minimal, inert bundle (shape:
+// BrowserProviders), same as plaintextWalletLoads.test.tsx.
+vi.mock('@unicitylabs/sphere-sdk/impl/browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk/impl/browser')>();
+  return {
+    ...actual,
+    createBrowserProviders: vi.fn(() => ({
+      storage: {
+        get: vi.fn(async () => null),
+        set: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+      },
+      transport: {
+        isConnected: () => false,
+        connect: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+        setIdentity: vi.fn(async () => {}),
+      },
+      oracle: {},
+      tokenStorage: { disconnect: vi.fn(async () => {}) },
+      ipfsTokenStorage: undefined,
+      groupChat: true,
+      market: true,
+    })),
+  };
+});
+
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+import { SphereProvider } from '../../../../src/sdk/SphereProvider';
+import { useSphereContext } from '../../../../src/sdk/hooks/core/useSphere';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+let ctx: SphereContextValue | null = null;
+function Probe() {
+  ctx = useSphereContext();
+  const { isLocked, isLoading, sphere, error } = ctx;
+  return (
+    <div>
+      <div data-testid="loading">{String(isLoading)}</div>
+      <div data-testid="sphere">{sphere ? 'present' : 'null'}</div>
+      <div data-testid="locked">{String(isLocked)}</div>
+      <div data-testid="error">{error ? error.message : 'null'}</div>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  initSpy.calls.length = 0;
+  ctx = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network disabled in test');
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  TokenRegistry.resetInstance();
+});
+
+describe('cold-start of a password-protected wallet (#449 critical fix regression)', () => {
+  it('ends locked (UnlockScreen), NOT on an error screen, and does not retry', async () => {
+    render(
+      <Wrapper>
+        <SphereProvider>
+          <Probe />
+        </SphereProvider>
+      </Wrapper>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+
+    // The bug's exact symptom, inverted: locked, not stuck/errored.
+    expect(screen.getByTestId('locked').textContent).toBe('true');
+    expect(screen.getByTestId('sphere').textContent).toBe('null');
+    expect(screen.getByTestId('error').textContent).toBe('null');
+    expect(ctx?.isLocked).toBe(true);
+
+    // Sharpest guard: the inner catch must classify this as 'locked' and
+    // return BEFORE the outer IndexedDB-retry catch ever sees it. Before the
+    // fix, this error fell through to the outer catch's
+    // `err.code === 'STORAGE_ERROR' && attempt < 1` guard and retried once —
+    // Sphere.init would have been called twice.
+    expect(initSpy.calls.length).toBe(1);
+    expect(initSpy.calls[0].password).toBeUndefined();
+  });
+});

--- a/tests/unit/sdk/walletLock/passwordChangeTimeoutPreservation.test.tsx
+++ b/tests/unit/sdk/walletLock/passwordChangeTimeoutPreservation.test.tsx
@@ -61,13 +61,15 @@ vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
       ...actual.Sphere,
       exists: vi.fn(async () => true),
       init: vi.fn(async (opts: Record<string, unknown>) => {
-        // 'encrypted': a passwordless load always throws DECRYPTION_ERROR
-        // (locked); any password unlocks. 'plaintext': always succeeds. The
-        // REAL password verification this file actually exercises happens
+        // 'encrypted': a passwordless load always throws the REAL SDK
+        // decrypt-mnemonic STORAGE_ERROR (@unicitylabs/sphere-sdk@0.12.0,
+        // code-verified — see src/sdk/walletLock/isDecryptionError.ts), read
+        // as "locked"; any password unlocks. 'plaintext': always succeeds.
+        // The REAL password verification this file actually exercises happens
         // inside reencryptStoredMnemonic against the fake storage below, not
         // here — Sphere.init's own credential logic is irrelevant to it.
         if (testState.mode === 'encrypted' && !opts.password) {
-          throw { code: 'DECRYPTION_ERROR' };
+          throw new actual.SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR');
         }
         return { sphere: makeFakeSphere() };
       }),

--- a/tests/unit/sdk/walletLock/passwordChangeTimeoutPreservation.test.tsx
+++ b/tests/unit/sdk/walletLock/passwordChangeTimeoutPreservation.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * #449 review-fix regression: Set/Change password must PRESERVE the user's
+ * chosen auto-lock timeout, not silently reset it to the 15-min default.
+ *
+ * Root cause that was fixed: the timeout is persisted ENCRYPTED with the
+ * wallet password (encodeLockSettings/decodeLockSettings —
+ * src/sdk/walletLock/lockSettings.ts). setWalletPassword/changeWalletPassword
+ * re-encrypt the mnemonic and call setSessionPassword(newPassword) — without
+ * ALSO re-persisting the timeout blob under the NEW password,
+ * decodeLockSettings(oldBlob, newPassword) fails to decrypt and silently
+ * falls back to DEFAULT_AUTO_LOCK_MINUTES (15). See SphereProvider.tsx:
+ * readCurrentAutoLockMinutes / setWalletPassword / changeWalletPassword.
+ *
+ * Runs REAL SDK crypto (reencryptStoredMnemonic + encode/decodeLockSettings)
+ * against a fake in-memory storage — same approach as reencryptMnemonic.test.ts
+ * and lockSettings.test.ts. These tests are given a generous timeout; PBKDF2
+ * is intentionally slow.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SphereContextValue } from '../../../../src/sdk/SphereContext';
+
+// Each test here runs SEVERAL real PBKDF2 round-trips (unlock, setAutoLockTimeout,
+// and change/remove/set password — the latter alone is decrypt+encrypt+verify-decrypt
+// inside reencryptStoredMnemonic), more than lockSettings.test.ts's single round-trip.
+// Under full-suite parallelism (many worker threads doing real crypto concurrently)
+// that can intermittently push past a 20s budget even though each test is fast in
+// isolation — give these a wide margin so they're reliably green under `npm run test:run`.
+const SLOW_CRYPTO_TIMEOUT_MS = 45000;
+
+const PUBKEY = '02' + 'ab'.repeat(32);
+const OLD_PASSWORD = 'correct horse battery staple';
+const NEW_PASSWORD = 'new correct horse battery staple';
+
+function makeFakeSphere() {
+  return {
+    identity: { chainPubkey: PUBKEY },
+    // SphereProvider's existing-wallet / unlock() success paths only ever
+    // call these on the adopted instance — keep in sync with SphereProvider.
+    on: vi.fn(() => () => {}),
+    destroy: vi.fn(async () => {}),
+    discoverAddresses: vi.fn(async () => ({ addresses: [] })),
+  };
+}
+
+// Shared, mutable per-test fake storage + wallet-shape toggle. Referenced
+// from inside the (hoisted) vi.mock factories below, so it must itself be
+// created via vi.hoisted — mirrors autoLockWiring.test.tsx's mockState.
+const testState = vi.hoisted(() => ({
+  store: new Map<string, string>(),
+  mode: 'encrypted' as 'plaintext' | 'encrypted',
+}));
+
+vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk')>();
+  return {
+    ...actual,
+    Sphere: {
+      ...actual.Sphere,
+      exists: vi.fn(async () => true),
+      init: vi.fn(async (opts: Record<string, unknown>) => {
+        // 'encrypted': a passwordless load always throws DECRYPTION_ERROR
+        // (locked); any password unlocks. 'plaintext': always succeeds. The
+        // REAL password verification this file actually exercises happens
+        // inside reencryptStoredMnemonic against the fake storage below, not
+        // here — Sphere.init's own credential logic is irrelevant to it.
+        if (testState.mode === 'encrypted' && !opts.password) {
+          throw { code: 'DECRYPTION_ERROR' };
+        }
+        return { sphere: makeFakeSphere() };
+      }),
+    },
+  };
+});
+
+// The real browser provider bundle opens IndexedDB/Nostr/network connections
+// that are irrelevant here — stub it with a minimal, inert bundle (shape:
+// BrowserProviders) whose storage is backed by testState.store so
+// reencryptStoredMnemonic (called for REAL by setWalletPassword/
+// changeWalletPassword/removeWalletPassword) round-trips against it.
+vi.mock('@unicitylabs/sphere-sdk/impl/browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk/impl/browser')>();
+  return {
+    ...actual,
+    createBrowserProviders: vi.fn(() => ({
+      storage: {
+        get: vi.fn(async (key: string) => testState.store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: string) => {
+          testState.store.set(key, value);
+        }),
+        disconnect: vi.fn(async () => {}),
+      },
+      transport: {
+        isConnected: () => false,
+        connect: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+        setIdentity: vi.fn(async () => {}),
+      },
+      oracle: {},
+      tokenStorage: { disconnect: vi.fn(async () => {}) },
+      ipfsTokenStorage: undefined,
+      groupChat: true,
+      market: true,
+    })),
+  };
+});
+
+import {
+  TokenRegistry,
+  STORAGE_KEYS_GLOBAL,
+  generateMnemonic,
+  encryptMnemonic,
+} from '@unicitylabs/sphere-sdk';
+import { SphereProvider } from '../../../../src/sdk/SphereProvider';
+import { useSphereContext } from '../../../../src/sdk/hooks/core/useSphere';
+import { STORAGE_KEYS } from '../../../../src/config/storageKeys';
+import { decodeLockSettings, DEFAULT_AUTO_LOCK_MINUTES } from '../../../../src/sdk/walletLock/lockSettings';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+// Captures the live context so the test can drive setAutoLockTimeout/
+// changeWalletPassword/etc imperatively — same pattern as
+// autoLockWiring.test.tsx.
+let ctx: SphereContextValue | null = null;
+function Probe() {
+  ctx = useSphereContext();
+  const { isLocked, isLoading, sphere } = ctx;
+  return (
+    <div>
+      <div data-testid="loading">{String(isLoading)}</div>
+      <div data-testid="sphere">{sphere ? 'present' : 'null'}</div>
+      <div data-testid="locked">{String(isLocked)}</div>
+    </div>
+  );
+}
+
+function renderProvider() {
+  render(
+    <Wrapper>
+      <SphereProvider>
+        <Probe />
+      </SphereProvider>
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  ctx = null;
+  testState.mode = 'encrypted';
+  testState.store.clear();
+  localStorage.clear();
+  const mnemonic = generateMnemonic();
+  testState.store.set(STORAGE_KEYS_GLOBAL.MNEMONIC, encryptMnemonic(mnemonic, OLD_PASSWORD));
+  // SphereProvider calls the real TokenRegistry.configure() as part of its
+  // normal init flow; with a cache miss that fetches its remote token list
+  // for real. Stub fetch so this test never makes a real network call.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network disabled in test');
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+  // TokenRegistry is a process-wide singleton that starts a background
+  // refresh timer on configure() — reset it so it doesn't leak into (or slow
+  // down) other test files.
+  TokenRegistry.resetInstance();
+});
+
+describe('auto-lock timeout survives Set/Change password (#449 review fix)', () => {
+  it('a custom timeout chosen before a password Change is still in effect after it', async () => {
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId('locked').textContent).toBe('true'));
+
+    await act(async () => {
+      await ctx!.unlock(OLD_PASSWORD);
+    });
+    expect(screen.getByTestId('locked').textContent).toBe('false');
+    expect(ctx!.hasWalletPassword).toBe(true);
+
+    // User picks a non-default timeout.
+    act(() => {
+      ctx!.setAutoLockTimeout(5);
+    });
+    expect(ctx!.autoLockMinutes).toBe(5);
+
+    // Now change the password.
+    await act(async () => {
+      await ctx!.changeWalletPassword(OLD_PASSWORD, NEW_PASSWORD);
+    });
+
+    // REGRESSION CHECK: must still be 5, not silently reset to the 15-min
+    // default (the bug this test guards against).
+    expect(ctx!.autoLockMinutes).toBe(5);
+
+    // And the persisted blob is genuinely readable under the NEW password —
+    // not just a stale in-memory state value that happens to still say 5.
+    const blob = localStorage.getItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT);
+    expect(blob).toBeTruthy();
+    expect(decodeLockSettings(blob!, NEW_PASSWORD)).toBe(5);
+    // The OLD password must no longer decode it (it was genuinely re-encrypted).
+    expect(decodeLockSettings(blob!, OLD_PASSWORD)).not.toBe(5);
+  }, SLOW_CRYPTO_TIMEOUT_MS);
+
+  it('"never" survives a password Change too', async () => {
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId('locked').textContent).toBe('true'));
+
+    await act(async () => {
+      await ctx!.unlock(OLD_PASSWORD);
+    });
+
+    act(() => {
+      ctx!.setAutoLockTimeout('never');
+    });
+    expect(ctx!.autoLockMinutes).toBe('never');
+
+    await act(async () => {
+      await ctx!.changeWalletPassword(OLD_PASSWORD, NEW_PASSWORD);
+    });
+
+    expect(ctx!.autoLockMinutes).toBe('never');
+  }, SLOW_CRYPTO_TIMEOUT_MS);
+
+  it('Remove disarms auto-lock instead of preserving the timeout (by design, not a regression)', async () => {
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId('locked').textContent).toBe('true'));
+
+    await act(async () => {
+      await ctx!.unlock(OLD_PASSWORD);
+    });
+
+    act(() => {
+      ctx!.setAutoLockTimeout(30);
+    });
+    expect(ctx!.autoLockMinutes).toBe(30);
+
+    await act(async () => {
+      await ctx!.removeWalletPassword(OLD_PASSWORD);
+    });
+
+    // No password left → nothing to arm auto-lock with; the context
+    // reflects the secure default rather than a stale custom value.
+    expect(ctx!.hasWalletPassword).toBe(false);
+    expect(ctx!.autoLockMinutes).toBe(DEFAULT_AUTO_LOCK_MINUTES);
+  }, SLOW_CRYPTO_TIMEOUT_MS);
+
+  it('Set on a plaintext wallet (nothing to preserve) still ends up armed at the default, without crashing', async () => {
+    testState.mode = 'plaintext';
+    testState.store.clear();
+    const mnemonic = generateMnemonic();
+    testState.store.set(STORAGE_KEYS_GLOBAL.MNEMONIC, mnemonic); // plaintext, no password yet
+
+    renderProvider();
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+    expect(screen.getByTestId('locked').textContent).toBe('false');
+    expect(ctx!.hasWalletPassword).toBe(false);
+
+    await act(async () => {
+      await ctx!.setWalletPassword(NEW_PASSWORD);
+    });
+
+    expect(ctx!.hasWalletPassword).toBe(true);
+    expect(ctx!.autoLockMinutes).toBe(DEFAULT_AUTO_LOCK_MINUTES);
+
+    const blob = localStorage.getItem(STORAGE_KEYS.AUTO_LOCK_TIMEOUT);
+    expect(blob).toBeTruthy();
+    expect(decodeLockSettings(blob!, NEW_PASSWORD)).toBe(DEFAULT_AUTO_LOCK_MINUTES);
+  }, SLOW_CRYPTO_TIMEOUT_MS);
+});

--- a/tests/unit/sdk/walletLock/plaintextWalletLoads.test.tsx
+++ b/tests/unit/sdk/walletLock/plaintextWalletLoads.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * #449 MANDATORY no-wallet-loss regression: an existing wallet stored WITHOUT
+ * a password (Sphere.init SUCCEEDS with no password — an existing plaintext
+ * user) must load with isLocked === false and no unlock step, and the
+ * existing-wallet load path must NEVER pass a `password` to Sphere.init. If
+ * this test ever fails, DECRYPTION_ERROR / lock detection has leaked into the
+ * plaintext-wallet path (see src/sdk/walletLock/classifyInitFailure.ts and
+ * SphereProvider.initialize()'s existing-wallet branch).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const PUBKEY = '02' + 'ab'.repeat(32);
+
+const initSpy = vi.hoisted(() => ({ calls: [] as Record<string, unknown>[] }));
+
+function makeFakeSphere() {
+  return {
+    identity: { chainPubkey: PUBKEY },
+    // SphereProvider's existing-wallet success path (initialize()) only ever
+    // calls these on the adopted instance — keep this in sync with
+    // src/sdk/SphereProvider.tsx if that path grows new calls.
+    on: vi.fn(() => () => {}),
+    destroy: vi.fn(async () => {}),
+    discoverAddresses: vi.fn(async () => ({ addresses: [] })),
+  };
+}
+
+vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk')>();
+  return {
+    ...actual,
+    Sphere: {
+      ...actual.Sphere,
+      exists: vi.fn(async () => true),
+      init: vi.fn(async (opts: Record<string, unknown>) => {
+        initSpy.calls.push(opts);
+        return { sphere: makeFakeSphere() };
+      }),
+    },
+  };
+});
+
+// The real browser provider bundle opens IndexedDB/Nostr/network connections
+// that are irrelevant here — this test only exercises SphereProvider's own
+// lock/no-password decision on an existing wallet, not provider composition.
+// Stub it with a minimal, inert bundle (shape: BrowserProviders).
+vi.mock('@unicitylabs/sphere-sdk/impl/browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk/impl/browser')>();
+  return {
+    ...actual,
+    createBrowserProviders: vi.fn(() => ({
+      storage: {
+        get: vi.fn(async () => null),
+        set: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+      },
+      transport: {
+        isConnected: () => false,
+        connect: vi.fn(async () => {}),
+        disconnect: vi.fn(async () => {}),
+        setIdentity: vi.fn(async () => {}),
+      },
+      oracle: {},
+      tokenStorage: { disconnect: vi.fn(async () => {}) },
+      ipfsTokenStorage: undefined,
+      groupChat: true,
+      market: true,
+    })),
+  };
+});
+
+import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+import { SphereProvider } from '../../../../src/sdk/SphereProvider';
+import { useSphereContext } from '../../../../src/sdk/hooks/core/useSphere';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+  );
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function Probe() {
+  const { isLocked, isLoading, sphere } = useSphereContext();
+  return (
+    <div>
+      <div data-testid="loading">{String(isLoading)}</div>
+      <div data-testid="sphere">{sphere ? 'present' : 'null'}</div>
+      <div data-testid="locked">{String(isLocked)}</div>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  initSpy.calls.length = 0;
+  // SphereProvider calls the real TokenRegistry.configure() as part of its
+  // normal init flow; with a cache miss that fetches its remote token list
+  // for real. Stub fetch so this test never makes a real network call.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('network disabled in test');
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // TokenRegistry is a process-wide singleton that starts a background
+  // refresh timer on configure() — reset it so it doesn't leak into (or slow
+  // down) other test files.
+  TokenRegistry.resetInstance();
+});
+
+describe('existing plaintext wallet', () => {
+  it('loads without a password and never locks', async () => {
+    render(
+      <Wrapper>
+        <SphereProvider>
+          <Probe />
+        </SphereProvider>
+      </Wrapper>,
+    );
+
+    // Wait for the full initialize() flow to finish (not just the initial
+    // synchronous render) so a lock flag flipped asynchronously — a false
+    // positive from a leaked DECRYPTION_ERROR classification — would be
+    // observed here rather than racing past it.
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+    expect(screen.getByTestId('sphere').textContent).toBe('present');
+
+    // Assertion 1: the wallet loaded straight through, never locked.
+    expect(screen.getByTestId('locked').textContent).toBe('false');
+
+    // Assertion 2: Sphere.init was called at least once, and NONE of those
+    // calls carried a `password` — the existing-wallet load path must stay
+    // exactly as it was for a plaintext wallet (#449).
+    expect(initSpy.calls.length).toBeGreaterThan(0);
+    expect(initSpy.calls.every((c) => c.password === undefined)).toBe(true);
+  });
+});

--- a/tests/unit/sdk/walletLock/reencryptMnemonic.test.ts
+++ b/tests/unit/sdk/walletLock/reencryptMnemonic.test.ts
@@ -1,0 +1,125 @@
+/**
+ * TDD for the VERIFIED-SAFE in-place mnemonic re-encryption mechanism used by
+ * Settings → Security "Set/Change/Remove password" (#449 Task 8b). This
+ * exercises REAL SDK crypto (encryptMnemonic/decryptMnemonic/validateMnemonic)
+ * against a fake in-memory storage — no mocking of the crypto itself, since the
+ * whole point is that the on-disk format must be byte-for-byte what Sphere
+ * itself reads on load.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  generateMnemonic,
+  STORAGE_KEYS_GLOBAL,
+  encryptMnemonic,
+  decryptMnemonic,
+} from '@unicitylabs/sphere-sdk';
+import { reencryptStoredMnemonic } from '../../../../src/sdk/walletLock/reencryptMnemonic';
+
+/** Minimal in-memory fake of the StorageProvider surface this helper touches. */
+function makeFakeStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    get: async (key: string) => store.get(key) ?? null,
+    set: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+}
+
+describe('reencryptStoredMnemonic', () => {
+  it('sets a password on a plaintext wallet (null -> pw): result decrypts with pw', async () => {
+    const mnemonic = generateMnemonic();
+    const storage = makeFakeStorage({ [STORAGE_KEYS_GLOBAL.MNEMONIC]: mnemonic });
+
+    await reencryptStoredMnemonic(storage, { currentPassword: null, newPassword: 'correct horse' });
+
+    const stored = storage.store.get(STORAGE_KEYS_GLOBAL.MNEMONIC)!;
+    expect(stored).not.toBe(mnemonic);
+    expect(decryptMnemonic(stored, 'correct horse')).toBe(mnemonic);
+  }, 20000);
+
+  it('changes the password on an encrypted wallet (pw -> pw2)', async () => {
+    const mnemonic = generateMnemonic();
+    const storage = makeFakeStorage({
+      [STORAGE_KEYS_GLOBAL.MNEMONIC]: encryptMnemonic(mnemonic, 'old-pw'),
+    });
+
+    await reencryptStoredMnemonic(storage, { currentPassword: 'old-pw', newPassword: 'new-pw' });
+
+    const stored = storage.store.get(STORAGE_KEYS_GLOBAL.MNEMONIC)!;
+    expect(decryptMnemonic(stored, 'new-pw')).toBe(mnemonic);
+    expect(() => decryptMnemonic(stored, 'old-pw')).toThrow();
+  }, 20000);
+
+  it('removes the password (pw -> null): result is a plaintext mnemonic', async () => {
+    const mnemonic = generateMnemonic();
+    const storage = makeFakeStorage({
+      [STORAGE_KEYS_GLOBAL.MNEMONIC]: encryptMnemonic(mnemonic, 'old-pw'),
+    });
+
+    await reencryptStoredMnemonic(storage, { currentPassword: 'old-pw', newPassword: null });
+
+    const stored = storage.store.get(STORAGE_KEYS_GLOBAL.MNEMONIC)!;
+    expect(stored).toBe(mnemonic);
+  }, 20000);
+
+  it('throws on a wrong current password and does NOT modify storage', async () => {
+    const mnemonic = generateMnemonic();
+    const encrypted = encryptMnemonic(mnemonic, 'old-pw');
+    const storage = makeFakeStorage({ [STORAGE_KEYS_GLOBAL.MNEMONIC]: encrypted });
+
+    await expect(
+      reencryptStoredMnemonic(storage, { currentPassword: 'WRONG', newPassword: 'new-pw' }),
+    ).rejects.toThrow();
+
+    expect(storage.store.get(STORAGE_KEYS_GLOBAL.MNEMONIC)).toBe(encrypted);
+  }, 20000);
+
+  it('throws when there is no stored mnemonic (nothing to protect)', async () => {
+    const storage = makeFakeStorage({});
+
+    await expect(
+      reencryptStoredMnemonic(storage, { currentPassword: null, newPassword: 'pw' }),
+    ).rejects.toThrow();
+  });
+
+  it('throws if currentPassword is null but the stored value is not a valid plaintext mnemonic', async () => {
+    const mnemonic = generateMnemonic();
+    const storage = makeFakeStorage({
+      [STORAGE_KEYS_GLOBAL.MNEMONIC]: encryptMnemonic(mnemonic, 'old-pw'),
+    });
+
+    await expect(
+      reencryptStoredMnemonic(storage, { currentPassword: null, newPassword: 'new-pw' }),
+    ).rejects.toThrow();
+  }, 20000);
+
+  it('restores the original value if the read-back verification would fail (storage lies about the write)', async () => {
+    const mnemonic = generateMnemonic();
+    const original = mnemonic;
+    const store = new Map([[STORAGE_KEYS_GLOBAL.MNEMONIC, original]]);
+    let getCalls = 0;
+    const lyingStorage = {
+      get: async (key: string) => {
+        getCalls++;
+        // First get(): the initial read (real value). Second get(): the
+        // read-back after set() — return corrupted garbage to simulate a
+        // storage layer that silently failed to persist the write.
+        if (getCalls >= 2) return 'not-a-real-encrypted-value';
+        return store.get(key) ?? null;
+      },
+      set: async (key: string, value: string) => {
+        store.set(key, value);
+      },
+    };
+
+    await expect(
+      reencryptStoredMnemonic(lyingStorage, { currentPassword: null, newPassword: 'new-pw' }),
+    ).rejects.toThrow();
+
+    // The helper must have restored the ORIGINAL value via set(), even though
+    // get() keeps lying — check what was actually written to the underlying map.
+    expect(store.get(STORAGE_KEYS_GLOBAL.MNEMONIC)).toBe(original);
+  }, 20000);
+});

--- a/tests/unit/sdk/walletLock/useIdleTimer.test.tsx
+++ b/tests/unit/sdk/walletLock/useIdleTimer.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useIdleTimer } from '../../../../src/sdk/walletLock/useIdleTimer';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('useIdleTimer', () => {
+  it('fires onIdle after the timeout with no activity', () => {
+    const onIdle = vi.fn();
+    renderHook(() => useIdleTimer({ timeoutMs: 1000, enabled: true, onIdle }));
+    vi.advanceTimersByTime(1000);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets on user activity', () => {
+    const onIdle = vi.fn();
+    renderHook(() => useIdleTimer({ timeoutMs: 1000, enabled: true, onIdle }));
+    vi.advanceTimersByTime(900);
+    window.dispatchEvent(new Event('keydown'));
+    vi.advanceTimersByTime(900);
+    expect(onIdle).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('never fires when disabled', () => {
+    const onIdle = vi.fn();
+    renderHook(() => useIdleTimer({ timeoutMs: 1000, enabled: false, onIdle }));
+    vi.advanceTimersByTime(5000);
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('never fires when timeoutMs is null (Never)', () => {
+    const onIdle = vi.fn();
+    renderHook(() => useIdleTimer({ timeoutMs: null, enabled: true, onIdle }));
+    vi.advanceTimersByTime(5000);
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sdk/walletLock/useIdleTimer.test.tsx
+++ b/tests/unit/sdk/walletLock/useIdleTimer.test.tsx
@@ -37,4 +37,42 @@ describe('useIdleTimer', () => {
     vi.advanceTimersByTime(5000);
     expect(onIdle).not.toHaveBeenCalled();
   });
+
+  // BroadcastChannel delivery is real-async and doesn't play well with fake
+  // timers, so this test uses real timers with generous margins around each
+  // deadline instead.
+  it('resets on activity broadcast from another tab, without echoing back', async () => {
+    vi.useRealTimers();
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+    const channelName = `cross-tab-test-${Math.random().toString(36).slice(2)}`;
+    const onIdle = vi.fn();
+
+    // Simulates activity happening in a separate browser tab.
+    const otherChannel = new BroadcastChannel(channelName);
+    const otherOnMessage = vi.fn();
+    otherChannel.onmessage = otherOnMessage;
+
+    const { unmount } = renderHook(() =>
+      useIdleTimer({ timeoutMs: 200, enabled: true, onIdle, channelName })
+    );
+
+    // Broadcast remote activity shortly before the original 200ms deadline.
+    await sleep(150);
+    otherChannel.postMessage('activity');
+
+    // Past the original deadline (200ms), but the reset should have pushed
+    // it out — onIdle must not have fired.
+    await sleep(100); // elapsed ~250ms since mount
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // Past the new deadline (~150ms reset point + 200ms timeout = ~350ms).
+    await sleep(170); // elapsed ~420ms since mount
+    expect(onIdle).toHaveBeenCalledTimes(1);
+
+    // The hook must never echo remote activity back onto the channel.
+    expect(otherOnMessage).not.toHaveBeenCalled();
+
+    unmount();
+    otherChannel.close();
+  });
 });


### PR DESCRIPTION
## Overview

This branch adds an **optional wallet password** to Sphere (#449): an at‑rest lock for the mnemonic, an unlock screen, idle auto‑lock, a Settings → Security panel, and password gates woven through the create / import / backup flows. The **one** password a user chooses protects the wallet at rest **and** encrypts the downloadable backup file — one secret, two jobs.

It is **fully opt‑in**. Wallets that never set a password behave exactly as before: no unlock screen, no prompts, nothing to remember.

> ⚠️ **Do not merge yet** — this is up for manual verification first. Please walk the "What to test" checklist below before approving/merging.

**Base = `audit-fixes-2026-07`** (the integration branch), not `main`. We accumulate every fix/feature into that branch and land it on `main` with a single `audit-fixes-2026-07 → main` PR at the end, so this PR contains **only** the #449 feature commits.

---

## No‑wallet‑loss guarantee (the hard constraint)

Existing users with created wallets must **never** lose them because of this feature. Every password path was designed and reviewed against that:

- **In‑place re‑encryption only.** Setting/changing/removing a password re‑encrypts the mnemonic *in place* at its existing storage key (`encryptMnemonic` === the SDK's internal `encrypt`, so the format is byte‑compatible). It **never** calls `Sphere.import()` / `Sphere.clear()`, which would wipe the token DB. Read‑back‑verify + restore‑on‑failure wraps the write.
- **Plaintext wallets keep loading untouched** — covered by a regression test (`plaintextWalletLoads.test.tsx`).
- **Restore‑from‑lock guard.** A forgotten‑password / restore path validates the mnemonic (`Sphere.validateMnemonic`) **before** any destructive import, and the lock screen cannot reach a destructive "Create New Wallet". Guarded by `restoreFromLock.test.tsx`.
- **Create flow persists exactly once.** `createWallet()` is the only persisting call; choosing a password afterward re‑encrypts in place — never a second import. Guarded by `createFlowSinglePersist.test.tsx`.

Three distinct wallet‑loss / lockout bugs were caught and fixed during review (create‑flow re‑import, restore‑from‑lock wipe, and a lock‑detection mismatch where the SDK actually throws `STORAGE_ERROR 'Failed to decrypt mnemonic'`, not `DECRYPTION_ERROR`).

---

## What's done — #449 (this feature)

### Lock / unlock engine
- **Optional at‑rest password.** The mnemonic can be encrypted at rest; the session password lives in memory only (never persisted).
- **Unlock screen + shell gate.** On cold start of an encrypted wallet the app shows an unlock screen; the wallet shell is gated behind it.
- **Correct lock detection.** Keyed on the SDK's real signal — `SphereError('Failed to decrypt mnemonic', 'STORAGE_ERROR')` — plus a literal `DECRYPTION_ERROR` fallback.
- **Idle auto‑lock.** Configurable inactivity timeout (1 / 5 / 15 / 30 min or Never; default 15). Cross‑tab: locking or activity in one tab broadcasts to the others via `BroadcastChannel`. The timeout is stored **password‑encrypted**, so it can't be trivially rewritten via localStorage.
- **dApp notify on lock.** Connect hosts are told the wallet locked (`notifyWalletLocked()`), so a connected dApp doesn't keep operating against a locked wallet.

### Settings → Security
- Set / change / remove the wallet password, and change the auto‑lock timeout, from a dedicated Security panel.
- Changing the password **preserves** the existing auto‑lock timeout; double‑submit is guarded.

### Manual lock
- A **"Lock Wallet"** action in Settings locks on demand (calls the same `lock()` as idle/cross‑tab). Shown **only when a password is set** — locking a password‑less wallet would demand an unlock password that doesn't exist (recoverable only from seed), so it's hidden in that case (no‑wallet‑loss invariant).

### Create‑wallet onboarding
- New ordered flow: **show recovery phrase → confirm phrase → set password (optional) → download backup → plan/capabilities**.
- **Confirm phrase** is a 12‑word cell grid (numbered inputs, paste‑fills‑all, Enter→next), matching the import UX — not a single textarea.
- The chosen password both encrypts the wallet at rest and encrypts the **downloadable backup file**.

### Import onboarding (Task C)
- After importing (recovery phrase **or** file), the user is offered the same optional password step, applied via the safe in‑place re‑encrypt — the import itself stays plaintext first.
- **Encrypted‑file import** auto‑applies the file's own decrypt password to the wallet (no double prompt). A master‑key‑only file (no mnemonic) skips gracefully — no scary error, wallet intact.

### In‑wallet backup gate
- **Backup Wallet** (Export Wallet File / Show Recovery Phrase) now requires re‑entering the wallet password before the seed is exposed, when a password is set. Verification is read‑only and never persisted. Wallets with no password skip the gate.

### UX / animation
- Backup → Export / Show‑Seed sub‑screens now **slide in** on top of a kept‑mounted parent (z‑index drill‑stack: backup `z‑20`, seed/export `z‑30`) instead of two panels cross‑fading. Matches the slide animation used everywhere else.

---

## What to test

**A. Existing plaintext wallet (regression — must be seamless)**
1. Open with a wallet that has **no** password → no unlock screen, no prompts, balances/tokens load as before.
2. Reload → still no unlock prompt.

**B. Create a new wallet**
1. Create → recovery phrase shown → **confirm** by re‑typing/pasting into the 12 cells → set a password (or Skip) → download backup → finish.
2. If you set a password: fully close & reopen the app → **unlock screen** appears → wrong password rejected, correct password unlocks.
3. Open the downloaded backup file — it should be **encrypted** with that same password.

**C. Import a wallet**
1. Import by **recovery phrase** → after address selection you're offered a password (or Skip) → wallet works; reload prompts unlock iff you set one.
2. Import an **encrypted backup file** → entering the file password imports and you are *not* asked for a password again; reload → unlock with that same password.
3. Import an unencrypted / legacy file → offered the optional password step, Skip works.

**D. Settings → Security**
1. Set a password on a previously‑passwordless wallet → reload → unlock required.
2. Change the password → old rejected, new accepted; the auto‑lock timeout is unchanged.
3. Remove the password → reload → no unlock screen.
4. Change auto‑lock timeout (e.g. 1 min) → leave the app idle → it auto‑locks; with two tabs open, locking/using one affects the other.

**E. In‑wallet backup gate**
1. With a password set: Settings → **Backup Wallet** → you must re‑enter the password before **Export Wallet File** / **Show Recovery Phrase** reveal anything.
2. Wrong password → error, seed stays hidden. Correct → Export/Seed sub‑screen **slides in** cleanly (no odd fade/cross).
3. With **no** password set: the gate is skipped (straight to the two options).

**F. dApp / Connect (wallet‑locked signal) — LIMITED, see note**
On lock, `ConnectHost.notifyWalletLocked()` pushes a `wallet:locked` event and revokes the session. What it does **not** yet do: keep the session alive so the dApp can prompt-unlock-and-resume. Locking currently destroys the Sphere instance, so a dApp request made after lock is not served gracefully (it errors / times out and the dApp disconnects). A proper "request‑while‑locked → prompt unlock → resume" flow is a **planned follow‑up** across sphere‑sdk + the connect‑example (a `WALLET_LOCKED` error code + host locked‑state + session‑preserving unlock), tracked separately from this PR.

1. Run the browser **connect‑example** (`sphere-sdk-connect-example/browser`, `npm run dev`), connect it, then **Settings → Lock Wallet**.
2. Expected today: the **Events** panel logs a `wallet:locked` entry and the dApp's session ends (popup mode disconnects cleanly; iframe/extension currently do **not** resume gracefully — that's the follow‑up).

---

## Status

- **Tests:** 63 files / **482 passing** (`npm run test:run`). Includes new regression suites: `plaintextWalletLoads`, `restoreFromLock`, `reencryptMnemonic`, `createFlowSinglePersist`, `createFlowPassword`, `createFlowMnemonicConfirm`, `importPassword`, `lockedWalletColdStart`, idle‑timer & lockSettings.
- **Lint:** 0 errors. **`tsc --noEmit`:** clean.
- **SDK:** no SDK changes required — built entirely on `@unicitylabs/sphere-sdk` 0.12.0's existing optional‑password support.
- Per‑task implementation was reviewed (spec + quality) plus a whole‑branch review; the no‑wallet‑loss constraint was the primary review lens throughout.
