### PR TITLE
fix: 2026-07 security & correctness audit — 7 high-severity fixes (#448, #450-#455)

### DIFF
--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -46,7 +46,7 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 | #448 | high | `fix/nametag-create-atomicity` | — | todo |
 | #453 | high | `fix/sphere-init-reentrancy-guard` | — | todo |
 | #454 | high | `fix/group-send-throw-on-null` | — | **merged** (send path; `requireSent` guard + `sendMessage` catch). Follow-ups: moderation actions (boolean-false) + DM/mini-chat sends |
-| #455 | high | `fix/desktop-layout-shared-route` | — | todo |
+| #455 | high | `fix/desktop-layout-shared-route` | — | **merged** (DesktopShell layout route; DesktopLayout mounts once across /home<->/agents) |
 | #447 | medium | `fix/swap-atomicity` (testnet-only) | — | todo |
 
 Deferred / not yet filed as issues (drafts exist): a11y dialog primitive, HTTP-service hardening, deploy-config follow-ups (may go into #443 instead), money-action modal-flow, marketplace pagination, perf dedupe.

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -43,7 +43,7 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 | #452 | high | `fix/connect-verified-origin` | #451 | **merged** (approval modal shows verified origin + untrusted/host-mismatch warnings; `requestApproval` carries the pinned origin) |
 | #449 | high | `feat/wallet-password-unlock` | — | todo |
 | #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |
-| #448 | high | `fix/nametag-create-atomicity` | — | todo |
+| #448 | high | `fix/nametag-create-atomicity` | — | **merged** (createWalletThenRegister: create without nametag → register separately; failure never wipes the wallet) |
 | #453 | high | `fix/sphere-init-reentrancy-guard` | — | **merged** (initGenRef generation guard + adoptOrDiscardInstance; one live instance) |
 | #454 | high | `fix/group-send-throw-on-null` | — | **merged** (send path; `requireSent` guard + `sendMessage` catch). Follow-ups: moderation actions (boolean-false) + DM/mini-chat sends |
 | #455 | high | `fix/desktop-layout-shared-route` | — | **merged** (DesktopShell layout route; DesktopLayout mounts once across /home<->/agents) |

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -1,0 +1,51 @@
+# Security & correctness audit — fix tracking (2026-07)
+
+Integration branch for the fixes from the 2026-07 multi-agent audit of Sphere (base: `main` @ `b477d4d7`, sphere-sdk 0.12.0). GitHub issues #447–#455.
+
+## Workflow
+
+- **Integration branch:** `audit-fixes-2026-07` (this branch). All fixes land here first.
+- **Per-issue branches:** one branch per issue, **based on this integration branch** (`git switch -c fix/... audit-fixes-2026-07`).
+- **Merge when ready:** a finished issue branch merges back into `audit-fixes-2026-07` (direct merge, or a PR *into the integration branch* for CI/review — not into `main`).
+- **One PR to main:** only `audit-fixes-2026-07 → main` is opened against `main`, at the end. This document is its running description.
+
+Rationale: keeps `main` untouched until the whole audit-fix set is green and reviewable as one unit, while each issue stays an isolated, revertible branch. Dependent fixes (e.g. #452 reuses #451's verified-origin plumbing) sequence cleanly because every issue branch already contains the previously merged fixes.
+
+## Prerequisite
+
+`npm ci` (local `node_modules` holds sphere-sdk 0.11.12 vs the 0.12.0 lockfile pin → `tsc` currently fails). Do this before any branch work.
+
+## Gate before merging an issue branch into the integration branch
+
+1. `npm run lint` — 0 errors.
+2. `npx tsc --noEmit -p tsconfig.app.json` — clean.
+3. `npm run test:run` — green, **including a new test for the fixed behaviour**.
+4. Manual check of the specific flow where feasible.
+
+## Issues → branches
+
+| # | Sev | Branch | Depends on | Status |
+|---|-----|--------|-----------|--------|
+| #451 | high | `fix/iframe-agent-origin-allowlist` | — | todo |
+| #452 | high | `fix/connect-verified-origin` | #451 | todo |
+| #449 | high | `feat/wallet-password-unlock` | — | todo |
+| #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |
+| #448 | high | `fix/nametag-create-atomicity` | — | todo |
+| #453 | high | `fix/sphere-init-reentrancy-guard` | — | todo |
+| #454 | high | `fix/group-send-throw-on-null` | — | todo |
+| #455 | high | `fix/desktop-layout-shared-route` | — | todo |
+| #447 | medium | `fix/swap-atomicity` (testnet-only) | — | todo |
+
+Deferred / not yet filed as issues (drafts exist): a11y dialog primitive, HTTP-service hardening, deploy-config follow-ups (may go into #443 instead), money-action modal-flow, marketplace pagination, perf dedupe.
+
+## Sequencing
+
+1. **Security first:** #451 → #452 (shared "show verified origin"); #448; #453.
+2. **Secrets:** #449 → #450.
+3. **Silent failures:** #454.
+4. **State/UX:** #455; #447 (testnet-only, low urgency).
+
+## Companion SDK improvements (separate repo, not in this branch)
+
+- `GroupChatModule.sendMessage` (+ moderation methods) should signal failure instead of returning `null` (root of #454).
+- `registerNametag` should be atomic / extractable from `Sphere.create` (root of #448).

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -45,7 +45,7 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 | #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |
 | #448 | high | `fix/nametag-create-atomicity` | — | todo |
 | #453 | high | `fix/sphere-init-reentrancy-guard` | — | todo |
-| #454 | high | `fix/group-send-throw-on-null` | — | todo |
+| #454 | high | `fix/group-send-throw-on-null` | — | **merged** (send path; `requireSent` guard + `sendMessage` catch). Follow-ups: moderation actions (boolean-false) + DM/mini-chat sends |
 | #455 | high | `fix/desktop-layout-shared-route` | — | todo |
 | #447 | medium | `fix/swap-atomicity` (testnet-only) | — | todo |
 

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -40,7 +40,7 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 | # | Sev | Branch | Depends on | Status |
 |---|-----|--------|-----------|--------|
 | #451 | high | `fix/iframe-agent-origin-allowlist` | — | **merged** (self-origin guard + hardened sandbox + `agentOrigins` trust module); follow-ups: verified-origin in modal → #452, CSP `frame-src` |
-| #452 | high | `fix/connect-verified-origin` | #451 | todo |
+| #452 | high | `fix/connect-verified-origin` | #451 | **merged** (approval modal shows verified origin + untrusted/host-mismatch warnings; `requestApproval` carries the pinned origin) |
 | #449 | high | `feat/wallet-password-unlock` | — | todo |
 | #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |
 | #448 | high | `fix/nametag-create-atomicity` | — | todo |

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -21,6 +21,19 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 2. `npx tsc --noEmit -p tsconfig.app.json` — clean.
 3. `npm run test:run` — green, **including a new test for the fixed behaviour**.
 4. Manual check of the specific flow where feasible.
+5. **NO EXISTING USER LOSES THEIR WALLET.** Hard requirement, overrides everything. Any change that reads/writes wallet storage, the mnemonic, identity, IndexedDB DB names, or a persisted-state schema MUST keep already-created wallets loadable. For those changes add a regression test that a wallet persisted by the PRE-fix code still opens/restores after the change. Migrations must be non-destructive and forward-only; never gate an existing user out of a wallet they already have.
+
+### Backward-compatibility risk per issue (existing wallets)
+
+| # | Storage / identity touched? | Backward-compat requirement |
+|---|---|---|
+| #451 | no (iframe framing only) | none — merged, safe |
+| #452 | connected-sites display only | keep reading the existing approved-origins shape |
+| #448 | new-wallet create flow + nametag persistence | existing wallets & restore path must be untouched; only the create ordering changes |
+| #453 | `SphereProvider.initialize()` (no storage writes) | guard must never end with zero live instance or destroy the winner → transient lockout risk; test init still resolves for an existing wallet |
+| **#449** | **mnemonic at-rest encryption** | **HIGHEST RISK.** Existing wallets are stored UNENCRYPTED. Password must be an opt-in migration: an existing plaintext wallet must still load with no password, then be offered encryption. NEVER pass a password to `Sphere.init` for a wallet stored without one (decrypt would fail → wallet appears lost). Add a test: a plaintext-persisted wallet opens after the change. |
+| #450 | backup export only | none (export path, not the live store) |
+| #454 / #455 / #447 | no | none |
 
 ## Issues → branches
 

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -44,7 +44,7 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 | #449 | high | `feat/wallet-password-unlock` | — | todo |
 | #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |
 | #448 | high | `fix/nametag-create-atomicity` | — | todo |
-| #453 | high | `fix/sphere-init-reentrancy-guard` | — | todo |
+| #453 | high | `fix/sphere-init-reentrancy-guard` | — | **merged** (initGenRef generation guard + adoptOrDiscardInstance; one live instance) |
 | #454 | high | `fix/group-send-throw-on-null` | — | **merged** (send path; `requireSent` guard + `sendMessage` catch). Follow-ups: moderation actions (boolean-false) + DM/mini-chat sends |
 | #455 | high | `fix/desktop-layout-shared-route` | — | **merged** (DesktopShell layout route; DesktopLayout mounts once across /home<->/agents) |
 | #447 | medium | `fix/swap-atomicity` (testnet-only) | — | todo |

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -26,7 +26,7 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 
 | # | Sev | Branch | Depends on | Status |
 |---|-----|--------|-----------|--------|
-| #451 | high | `fix/iframe-agent-origin-allowlist` | — | todo |
+| #451 | high | `fix/iframe-agent-origin-allowlist` | — | **merged** (self-origin guard + hardened sandbox + `agentOrigins` trust module); follow-ups: verified-origin in modal → #452, CSP `frame-src` |
 | #452 | high | `fix/connect-verified-origin` | #451 | todo |
 | #449 | high | `feat/wallet-password-unlock` | — | todo |
 | #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |

--- a/docs/audit-2026-07-fixes.md
+++ b/docs/audit-2026-07-fixes.md
@@ -41,8 +41,8 @@ Rationale: keeps `main` untouched until the whole audit-fix set is green and rev
 |---|-----|--------|-----------|--------|
 | #451 | high | `fix/iframe-agent-origin-allowlist` | — | **merged** (self-origin guard + hardened sandbox + `agentOrigins` trust module); follow-ups: verified-origin in modal → #452, CSP `frame-src` |
 | #452 | high | `fix/connect-verified-origin` | #451 | **merged** (approval modal shows verified origin + untrusted/host-mismatch warnings; `requestApproval` carries the pinned origin) |
-| #449 | high | `feat/wallet-password-unlock` | — | todo |
-| #450 | high | `fix/onboarding-encrypted-backup` | #449 | todo |
+| #449 | high | `feat/wallet-password-unlock` | — | **DEFERRED — designed feature, not merged**. All-or-nothing (encrypting at rest without a complete unlock flow itself loses wallets). Needs a designed UX with a forgot-password→restore-from-seed escape. SDK is ready (password option + DECRYPTION_ERROR detection). |
+| #450 | high | `fix/onboarding-encrypted-backup` | — (independent of #449) | **merged** (generic filename, optional backup-file encryption, honest copy) |
 | #448 | high | `fix/nametag-create-atomicity` | — | **merged** (createWalletThenRegister: create without nametag → register separately; failure never wipes the wallet) |
 | #453 | high | `fix/sphere-init-reentrancy-guard` | — | **merged** (initGenRef generation guard + adoptOrDiscardInstance; one live instance) |
 | #454 | high | `fix/group-send-throw-on-null` | — | **merged** (send path; `requireSent` guard + `sendMessage` catch). Follow-ups: moderation actions (boolean-false) + DM/mini-chat sends |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { IntroPage } from './pages/IntroPage';
 import { HomePage } from './pages/HomePage';
 import { AgentPage } from './pages/AgentPage';
 import { ConnectPage } from './pages/ConnectPage';
+import { DesktopShell } from './components/desktop/DesktopShell';
 import { useSphereEvents } from './sdk';
 
 // Retry wrapper: auto-reload page once on chunk load failure (stale deployment)
@@ -40,16 +41,18 @@ function LazyFallback() {
   );
 }
 
-export default function App() {
-  useSphereEvents();
-
+export function AppRoutes() {
   return (
     <Routes>
       <Route path="/" element={<IntroPage />} />
       <Route path="/connect" element={<ConnectPage />} />
       <Route element={<DashboardLayout />}>
-        <Route path="/home" element={<HomePage />} />
-        <Route path="/agents/:agentId" element={<AgentPage />} />
+        {/* DesktopShell renders DesktopLayout once so /home <-> /agents/:id
+            navigation keeps open iframe tabs mounted (see #455). */}
+        <Route element={<DesktopShell />}>
+          <Route path="/home" element={<HomePage />} />
+          <Route path="/agents/:agentId" element={<AgentPage />} />
+        </Route>
         <Route path="/developers" element={<Suspense fallback={<LazyFallback />}><DevelopersPage /></Suspense>} />
         <Route path="/developers/docs" element={<Suspense fallback={<LazyFallback />}><DocsPage /></Suspense>} />
         <Route path="/markets" element={<Suspense fallback={<LazyFallback />}><MarketsPage /></Suspense>} />
@@ -60,4 +63,9 @@ export default function App() {
       </Route>
     </Routes>
   );
+}
+
+export default function App() {
+  useSphereEvents();
+  return <AppRoutes />;
 }

--- a/src/components/agents/IframeAgent.tsx
+++ b/src/components/agents/IframeAgent.tsx
@@ -1,10 +1,15 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Loader2, Globe, ExternalLink, RotateCw } from 'lucide-react';
+import { Loader2, Globe, ExternalLink, RotateCw, ShieldAlert } from 'lucide-react';
 import { ConnectHost, HOST_READY_TYPE } from '@unicitylabs/sphere-sdk/connect';
 import type { DAppMetadata, PermissionScope } from '@unicitylabs/sphere-sdk/connect';
 import { PostMessageTransport } from '@unicitylabs/sphere-sdk/connect/browser';
 import type { AgentConfig } from '../../config/activities';
 import { CONNECT_MIN_SDK_VERSION } from '../../config/connect';
+import {
+  isWalletOwnOrigin,
+  AGENT_IFRAME_SANDBOX,
+  AGENT_IFRAME_ALLOW,
+} from '../../config/agentOrigins';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
 import { useConnectContext } from '../connect/ConnectContext';
 import { describeConnectRejection } from '../connect/rejectionMessage';
@@ -32,6 +37,19 @@ export function IframeAgent({ agent }: IframeAgentProps) {
   const { requestApproval, requestIntent, setConnectHost } = useConnectContext();
 
   const hasUrlOptions = agent.iframeUrls && agent.iframeUrls.length > 1;
+
+  // Trust boundary: a frame on the wallet's OWN origin, with allow-same-origin,
+  // could execute as the wallet and reach the parent DOM. Refuse to frame it or
+  // attach a Connect host — this URL only ever arrives from an untrusted source
+  // (e.g. a deep link in a DM). See config/agentOrigins.ts.
+  const framedOrigin = (() => {
+    try {
+      return new URL(activeUrl).origin;
+    } catch {
+      return null;
+    }
+  })();
+  const isSelfOrigin = framedOrigin !== null && isWalletOwnOrigin(framedOrigin);
 
   // Stable refs to avoid effect re-runs
   const sphereRef = useRef(sphere);
@@ -82,6 +100,12 @@ export function IframeAgent({ agent }: IframeAgentProps) {
       origin = new URL(activeUrl).origin;
     } catch {
       console.warn('[Connect] Invalid iframe URL:', activeUrl);
+      return;
+    }
+
+    // Never bridge the wallet to its own origin (see isSelfOrigin above).
+    if (isWalletOwnOrigin(origin)) {
+      console.warn('[Connect] Refusing to attach a Connect host to the wallet own origin:', origin);
       return;
     }
 
@@ -155,6 +179,33 @@ export function IframeAgent({ agent }: IframeAgentProps) {
     displayHost = new URL(activeUrl).host;
   } catch {
     displayHost = activeUrl;
+  }
+
+  if (isSelfOrigin) {
+    return (
+      <div
+        data-testid="agent-self-origin-blocked"
+        className="h-full min-h-0 flex flex-col items-center justify-center gap-3 p-6 text-center"
+      >
+        <ShieldAlert className="w-10 h-10 text-orange-500" />
+        <div className="font-semibold text-neutral-900 dark:text-white">
+          This page can't be opened as an agent
+        </div>
+        <p className="max-w-sm text-sm text-neutral-500 dark:text-neutral-400">
+          It points at Sphere's own address, so opening it here would give an untrusted page
+          access to your wallet. Open it in a normal browser tab instead.
+        </p>
+        <a
+          href={activeUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-orange-600 dark:text-orange-400 rounded-lg hover:bg-orange-500/10 transition-colors"
+        >
+          <ExternalLink className="w-4 h-4" />
+          Open in new tab
+        </a>
+      </div>
+    );
   }
 
   return (
@@ -242,8 +293,8 @@ export function IframeAgent({ agent }: IframeAgentProps) {
               setTimeout(sendReady, 300);
             }
           }}
-          allow="clipboard-write"
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+          allow={AGENT_IFRAME_ALLOW}
+          sandbox={AGENT_IFRAME_SANDBOX}
         />
       </div>
     </div>

--- a/src/components/agents/IframeAgent.tsx
+++ b/src/components/agents/IframeAgent.tsx
@@ -134,8 +134,9 @@ export function IframeAgent({ agent }: IframeAgentProps) {
           return { approved: false, grantedPermissions: [] };
         }
 
-        // First time — show approval modal via ConnectProvider
-        const result = await requestApprovalRef.current(dapp, perms);
+        // First time — show approval modal via ConnectProvider (anchor trust to
+        // the transport-verified origin, not the dApp-supplied metadata).
+        const result = await requestApprovalRef.current(dapp, perms, origin);
         if (result.approved) {
           saveApprovedOrigin(origin, dapp, result.grantedPermissions);
         }

--- a/src/components/chat/hooks/useGroupChat.ts
+++ b/src/components/chat/hooks/useGroupChat.ts
@@ -8,6 +8,7 @@ import { useIdentity } from '../../../sdk/hooks/core/useIdentity';
 import { useActiveTabId } from '../../../hooks/useDesktopState';
 import { STORAGE_KEYS } from '../../../config/storageKeys';
 import { getGroupDisplayName, isPinnedGroup } from '../utils/groupChatHelpers';
+import { requireSent } from '../utils/requireSent';
 import { buildAddressId } from '../data/chatTypes';
 
 export const groupChatKeys = (addressId: string) => ({
@@ -364,8 +365,13 @@ export const useGroupChat = (): UseGroupChatReturn => {
       if (!selectedGroup) throw new Error('No group selected');
       if (!groupChat) throw new Error('Group chat not available');
 
+      // GroupChatModule.sendMessage resolves to null on failure (it swallows
+      // its own errors). requireSent turns that into a rejection so onSuccess
+      // (which clears the input) is skipped and the global onError toast fires,
+      // instead of the typed message being discarded silently. See #454.
       const message = await groupChat.sendMessage(selectedGroup.id, content, replyToId);
-      return !!message;
+      requireSent(message);
+      return true;
     },
     onSuccess: () => {
       setMessageInput('');
@@ -432,7 +438,15 @@ export const useGroupChat = (): UseGroupChatReturn => {
   const sendMessage = useCallback(
     async (content: string, replyToId?: string): Promise<boolean> => {
       if (!content.trim()) return false;
-      return sendMessageMutation.mutateAsync({ content, replyToId });
+      try {
+        await sendMessageMutation.mutateAsync({ content, replyToId });
+        return true;
+      } catch {
+        // The failure is surfaced by the mutation's global onError toast; return
+        // false here so the click handler doesn't also raise an unhandled
+        // rejection (which would double-report to Sentry). Input stays intact.
+        return false;
+      }
     },
     [sendMessageMutation]
   );

--- a/src/components/chat/utils/requireSent.ts
+++ b/src/components/chat/utils/requireSent.ts
@@ -1,0 +1,19 @@
+/**
+ * The chat SDK methods (`GroupChatModule.sendMessage`, `deleteMessage`,
+ * `kickUser`, ...) catch their own errors and resolve to `null` on failure
+ * instead of throwing. A mutation that wraps that as `return !!result` therefore
+ * RESOLVES with `false` — react-query runs `onSuccess` (which clears the input),
+ * the global `onError` toast never fires, and the user's typed message is
+ * silently discarded.
+ *
+ * `requireSent` converts the silent `null`/`undefined` into a rejection so the
+ * mutation fails: `onSuccess` is skipped (input preserved) and the global
+ * `onError` toast surfaces the failure. Falsy-but-valid results (`''`, `0`) are
+ * treated as success.
+ */
+export function requireSent<T>(result: T | null | undefined, action = 'send message'): T {
+  if (result == null) {
+    throw new Error(`Failed to ${action}`);
+  }
+  return result;
+}

--- a/src/components/connect/ConnectContext.ts
+++ b/src/components/connect/ConnectContext.ts
@@ -5,6 +5,13 @@ import type { ConnectHost } from '@unicitylabs/sphere-sdk/connect';
 export interface PendingApproval {
   dapp: DAppMetadata;
   permissions: PermissionScope[];
+  /**
+   * The transport-verified origin the dApp is loaded from (from the iframe URL
+   * or the popup `origin` param, enforced by the transport's allowedOrigins).
+   * This — NOT the dApp-supplied `dapp.url` — is the trust anchor shown to the
+   * user. See config/agentOrigins.ts.
+   */
+  origin: string;
   resolve: (result: { approved: boolean; grantedPermissions: PermissionScope[] }) => void;
 }
 
@@ -15,10 +22,15 @@ export interface PendingIntent {
 }
 
 export interface ConnectContextValue {
-  /** Called by IframeAgent's ConnectHost when a dApp requests connection */
+  /**
+   * Called by the ConnectHost host (IframeAgent / ConnectPage) when a dApp
+   * requests connection. `origin` is the transport-verified origin — pass the
+   * value the transport pins (never `dapp.url`).
+   */
   requestApproval: (
     dapp: DAppMetadata,
     permissions: PermissionScope[],
+    origin: string,
   ) => Promise<{ approved: boolean; grantedPermissions: PermissionScope[] }>;
 
   /** Called by IframeAgent's ConnectHost when a dApp sends an intent */

--- a/src/components/connect/ConnectProvider.tsx
+++ b/src/components/connect/ConnectProvider.tsx
@@ -35,9 +35,9 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
   }, []);
 
   const requestApproval = useCallback(
-    (dapp: DAppMetadata, permissions: PermissionScope[]) => {
+    (dapp: DAppMetadata, permissions: PermissionScope[], origin: string) => {
       return new Promise<{ approved: boolean; grantedPermissions: PermissionScope[] }>((resolve) => {
-        setPendingApproval({ dapp, permissions, resolve });
+        setPendingApproval({ dapp, permissions, origin, resolve });
       });
     },
     [],

--- a/src/components/connect/ConnectionApprovalModal.tsx
+++ b/src/components/connect/ConnectionApprovalModal.tsx
@@ -1,9 +1,18 @@
 import { useState, useEffect } from 'react';
-import { Plug, Shield } from 'lucide-react';
+import { Plug, Shield, Globe, AlertTriangle } from 'lucide-react';
 import { PERMISSION_SCOPES } from '@unicitylabs/sphere-sdk/connect';
 import type { PermissionScope } from '@unicitylabs/sphere-sdk/connect';
 import { BaseModal, ModalHeader, Button } from '../wallet/ui';
+import { classifyAgentOrigin } from '../../config/agentOrigins';
 import { useConnectContext } from './ConnectContext';
+
+function hostOf(value: string): string | null {
+  try {
+    return new URL(value).host;
+  } catch {
+    return null;
+  }
+}
 
 const PERMISSION_LABELS: Record<string, string> = {
   [PERMISSION_SCOPES.IDENTITY_READ]: 'View identity',
@@ -38,7 +47,17 @@ export function ConnectionApprovalModal() {
 
   if (!pendingApproval) return null;
 
-  const { dapp, permissions } = pendingApproval;
+  const { dapp, permissions, origin } = pendingApproval;
+
+  // Trust is anchored to the transport-verified origin, never to dApp-supplied
+  // metadata. `untrusted` (anything not on the curated allowlist) gets a plain
+  // warning; a reported-url host that disagrees with the verified origin is a
+  // spoofing signal and gets its own callout.
+  const isTrusted = classifyAgentOrigin(origin) === 'trusted';
+  const reportedHost = hostOf(dapp.url);
+  const verifiedHost = hostOf(origin);
+  const hostMismatch =
+    reportedHost !== null && verifiedHost !== null && reportedHost !== verifiedHost;
 
   const togglePermission = (perm: PermissionScope) => {
     if (perm === PERMISSION_SCOPES.IDENTITY_READ) return; // always granted
@@ -67,24 +86,63 @@ export function ConnectionApprovalModal() {
     <BaseModal isOpen={true} onClose={handleDeny}>
       <ModalHeader
         title="Connect dApp"
-        subtitle={dapp.url}
+        subtitle={verifiedHost ?? origin}
         icon={Plug}
         onClose={handleDeny}
       />
 
       <div className="relative z-10 px-6 py-5 overflow-y-auto flex-1">
-        {/* dApp info */}
-        <div className="flex items-center gap-3 mb-5 p-3 bg-neutral-50 dark:bg-white/4 rounded-xl">
+        {/* Trust anchor: the transport-verified origin (not dApp-supplied). */}
+        <div
+          data-testid="connect-verified-origin"
+          className="flex items-center gap-3 mb-3 p-3 bg-neutral-50 dark:bg-white/4 rounded-xl"
+        >
+          <Globe className="w-5 h-5 text-neutral-500 shrink-0" />
+          <div className="min-w-0">
+            <div className="text-[11px] uppercase tracking-wide text-neutral-400">Site (verified)</div>
+            <div className="font-mono text-sm text-neutral-900 dark:text-white break-all">{origin}</div>
+          </div>
+        </div>
+
+        {/* dApp-reported metadata — untrusted decoration, clearly labelled. */}
+        <div className="flex items-center gap-3 mb-3 p-3 rounded-xl border border-neutral-200/70 dark:border-white/8">
           {dapp.icon && (
-            <img src={dapp.icon} alt="" className="w-10 h-10 rounded-lg" />
+            <img src={dapp.icon} alt="" className="w-8 h-8 rounded-lg shrink-0" />
           )}
-          <div>
-            <div className="font-semibold text-neutral-900 dark:text-white">{dapp.name}</div>
+          <div className="min-w-0">
+            <div className="text-[11px] uppercase tracking-wide text-neutral-400">Site says its name is</div>
+            <div className="font-medium text-neutral-700 dark:text-white/80 truncate">{dapp.name}</div>
             {dapp.description && (
-              <div className="text-xs text-neutral-500 dark:text-white/45">{dapp.description}</div>
+              <div className="text-xs text-neutral-500 dark:text-white/45 truncate">{dapp.description}</div>
             )}
           </div>
         </div>
+
+        {hostMismatch && (
+          <div
+            data-testid="connect-origin-mismatch"
+            className="flex items-start gap-2 mb-3 p-3 rounded-xl bg-red-500/10 text-red-700 dark:text-red-300"
+          >
+            <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+            <div className="text-xs">
+              This site claims to be <span className="font-mono">{reportedHost}</span> but is actually
+              loaded from <span className="font-mono">{verifiedHost}</span>. Do not connect unless you
+              trust it.
+            </div>
+          </div>
+        )}
+
+        {!isTrusted && !hostMismatch && (
+          <div
+            data-testid="connect-origin-warning"
+            className="flex items-start gap-2 mb-3 p-3 rounded-xl bg-amber-500/10 text-amber-700 dark:text-amber-300"
+          >
+            <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+            <div className="text-xs">
+              Sphere can't verify this site. Only connect if you trust the address above.
+            </div>
+          </div>
+        )}
 
         {/* Permissions */}
         <div className="flex items-center gap-2 mb-3">

--- a/src/components/desktop/DesktopShell.tsx
+++ b/src/components/desktop/DesktopShell.tsx
@@ -1,0 +1,20 @@
+import { Outlet } from 'react-router-dom';
+import { DesktopLayout } from './DesktopLayout';
+
+/**
+ * Shared route element for the desktop (/home) and its agent tabs
+ * (/agents/:agentId). It renders {@link DesktopLayout} ONCE, so navigating
+ * between the desktop and a tab keeps DesktopLayout mounted — preserving the
+ * hidden-but-mounted open tabs (and their iframes) it deliberately holds.
+ *
+ * The child routes (HomePage / AgentPage) only run their URL -> desktop-state
+ * sync effects and render nothing into the Outlet. See #455.
+ */
+export function DesktopShell() {
+  return (
+    <>
+      <DesktopLayout />
+      <Outlet />
+    </>
+  );
+}

--- a/src/components/wallet/onboarding/components/MnemonicBackupScreen.tsx
+++ b/src/components/wallet/onboarding/components/MnemonicBackupScreen.tsx
@@ -9,7 +9,7 @@ import { useState, useCallback } from "react";
 
 interface MnemonicBackupScreenProps {
   mnemonic: string;
-  onDownloadBackup: () => void;
+  onDownloadBackup: (password?: string) => void;
   onConfirm: () => void;
 }
 
@@ -19,6 +19,7 @@ export function MnemonicBackupScreen({
   onConfirm,
 }: MnemonicBackupScreenProps) {
   const [copied, setCopied] = useState(false);
+  const [backupPassword, setBackupPassword] = useState("");
   const words = mnemonic.split(" ");
 
   const handleCopy = useCallback(async () => {
@@ -105,20 +106,32 @@ export function MnemonicBackupScreen({
         )}
       </button>
 
+      {/* Optional backup-file encryption password */}
+      <input
+        type="password"
+        value={backupPassword}
+        onChange={(e) => setBackupPassword(e.target.value)}
+        placeholder="Backup file password (optional)"
+        aria-label="Backup file password (optional)"
+        autoComplete="new-password"
+        className="w-full mb-2 px-4 py-2.5 text-sm rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:border-brand-orange/60"
+      />
+
       {/* Download backup button */}
       <button
-        onClick={onDownloadBackup}
+        onClick={() => onDownloadBackup(backupPassword || undefined)}
         className="flex items-center justify-center gap-2 w-full mb-5 px-4 py-2.5 text-sm text-neutral-600 dark:text-[#ffe2cc] border border-neutral-200 dark:border-white/15 hover:bg-neutral-100 dark:hover:bg-white/6 transition-colors rounded-xl"
       >
         <Download className="w-4 h-4" />
-        <span>Download Backup File</span>
+        <span>{backupPassword ? "Download Encrypted Backup" : "Download Backup File"}</span>
       </button>
 
       {/* Warning notice */}
       <div className="mb-5 p-3 rounded-lg bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/20">
         <p className="text-xs text-amber-700 dark:text-amber-400 leading-relaxed">
-          Never share your recovery phrase with anyone. Anyone with these words
-          can access your wallet and funds.
+          {backupPassword
+            ? "The backup file is encrypted with this password — you'll need it to restore. Keep both safe. Anyone with your recovery phrase can access your funds."
+            : "Without a password the backup file contains your recovery phrase in plain text. Anyone with it can access your wallet and funds — set a password or store it securely."}
         </p>
       </div>
 

--- a/src/components/wallet/onboarding/hooks/buildWalletBackup.ts
+++ b/src/components/wallet/onboarding/hooks/buildWalletBackup.ts
@@ -1,0 +1,29 @@
+/**
+ * Builds the onboarding wallet-backup file (#450).
+ *
+ * The old flow wrote `exportToJSON({ includeMnemonic: true })` with no password
+ * — a cleartext recovery phrase — into a file named after the user's public
+ * handle (`@alice.json`), which is both unencrypted and trivially identifiable.
+ *
+ * This returns a generic filename (never the handle) and threads an OPTIONAL
+ * encryption password to `exportToJSON` (mirroring the in-wallet "Save Wallet").
+ * An empty password means plaintext (password omitted, not passed as '').
+ */
+export interface BackupSphere {
+  exportToJSON(opts: { includeMnemonic: boolean; password?: string }): unknown;
+}
+
+export function buildWalletBackup(
+  sphere: BackupSphere,
+  password?: string,
+): { fileName: string; json: unknown; encrypted: boolean } {
+  const json = sphere.exportToJSON({
+    includeMnemonic: true,
+    password: password ? password : undefined,
+  });
+  return {
+    fileName: 'sphere-wallet-recovery.json',
+    json,
+    encrypted: !!password,
+  };
+}

--- a/src/components/wallet/onboarding/hooks/createWalletThenRegister.ts
+++ b/src/components/wallet/onboarding/hooks/createWalletThenRegister.ts
@@ -1,0 +1,41 @@
+/**
+ * Atomic-safe wallet creation for the onboarding "create" flow (#448).
+ *
+ * Creating a wallet WITH a nametag in one shot publishes the first-write-wins
+ * Nostr binding inside `Sphere.init`. If a later step throws, `createWallet`'s
+ * cleanup wipes the only key that owns the binding — the nametag is burned
+ * forever and the mnemonic was never shown.
+ *
+ * This orchestrator splits the two concerns:
+ *  1. Create the wallet WITHOUT a nametag — no binding is published, so a
+ *     failure here can safely wipe storage (nothing is owned yet).
+ *  2. Hand the created wallet back via `onWalletCreated` so the caller stores it
+ *     and the mnemonic BEFORE the fallible step.
+ *  3. Register the nametag as a SEPARATE step on the created wallet. A failure
+ *     here never re-runs `createWallet` and never wipes the wallet — the key
+ *     survives, so the binding (if it did publish) stays owned by the user and
+ *     the nametag can be retried.
+ */
+export interface CreateWalletThenRegisterDeps<
+  S extends { registerNametag(nametag: string): Promise<void> },
+> {
+  /** Creates the wallet with NO nametag (so no binding is published). */
+  createWallet: () => Promise<{ mnemonic: string; sphere: S }>;
+  /** Called with the created wallet BEFORE the fallible nametag step. */
+  onWalletCreated: (result: { mnemonic: string; sphere: S }) => void;
+  /** Bare nametag to register (without '@'); omit to skip registration. */
+  nametag?: string;
+}
+
+export async function createWalletThenRegister<
+  S extends { registerNametag(nametag: string): Promise<void> },
+>(deps: CreateWalletThenRegisterDeps<S>): Promise<{ mnemonic: string; sphere: S }> {
+  const result = await deps.createWallet();
+  // Preserve the wallet + mnemonic before anything that can fail: from here on
+  // the wallet exists and must never be lost by a nametag-registration failure.
+  deps.onWalletCreated(result);
+  if (deps.nametag) {
+    await result.sphere.registerNametag(deps.nametag);
+  }
+  return result;
+}

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -9,6 +9,7 @@ import type { LegacyFileType } from "@unicitylabs/sphere-sdk";
 import { useSphereContext } from "../../../../sdk/hooks/core/useSphere";
 import { SPHERE_KEYS } from "../../../../sdk/queryKeys";
 import { addrKey } from "../components/addrKey";
+import { createWalletThenRegister } from "./createWalletThenRegister";
 import type { DerivedAddressInfo } from "../components/AddressSelectionScreen";
 import type { NametagAvailability } from "../components/NametagScreen";
 import { provisionOrRecoverKey } from "../../../../services/subscriptionApi";
@@ -540,13 +541,23 @@ export function useOnboardingFlow(): UseOnboardingFlowReturn {
         setProcessingStatus("Setup complete!");
         setIsProcessingComplete(true);
       } else {
-        // Create flow — create wallet with nametag
-        setProcessingStatus("Creating wallet and registering Unicity ID...");
-        const result = await createWallet({ nametag: cleanTag });
-        setGeneratedMnemonic(result.mnemonic);
-        importedSphereRef.current = result.sphere;
-        isCreateFlowRef.current = true;
-          setProcessingStep(2);
+        // Create flow — create the wallet WITHOUT a nametag first (no Nostr
+        // binding is published, so a failure here can safely wipe storage), then
+        // register the nametag as a separate step. A registration failure never
+        // re-runs createWallet and never wipes the wallet, so the key survives
+        // and the nametag can't be burned (#448).
+        setProcessingStatus("Creating wallet...");
+        await createWalletThenRegister({
+          createWallet,
+          nametag: cleanTag,
+          onWalletCreated: (result) => {
+            setGeneratedMnemonic(result.mnemonic);
+            importedSphereRef.current = result.sphere;
+            isCreateFlowRef.current = true;
+            setProcessingStatus("Registering Unicity ID...");
+          },
+        });
+        setProcessingStep(2);
         setProcessingStatus("Setup complete!");
         setIsProcessingComplete(true);
       }

--- a/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
+++ b/src/components/wallet/onboarding/hooks/useOnboardingFlow.ts
@@ -10,6 +10,7 @@ import { useSphereContext } from "../../../../sdk/hooks/core/useSphere";
 import { SPHERE_KEYS } from "../../../../sdk/queryKeys";
 import { addrKey } from "../components/addrKey";
 import { createWalletThenRegister } from "./createWalletThenRegister";
+import { buildWalletBackup } from "./buildWalletBackup";
 import type { DerivedAddressInfo } from "../components/AddressSelectionScreen";
 import type { NametagAvailability } from "../components/NametagScreen";
 import { provisionOrRecoverKey } from "../../../../services/subscriptionApi";
@@ -64,7 +65,7 @@ export interface UseOnboardingFlowReturn {
   isProcessingComplete: boolean;
   handleCompleteOnboarding: () => Promise<void>;
   handleMnemonicBackupComplete: () => void;
-  handleDownloadBackup: () => Promise<void>;
+  handleDownloadBackup: (password?: string) => Promise<void>;
 
   // Subscription plan-capabilities state (post-finalize provisioning)
   planName: string | null;
@@ -689,16 +690,13 @@ export function useOnboardingFlow(): UseOnboardingFlowReturn {
     finishFinalize();
   }, [finishFinalize]);
 
-  // Action: Download wallet backup file
-  const handleDownloadBackup = useCallback(async () => {
+  // Action: Download wallet backup file. Optional password encrypts the file
+  // (like the in-wallet "Save Wallet"); the filename never leaks the handle (#450).
+  const handleDownloadBackup = useCallback(async (password?: string) => {
     const activeSphere = importedSphereRef.current ?? sphere;
     if (!activeSphere) return;
-    const jsonData = activeSphere.exportToJSON({ includeMnemonic: true });
-    const nametag = activeSphere.identity?.nametag?.replace(/^@/, "");
-    const fileName = nametag
-      ? `${nametag}.json`
-      : "sphere_wallet_backup.json";
-    const blob = new Blob([JSON.stringify(jsonData, null, 2)], { type: "application/json" });
+    const { fileName, json } = buildWalletBackup(activeSphere, password);
+    const blob = new Blob([JSON.stringify(json, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/src/config/agentOrigins.ts
+++ b/src/config/agentOrigins.ts
@@ -1,0 +1,89 @@
+/**
+ * Trust boundary for third-party "agent" iframes.
+ *
+ * A custom agent can frame an arbitrary URL (the feature explicitly allows
+ * loading any dev/dApp URL), and Sphere attaches a live Connect bridge to it.
+ * That makes the framed origin a trust boundary: we must never bridge the
+ * wallet to its OWN origin, and the UI must be able to tell a curated
+ * first-party origin apart from an arbitrary third party.
+ *
+ * This module is the single source of truth for that classification and for
+ * the hardened iframe sandbox. It is pure (origins passed in) so it is fully
+ * unit-testable.
+ */
+
+export type AgentOriginTrust = 'self' | 'trusted' | 'untrusted';
+
+/**
+ * Curated first-party agent origins. Anything not listed here is treated as an
+ * untrusted third party (still framable, but shown as such — never as a
+ * first-party feature). Kept intentionally small; grow it as a real registry
+ * ships. `window.location.origin` is deliberately NOT in this list — the wallet
+ * must never bridge to itself (see {@link isWalletOwnOrigin}).
+ */
+export const TRUSTED_AGENT_ORIGINS: readonly string[] = [];
+
+/**
+ * Hardened sandbox for agent iframes. Deliberately WITHOUT
+ * `allow-popups-to-escape-sandbox`: an escaped popup runs unsandboxed with full
+ * privileges, a convincing phishing surface launched from inside trusted wallet
+ * chrome. `allow-same-origin` stays so normal dApps keep storage/cookies —
+ * framing the wallet's own origin is refused separately (see
+ * {@link isWalletOwnOrigin}) so a frame can never execute as the wallet origin.
+ */
+export const AGENT_IFRAME_SANDBOX = 'allow-scripts allow-same-origin allow-forms allow-popups';
+
+/**
+ * `allow` attribute for agent iframes. Empty on purpose: `clipboard-write` is
+ * dropped because programmatic clipboard access on an attacker-chosen origin is
+ * the classic crypto address-swap vector.
+ */
+export const AGENT_IFRAME_ALLOW = '';
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `origin` resolves to the same origin the wallet itself runs on.
+ * Such a frame, combined with `allow-same-origin`, would execute as the wallet
+ * origin and could reach the parent DOM — so it must never get a Connect bridge.
+ */
+export function isWalletOwnOrigin(
+  origin: string,
+  selfOrigin: string = window.location.origin,
+): boolean {
+  const a = normalizeOrigin(origin);
+  const b = normalizeOrigin(selfOrigin);
+  return a !== null && b !== null && a === b;
+}
+
+export interface ClassifyAgentOriginOptions {
+  selfOrigin?: string;
+  trustedOrigins?: readonly string[];
+}
+
+/**
+ * Classify a framed agent origin. `self` (the wallet's own origin) takes
+ * precedence over everything and must be refused; `trusted` is a curated
+ * first-party origin; everything else is `untrusted`.
+ */
+export function classifyAgentOrigin(
+  origin: string,
+  options: ClassifyAgentOriginOptions = {},
+): AgentOriginTrust {
+  const selfOrigin = options.selfOrigin ?? window.location.origin;
+  const trusted = options.trustedOrigins ?? TRUSTED_AGENT_ORIGINS;
+
+  if (isWalletOwnOrigin(origin, selfOrigin)) return 'self';
+
+  const normalized = normalizeOrigin(origin);
+  if (normalized !== null && trusted.some((t) => normalizeOrigin(t) === normalized)) {
+    return 'trusted';
+  }
+  return 'untrusted';
+}

--- a/src/pages/AgentPage.tsx
+++ b/src/pages/AgentPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useParams, useSearchParams, Navigate } from 'react-router-dom';
-import { DesktopLayout } from '../components/desktop/DesktopLayout';
 import { getAgentConfig } from '../config/activities';
 import { useDesktopState } from '../hooks/useDesktopState';
 import { normalizeUrl } from '../utils/normalizeUrl';
@@ -42,5 +41,7 @@ export function AgentPage() {
     return <Navigate to="/home" replace />;
   }
 
-  return <DesktopLayout />;
+  // DesktopLayout is rendered by the shared DesktopShell (see #455); this route
+  // only syncs the URL into desktop state.
+  return null;
 }

--- a/src/pages/ConnectPage.tsx
+++ b/src/pages/ConnectPage.tsx
@@ -116,8 +116,8 @@ export function ConnectPage() {
           return { approved: false, grantedPermissions: [] };
         }
 
-        // First time — show approval modal
-        const result = await requestApprovalRef.current(dapp, perms);
+        // First time — show approval modal (anchor trust to the verified origin).
+        const result = await requestApprovalRef.current(dapp, perms, origin);
         if (result.approved) {
           setConnectedDapp(dapp.name);
           saveApprovedOrigin(origin, dapp, result.grantedPermissions);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,11 @@
 import { useEffect } from 'react';
-import { DesktopLayout } from '../components/desktop/DesktopLayout';
 import { useDesktopState } from '../hooks/useDesktopState';
 
+/**
+ * Route sync for /home. DesktopLayout is rendered by the shared DesktopShell
+ * (see #455), so this only resets to the desktop (no active tab) and renders
+ * nothing itself.
+ */
 export function HomePage() {
   const { activeTabId, showDesktop } = useDesktopState();
 
@@ -12,5 +16,5 @@ export function HomePage() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return <DesktopLayout />;
+  return null;
 }

--- a/src/sdk/SphereProvider.tsx
+++ b/src/sdk/SphereProvider.tsx
@@ -8,6 +8,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { Sphere, TokenRegistry, NETWORKS, logger, isSphereError, getPublicKey } from '@unicitylabs/sphere-sdk';
 import { sendWelcomeDM } from './welcomeDM';
+import { adoptOrDiscardInstance } from './adoptOrDiscardInstance';
 import type { InitProgress, NetworkType } from '@unicitylabs/sphere-sdk';
 import { getErrorMessage } from './errors';
 import {
@@ -206,6 +207,11 @@ export function SphereProvider({
     SUBSCRIPTION_ENABLED ? 'provisioning' : 'not-required',
   );
   const sphereRef = useRef<Sphere | null>(null);
+  // Monotonic init generation: only the LATEST initialize() run may adopt its
+  // Sphere; a run superseded mid-flight (StrictMode double-mount, IPFS/network
+  // toggle, unmount) destroys the instance it built instead of leaking it. See
+  // #453 and adoptOrDiscardInstance.
+  const initGenRef = useRef(0);
   // Subscription-key reconcile bookkeeping (SUBSCRIPTION_ENABLED only):
   // - subKeyGenRef: monotonic generation so only the LATEST reconcile (initial
   //   load or a live address switch) may apply its key + flip status; stale
@@ -368,12 +374,18 @@ export function SphereProvider({
   );
 
   const initialize = useCallback(async (attempt = 0, skipLoading = false) => {
+    // Claim this generation; any later initialize() (or the unmount cleanup)
+    // supersedes us. Checked after every await so a stale run stops touching
+    // state and, crucially, never adopts the instance it built.
+    const gen = ++initGenRef.current;
+    const isStale = () => gen !== initGenRef.current;
     try {
       // Destroy previous instance to release IndexedDB connections
       if (sphereRef.current) {
         await sphereRef.current.destroy();
         sphereRef.current = null;
       }
+      if (isStale()) return;
 
       if (!skipLoading) setIsLoading(true);
       setError(null);
@@ -396,6 +408,7 @@ export function SphereProvider({
       });
 
       const exists = await Sphere.exists(browserProviders.storage);
+      if (isStale()) return;
       setWalletExists(exists);
 
       if (exists) {
@@ -406,10 +419,15 @@ export function SphereProvider({
           discoverAddresses: false, // Run separately below for UX
           onProgress: setInitProgress,
         });
-        setupIpfsSync(instance, browserProviders);
+        // Adopt only if we're still the latest init; otherwise destroy the
+        // instance we just built so it can't linger as a zombie (#453).
+        const outcome = await adoptOrDiscardInstance(instance, isStale, (inst) => {
+          setupIpfsSync(inst, browserProviders);
+          sphereRef.current = inst;
+          setSphere(inst);
+        });
+        if (outcome === 'discarded') return;
         setInitProgress(null);
-        sphereRef.current = instance;
-        setSphere(instance);
 
         // Readiness for the send gate: 'ready' iff this oracle was built WITH a
         // subscription key. With no key yet we provision below and stay
@@ -454,12 +472,17 @@ export function SphereProvider({
         // Pre-connect transport for nametag lookups during onboarding
         const transport = browserProviders.transport;
         await transport.connect();
+        if (isStale()) return;
         transport.setIdentity({
           privateKey: '0000000000000000000000000000000000000000000000000000000000000001',
           chainPubkey: '000000000000000000000000000000000000000000000000000000000000000000',
         });
       }
     } catch (err) {
+      // A superseded run's failure is not the user's problem — a newer init
+      // owns the outcome. Don't surface its error or retry.
+      if (isStale()) return;
+
       // IndexedDB may be temporarily blocked after database deletion.
       // Retry once after a short delay before giving up.
       if (isSphereError(err) && err.code === 'STORAGE_ERROR' && attempt < 1) {
@@ -471,15 +494,22 @@ export function SphereProvider({
       logger.error('SphereProvider', 'Initialization failed', err);
       setError(err instanceof Error ? err : new Error(getErrorMessage(err)));
     } finally {
-      setInitProgress(null);
-      setIsLoading(false);
+      // Only the latest run owns the shared loading/progress UI.
+      if (!isStale()) {
+        setInitProgress(null);
+        setIsLoading(false);
+      }
     }
   }, [network, setupSubscriptionKey]);
 
   useEffect(() => {
     initialize();
     return () => {
-      // Cleanup on unmount
+      // Supersede any in-flight init so it destroys its instance instead of
+      // adopting it after unmount, then tear down the live one. Reading the
+      // LIVE ref values at cleanup time is intentional here (not a snapshot).
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      initGenRef.current++;
       sphereRef.current?.destroy();
       sphereRef.current = null;
     };

--- a/src/sdk/adoptOrDiscardInstance.ts
+++ b/src/sdk/adoptOrDiscardInstance.ts
@@ -1,0 +1,25 @@
+/**
+ * Re-entrant-init guard for the single live Sphere instance.
+ *
+ * `initialize()` can run concurrently (React StrictMode double-mount, an
+ * IPFS/network toggle). Each run builds its own Sphere. Only the LATEST run may
+ * adopt its instance; any run that has been superseded while its `Sphere.init`
+ * was in flight must DESTROY the instance it built — otherwise it leaks as a
+ * zombie holding open relay + IndexedDB connections.
+ *
+ * `isStale()` returns true when a newer init (or an unmount) has superseded this
+ * one. Because only the latest run adopts and superseded runs destroy their own
+ * instance, there is always exactly one live instance.
+ */
+export async function adoptOrDiscardInstance<T extends { destroy: () => Promise<void> }>(
+  instance: T,
+  isStale: () => boolean,
+  adopt: (instance: T) => void,
+): Promise<'adopted' | 'discarded'> {
+  if (isStale()) {
+    await instance.destroy();
+    return 'discarded';
+  }
+  adopt(instance);
+  return 'adopted';
+}

--- a/tests/unit/chat/requireSent.test.ts
+++ b/tests/unit/chat/requireSent.test.ts
@@ -1,0 +1,33 @@
+/**
+ * #454: chat SDK methods (sendMessage, deleteMessage, ...) resolve to null on
+ * failure instead of throwing, so a mutation wrapping them as `return !!result`
+ * RESOLVES with false — onSuccess (which clears the input) runs and the typed
+ * message is silently discarded. requireSent turns the silent null into a
+ * rejection so onError fires and onSuccess is skipped.
+ */
+import { describe, it, expect } from 'vitest';
+import { requireSent } from '../../../src/components/chat/utils/requireSent';
+
+describe('requireSent (silent-null guard for chat SDK results)', () => {
+  it('throws when the SDK returned null', () => {
+    expect(() => requireSent(null)).toThrow(/failed to send message/i);
+  });
+
+  it('throws when the SDK returned undefined', () => {
+    expect(() => requireSent(undefined)).toThrow();
+  });
+
+  it('uses the action label in the error message', () => {
+    expect(() => requireSent(null, 'delete message')).toThrow(/failed to delete message/i);
+  });
+
+  it('returns the value unchanged when the send succeeded', () => {
+    const message = { id: 'm1' };
+    expect(requireSent(message)).toBe(message);
+  });
+
+  it('treats falsy-but-valid values (empty string, 0) as success, not failure', () => {
+    expect(requireSent('')).toBe('');
+    expect(requireSent(0)).toBe(0);
+  });
+});

--- a/tests/unit/components/buildWalletBackup.test.ts
+++ b/tests/unit/components/buildWalletBackup.test.ts
@@ -1,0 +1,39 @@
+/**
+ * #450: the onboarding "Download Backup" wrote the mnemonic as an UNENCRYPTED
+ * JSON named after the user's public handle (`@alice.json`) — trivially
+ * identifiable and cleartext. buildWalletBackup fixes both: a generic filename
+ * (no handle leak) and an optional at-file encryption password threaded to
+ * exportToJSON (mirroring the in-wallet "Save Wallet").
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { buildWalletBackup } from '../../../src/components/wallet/onboarding/hooks/buildWalletBackup';
+
+function makeSphere(nametag?: string) {
+  return {
+    exportToJSON: vi.fn((opts) => ({ opts })),
+    identity: { nametag },
+  };
+}
+
+describe('buildWalletBackup', () => {
+  it('never names the file after the public handle', () => {
+    const sphere = makeSphere('@alice');
+    const { fileName } = buildWalletBackup(sphere);
+    expect(fileName).not.toContain('alice');
+    expect(fileName).toBe('sphere-wallet-recovery.json');
+  });
+
+  it('encrypts the export when a password is given', () => {
+    const sphere = makeSphere('@alice');
+    const { encrypted } = buildWalletBackup(sphere, 'hunter2');
+    expect(sphere.exportToJSON).toHaveBeenCalledWith({ includeMnemonic: true, password: 'hunter2' });
+    expect(encrypted).toBe(true);
+  });
+
+  it('exports plaintext (password omitted, not empty string) when no password', () => {
+    const sphere = makeSphere();
+    const { encrypted } = buildWalletBackup(sphere, '');
+    expect(sphere.exportToJSON).toHaveBeenCalledWith({ includeMnemonic: true, password: undefined });
+    expect(encrypted).toBe(false);
+  });
+});

--- a/tests/unit/components/connectionApprovalModal.test.tsx
+++ b/tests/unit/components/connectionApprovalModal.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * #452: the connection-approval modal must anchor trust to the transport-verified
+ * origin, not to the dApp-self-reported metadata (name/url/icon). A malicious
+ * embed supplies attacker-controlled decoration, so the verified origin is the
+ * only thing the user can rely on.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PermissionScope } from '@unicitylabs/sphere-sdk/connect';
+
+const state = vi.hoisted(() => ({
+  pending: null as null | {
+    dapp: { name: string; url: string; icon?: string };
+    permissions: PermissionScope[];
+    origin: string;
+    resolve: () => void;
+  },
+}));
+
+vi.mock('../../../src/components/connect/ConnectContext', () => ({
+  useConnectContext: () => ({
+    pendingApproval: state.pending,
+    approveConnection: vi.fn(),
+    denyConnection: vi.fn(),
+  }),
+}));
+
+import { ConnectionApprovalModal } from '../../../src/components/connect/ConnectionApprovalModal';
+
+beforeEach(() => {
+  state.pending = null;
+});
+
+describe('ConnectionApprovalModal — verified origin as trust anchor', () => {
+  it('shows the transport-verified origin, not the dApp-reported url', () => {
+    state.pending = {
+      dapp: { name: 'Totally Legit Wallet', url: 'https://accounts.google.com' },
+      permissions: [],
+      origin: 'https://evil.attacker.example',
+      resolve: () => {},
+    };
+
+    render(<ConnectionApprovalModal />);
+
+    // The verified origin is shown as the primary identity.
+    expect(screen.getByTestId('connect-verified-origin').textContent).toContain(
+      'https://evil.attacker.example',
+    );
+  });
+
+  it('warns that an unverified third-party origin is not trusted by Sphere', () => {
+    state.pending = {
+      dapp: { name: 'App', url: 'https://app.example' },
+      permissions: [],
+      origin: 'https://app.example',
+      resolve: () => {},
+    };
+
+    render(<ConnectionApprovalModal />);
+
+    expect(screen.getByTestId('connect-origin-warning')).toBeDefined();
+  });
+
+  it('warns when the dApp-reported url host does not match the verified origin', () => {
+    state.pending = {
+      dapp: { name: 'App', url: 'https://accounts.google.com/signin' },
+      permissions: [],
+      origin: 'https://evil.attacker.example',
+      resolve: () => {},
+    };
+
+    render(<ConnectionApprovalModal />);
+
+    expect(screen.getByTestId('connect-origin-mismatch')).toBeDefined();
+  });
+});

--- a/tests/unit/components/createWalletThenRegister.test.ts
+++ b/tests/unit/components/createWalletThenRegister.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #448: creating a wallet WITH a nametag in one shot publishes the first-write-
+ * wins Nostr binding inside Sphere.init; if anything then fails, cleanupOnError
+ * wipes the only key that owns the binding — the nametag is burned forever and
+ * the mnemonic was never shown. The fix: create the wallet WITHOUT a nametag
+ * first (no binding published, safe to wipe on failure), report/preserve it,
+ * then register the nametag as a SEPARATE step whose failure never wipes the
+ * wallet.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createWalletThenRegister } from '../../../src/components/wallet/onboarding/hooks/createWalletThenRegister';
+
+function makeSphere() {
+  return { registerNametag: vi.fn(async () => {}) };
+}
+
+describe('createWalletThenRegister', () => {
+  it('creates the wallet WITHOUT a nametag, then registers it separately', async () => {
+    const sphere = makeSphere();
+    const createWallet = vi.fn(async () => ({ mnemonic: 'seed words', sphere }));
+    const onWalletCreated = vi.fn();
+
+    await createWalletThenRegister({ createWallet, onWalletCreated, nametag: 'alice' });
+
+    // Wallet is created with no arguments — so Sphere.init publishes no binding.
+    expect(createWallet).toHaveBeenCalledTimes(1);
+    expect(createWallet).toHaveBeenCalledWith();
+    // The nametag is registered as a separate step on the created wallet.
+    expect(sphere.registerNametag).toHaveBeenCalledWith('alice');
+  });
+
+  it('preserves the created wallet BEFORE the fallible nametag step', async () => {
+    const sphere = makeSphere();
+    const result = { mnemonic: 'seed words', sphere };
+    const createWallet = vi.fn(async () => result);
+    const calls: string[] = [];
+    const onWalletCreated = vi.fn(() => calls.push('created'));
+    sphere.registerNametag.mockImplementation(async () => {
+      calls.push('register');
+    });
+
+    await createWalletThenRegister({ createWallet, onWalletCreated, nametag: 'alice' });
+
+    // The wallet must be handed back (and stored by the caller) BEFORE register.
+    expect(calls).toEqual(['created', 'register']);
+    expect(onWalletCreated).toHaveBeenCalledWith(result);
+  });
+
+  it('keeps the wallet when nametag registration fails (no re-create, no wipe)', async () => {
+    const sphere = makeSphere();
+    const result = { mnemonic: 'seed words', sphere };
+    const createWallet = vi.fn(async () => result);
+    const onWalletCreated = vi.fn();
+    sphere.registerNametag.mockRejectedValue(new Error('relay down'));
+
+    await expect(
+      createWalletThenRegister({ createWallet, onWalletCreated, nametag: 'alice' }),
+    ).rejects.toThrow('relay down');
+
+    // Wallet was created once and preserved; registration failure must NOT
+    // trigger another createWallet (which is where cleanupOnError lives).
+    expect(createWallet).toHaveBeenCalledTimes(1);
+    expect(onWalletCreated).toHaveBeenCalledWith(result);
+  });
+
+  it('skips registration entirely when no nametag is given', async () => {
+    const sphere = makeSphere();
+    const createWallet = vi.fn(async () => ({ mnemonic: 'seed words', sphere }));
+    const onWalletCreated = vi.fn();
+
+    await createWalletThenRegister({ createWallet, onWalletCreated });
+
+    expect(createWallet).toHaveBeenCalledWith();
+    expect(sphere.registerNametag).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/desktopRoute.test.tsx
+++ b/tests/unit/components/desktopRoute.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * #455: navigating between the desktop (/home) and an agent tab (/agents/:id)
+ * must NOT remount DesktopLayout — remounting reloads every open iframe app and
+ * discards the hidden-tab state DesktopLayout deliberately preserves.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useNavigate, Outlet } from 'react-router-dom';
+import { AppRoutes } from '../../../src/App';
+
+const mounts = vi.hoisted(() => ({ count: 0 }));
+
+// Count how many times DesktopLayout mounts across navigation.
+vi.mock('../../../src/components/desktop/DesktopLayout', async () => {
+  const { useEffect } = await import('react');
+  return {
+    DesktopLayout: () => {
+      useEffect(() => {
+        mounts.count += 1;
+      }, []);
+      return <div data-testid="desktop-layout" />;
+    },
+  };
+});
+
+// DashboardLayout just needs to render its Outlet for this test.
+vi.mock('../../../src/components/layout/DashboardLayout', () => ({
+  DashboardLayout: () => <Outlet />,
+}));
+
+// Eager route pages we never navigate to — stub so their asset imports (svg)
+// don't load in the test environment.
+vi.mock('../../../src/pages/IntroPage', () => ({ IntroPage: () => null }));
+vi.mock('../../../src/pages/ConnectPage', () => ({ ConnectPage: () => null }));
+vi.mock('../../../src/sdk', () => ({ useSphereEvents: () => {} }));
+
+// The page components' desktop-state side effects are irrelevant here.
+vi.mock('../../../src/hooks/useDesktopState', () => ({
+  useDesktopState: () => ({ activeTabId: null, showDesktop: vi.fn(), openTab: vi.fn() }),
+  useActiveTabId: () => null,
+}));
+
+function Nav() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button onClick={() => navigate('/home')}>go-home</button>
+      <button onClick={() => navigate('/agents/custom')}>go-agent</button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  mounts.count = 0;
+});
+
+describe('desktop <-> agent navigation', () => {
+  it('keeps DesktopLayout mounted (no remount) across /home <-> /agents', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <AppRoutes />
+        <Nav />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('desktop-layout')).toBeDefined();
+    expect(mounts.count).toBe(1);
+
+    fireEvent.click(screen.getByText('go-agent'));
+    fireEvent.click(screen.getByText('go-home'));
+    fireEvent.click(screen.getByText('go-agent'));
+
+    // A stable shared layout mounts DesktopLayout exactly once.
+    expect(mounts.count).toBe(1);
+  });
+});

--- a/tests/unit/components/iframeAgent.test.tsx
+++ b/tests/unit/components/iframeAgent.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * #451: the in-app agent iframe is a trust boundary. It must never bridge the
+ * wallet to its own origin (a same-origin frame could reach the parent DOM),
+ * and third-party frames must run under a hardened sandbox (no escaping popups,
+ * no clipboard write).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AgentConfig } from '../../../src/config/activities';
+import { AGENT_IFRAME_SANDBOX } from '../../../src/config/agentOrigins';
+
+const { ConnectHostMock } = vi.hoisted(() => ({
+  ConnectHostMock: vi.fn(function () {
+    return {
+      destroy: vi.fn(),
+      updateSphere: vi.fn(),
+      notifyWalletLocked: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('@unicitylabs/sphere-sdk/connect', () => ({
+  ConnectHost: ConnectHostMock,
+  HOST_READY_TYPE: 'sphere-connect:host-ready',
+}));
+
+vi.mock('@unicitylabs/sphere-sdk/connect/browser', () => ({
+  PostMessageTransport: { forHost: vi.fn(() => ({ destroy: vi.fn() })) },
+}));
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ sphere: { identity: { chainPubkey: '02ab' } } }),
+}));
+
+vi.mock('../../../src/components/connect/ConnectContext', () => ({
+  useConnectContext: () => ({
+    requestApproval: vi.fn(),
+    requestIntent: vi.fn(),
+    setConnectHost: vi.fn(),
+  }),
+}));
+
+import { IframeAgent } from '../../../src/components/agents/IframeAgent';
+
+function makeAgent(url: string): AgentConfig {
+  return {
+    id: 'custom',
+    name: 'Test Agent',
+    description: '',
+    Icon: (() => null) as unknown as AgentConfig['Icon'],
+    category: 'Custom',
+    color: '',
+    type: 'iframe',
+    iframeUrl: url,
+  };
+}
+
+beforeEach(() => {
+  ConnectHostMock.mockClear();
+});
+
+describe('IframeAgent trust boundary', () => {
+  it('refuses to frame the wallet own origin and never attaches a Connect host', () => {
+    render(<IframeAgent agent={makeAgent(`${window.location.origin}/malicious`)} />);
+
+    expect(ConnectHostMock).not.toHaveBeenCalled();
+    expect(screen.queryByTitle('Test Agent')).toBeNull(); // no iframe rendered
+    expect(screen.getByTestId('agent-self-origin-blocked')).toBeDefined();
+  });
+
+  it('frames a third-party origin under the hardened sandbox (no escaping popups, no clipboard-write)', () => {
+    render(<IframeAgent agent={makeAgent('https://third-party.example/app')} />);
+
+    const iframe = screen.getByTitle('Test Agent') as HTMLIFrameElement;
+    expect(iframe.getAttribute('sandbox')).toBe(AGENT_IFRAME_SANDBOX);
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-popups-to-escape-sandbox');
+    expect(iframe.getAttribute('allow') ?? '').not.toContain('clipboard-write');
+    expect(ConnectHostMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/config/agentOrigins.test.ts
+++ b/tests/unit/config/agentOrigins.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWalletOwnOrigin,
+  classifyAgentOrigin,
+  AGENT_IFRAME_SANDBOX,
+  AGENT_IFRAME_ALLOW,
+} from '../../../src/config/agentOrigins';
+
+describe('isWalletOwnOrigin (self-framing guard)', () => {
+  it('is true when the framed origin equals the wallet origin', () => {
+    expect(isWalletOwnOrigin('https://wallet.example', 'https://wallet.example')).toBe(true);
+  });
+
+  it('is false for a different origin', () => {
+    expect(isWalletOwnOrigin('https://dapp.example', 'https://wallet.example')).toBe(false);
+  });
+
+  it('normalizes case so a spoofed-case host still matches the wallet origin', () => {
+    expect(isWalletOwnOrigin('https://Wallet.Example', 'https://wallet.example')).toBe(true);
+  });
+
+  it('is false for an unparseable origin', () => {
+    expect(isWalletOwnOrigin('not a url', 'https://wallet.example')).toBe(false);
+  });
+});
+
+describe('classifyAgentOrigin (trust level of a framed agent origin)', () => {
+  it('classifies the wallet own origin as "self"', () => {
+    expect(
+      classifyAgentOrigin('https://wallet.example', { selfOrigin: 'https://wallet.example' }),
+    ).toBe('self');
+  });
+
+  it('classifies an allowlisted origin as "trusted"', () => {
+    expect(
+      classifyAgentOrigin('https://trusted.example', {
+        selfOrigin: 'https://wallet.example',
+        trustedOrigins: ['https://trusted.example'],
+      }),
+    ).toBe('trusted');
+  });
+
+  it('classifies any other origin as "untrusted"', () => {
+    expect(
+      classifyAgentOrigin('https://attacker.example', {
+        selfOrigin: 'https://wallet.example',
+        trustedOrigins: ['https://trusted.example'],
+      }),
+    ).toBe('untrusted');
+  });
+
+  it('self takes precedence even if the origin is also allowlisted', () => {
+    expect(
+      classifyAgentOrigin('https://wallet.example', {
+        selfOrigin: 'https://wallet.example',
+        trustedOrigins: ['https://wallet.example'],
+      }),
+    ).toBe('self');
+  });
+});
+
+describe('hardened agent-iframe sandbox/allow', () => {
+  it('does not grant clipboard-write to agent frames (address-swap vector)', () => {
+    expect(AGENT_IFRAME_ALLOW).not.toMatch(/clipboard-write/);
+  });
+
+  it('does not let popups escape the sandbox (unsandboxed phishing popups)', () => {
+    expect(AGENT_IFRAME_SANDBOX).not.toMatch(/allow-popups-to-escape-sandbox/);
+  });
+
+  it('still allows scripts and forms so normal dApps keep working', () => {
+    expect(AGENT_IFRAME_SANDBOX).toMatch(/allow-scripts/);
+    expect(AGENT_IFRAME_SANDBOX).toMatch(/allow-forms/);
+  });
+});

--- a/tests/unit/sdk/adoptOrDiscardInstance.test.ts
+++ b/tests/unit/sdk/adoptOrDiscardInstance.test.ts
@@ -1,0 +1,36 @@
+/**
+ * #453: SphereProvider.initialize() is not re-entrant. Two overlapping inits
+ * (StrictMode double-mount, an IPFS/network toggle) both build a live Sphere;
+ * the loser of the setSphere race was never destroyed and leaked as a zombie
+ * (open relay + IndexedDB connections). The guard: a superseded init must
+ * DESTROY the instance it built and never adopt it — while the latest init
+ * always adopts, so there is always exactly one live instance.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { adoptOrDiscardInstance } from '../../../src/sdk/adoptOrDiscardInstance';
+
+describe('adoptOrDiscardInstance (re-entrant init guard)', () => {
+  it('adopts the instance when the init is still the latest', async () => {
+    const destroy = vi.fn(async () => {});
+    const adopt = vi.fn();
+    const instance = { destroy };
+
+    const outcome = await adoptOrDiscardInstance(instance, () => false, adopt);
+
+    expect(outcome).toBe('adopted');
+    expect(adopt).toHaveBeenCalledWith(instance);
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  it('destroys (never adopts) a superseded instance so it cannot leak', async () => {
+    const destroy = vi.fn(async () => {});
+    const adopt = vi.fn();
+    const instance = { destroy };
+
+    const outcome = await adoptOrDiscardInstance(instance, () => true, adopt);
+
+    expect(outcome).toBe('discarded');
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(adopt).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Integration branch for the 2026-07 multi-agent security & correctness audit of Sphere (base `main` @ `b477d4d7`, sphere-sdk 0.12.0). Seven high-severity issues, each developed on its own `fix/` branch and merged here with `--no-ff`.

Running description and per-issue notes live in `docs/audit-2026-07-fixes.md`.

## What is in this PR

| # | Fix | Where |
|---|---|---|
| #451 | **Agent iframe trust boundary.** Self-origin guard so an agent URL can never frame the wallet's own origin with a live `ConnectHost` bound to it; hardened iframe `sandbox`; new `agentOrigins` trust module. | `src/config/agentOrigins.ts`, `IframeAgent.tsx` |
| #452 | **Connect approval anchored to the verified origin.** The approval modal shows the transport-verified origin instead of dApp-declared metadata, plus untrusted / host-mismatch warnings; `requestApproval` carries the pinned origin. | `ConnectionApprovalModal.tsx`, `ConnectPage.tsx` |
| #448 | **Atomic create-with-nametag.** `createWalletThenRegister`: the wallet is created without a nametag, the mnemonic is shown, and the nametag is registered as a separate retryable step — a failure can no longer wipe the only owning key and burn the nametag. | `onboarding/` |
| #450 | **Onboarding backup no longer a cleartext seed named after the user.** Generic filename, optional encryption of the backup file, honest copy. | `onboarding/`, `buildWalletBackup` |
| #453 | **`SphereProvider.initialize()` is re-entrant.** Generation counter + `adoptOrDiscardInstance` so StrictMode / IPFS toggle cannot leave two live Sphere instances (duplicate relays and IndexedDB handles). | `src/sdk/SphereProvider.tsx`, `src/sdk/adoptOrDiscardInstance.ts` |
| #454 | **Group send failure no longer discards the typed message.** `requireSent` guard — the SDK's `sendMessage` returns `null` instead of throwing, so the mutation resolved "successfully" and the input was cleared. | `chat/utils/requireSent.ts`, `useGroupChat.ts` |
| #455 | **DesktopLayout mounts once.** Shared `DesktopShell` layout route, so navigating `/home` ↔ `/agents` stops remounting the layout and reloading every open iframe app. | `desktop/DesktopShell`, `App.tsx` |

## What is deliberately NOT in this PR

- **#449 (wallet password / at-rest encryption / unlock)** — designed feature, its own PR later. It is all-or-nothing: encrypting the mnemonic at rest without a complete unlock flow risks locking existing users out of wallets they already have. Work exists on `feat/wallet-password-unlock`.
- **#447 (swap non-atomic double-pay)** — testnet-only. Swap and Top-Up are gated behind `canSelfMint(network)` by #443, so this is not a mainnet blocker; it only costs testnet2 tokens on a re-click.
- Medium/low findings from the audit (a11y dialog primitive, HTTP-service hardening, deploy-config follow-ups, money-modal flow, marketplace pagination, perf) — drafted, not filed.

## Backward compatibility

No change here touches the at-rest wallet storage format, the mnemonic, identity derivation, IndexedDB database names or a persisted-state schema. #452 only changes what the approval modal *displays* and keeps reading the existing approved-origins shape; #448 changes the ordering of the create flow only, leaving existing wallets and the restore path untouched. The one change that would have carried real wallet-loss risk (#449) is exactly the one held back.

## How to test

**Prerequisite:** `npm ci` before anything. Local `node_modules` may hold sphere-sdk 0.11.12 against the 0.12.0 lockfile pin, in which case `tsc` fails for reasons unrelated to this branch.

**Automated gate** (run per fix branch before it was merged here):

```
npm run lint                              # 0 errors
npx tsc --noEmit -p tsconfig.app.json     # clean
npm run test:run                          # green
```

**Manual — regression first (highest value):**

1. Open the app with a **wallet created before this branch**. It must load normally, show the same address, and the existing list of connected sites must still be there. Restore-from-seed must still work.

**Manual — per fix:**

2. **#455** — open an agent app in a desktop tab, put it in a state you can see (scroll position, a value typed into it), then navigate `/home` ↔ `/agents` and back. The iframe app must **not** reload or lose that state.
3. **#453** — toggle IPFS on/off a few times in quick succession, and reload with React StrictMode active. Only one Sphere instance should end up live: no duplicated relay connections, no duplicate event delivery, and the wallet still initializes for an existing wallet (the guard must never end with zero live instances).
4. **#452** — connect a dApp through the Connect popup. The approval modal must show the **real, transport-verified origin**, not the name/URL the dApp declares about itself. Point a test dApp's declared `url` at something else and confirm the mismatch warning appears. Approve, and confirm the session works and the site appears in connected sites.
5. **#451** — try to open an agent whose URL points at the wallet's own origin: it must be refused rather than framed with a live host. Confirm a normal third-party agent still loads and its Connect session still works.
6. **#448** — create a new wallet **with a nametag** while nametag registration is made to fail (offline / unreachable aggregator). Expected: the mnemonic is still shown, the wallet exists and is usable, and the nametag is a separate retryable step. The wallet must never be wiped, and the nametag must not be left burned.
7. **#450** — go through onboarding backup. The downloaded filename must not contain the handle/nametag; the option to encrypt the backup must be offered; an encrypted backup must restore with its password and an unencrypted one must still restore.
8. **#454** — open a group chat, type a message, and make the send fail (relay down / offline). The failure must surface as an error and the typed text must **stay in the input** instead of being silently cleared.

## Follow-ups already identified

- SDK companions (separate repo): `GroupChatModule.sendMessage` and the moderation methods should signal failure instead of returning `null` (root cause of #454); `registerNametag` should be atomic / extractable from `Sphere.create` (root cause of #448).
- #454's sibling silent failures: moderation actions (boolean-false), DM and mini-chat sends.
- #451 follow-up: CSP `frame-src`.
