### PR TITLE
fix(connect): say which SDK version and network the wallet requires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.13.0",
+        "@unicitylabs/sphere-sdk": "0.13.1",
         "@unicitylabs/sphere-ui": "^0.1.34",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
@@ -2907,9 +2907,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.0.tgz",
-      "integrity": "sha512-uK7/xplYUNwsQ+tKJDDVClWXYxz9x7gKP8aVoSbJAbrGshG1XsG7D260AUDfIvG+pSONRfwX42ga3lW3TT/dmw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.13.1.tgz",
+      "integrity": "sha512-i/cnbr9Puk30b7z/JANTYN8hhp5OmVCpmo/MA2dS0SwV9wtBasQYI3sLosRXaVMCEX2n269K1y3M+BccU1KBxA==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.13.0",
+    "@unicitylabs/sphere-sdk": "0.13.1",
     "@unicitylabs/sphere-ui": "^0.1.34",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",

--- a/src/components/connect/rejectionMessage.ts
+++ b/src/components/connect/rejectionMessage.ts
@@ -1,19 +1,80 @@
 /**
  * Human-readable explanation for a Sphere Connect compatibility-gate rejection,
- * derived from the SphereRpcError `data.reason` (see the SDK's `checkCompatibility`).
+ * derived from the SphereRpcError `data` (see the SDK's `checkCompatibility`).
  * Shared by the wallet's Connect surfaces (ConnectPage popup, IframeAgent) so the
  * copy stays consistent.
+ *
+ * The gate publishes the versions it compared — `requiredSdk`/`actualSdk` for the npm
+ * floor, `clientProtocol`/`requiredProtocol`/`walletProtocol` for the protocol checks,
+ * `clientNetwork`/`walletNetwork` for the network check. Quote them: this fragment plus
+ * a bare error code is the whole of what a developer sees, and "built for an older
+ * version" with no number tells them to upgrade without saying to what.
+ *
+ * Every field is read defensively. `data` arrives over postMessage from a peer that may
+ * be on an older (or newer) SDK, so a missing or malformed field degrades to the generic
+ * copy rather than printing `undefined` at the user.
  *
  * The returned phrase is a sentence fragment meant to follow the dApp name, e.g.
  * `${dapp.name} ${describeConnectRejection(data)}`.
  */
+
+/** A non-empty string field, or null for anything else (missing, null, wrong type). */
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** `testnet2 (4)` / `network 4`, or null when the peer sent no usable descriptor. */
+function describeNetwork(value: unknown): string | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const { id, name } = value as { id?: unknown; name?: unknown };
+  if (typeof id !== 'number') return null;
+  const label = text(name);
+  return label ? `${label} (${id})` : `network ${id}`;
+}
+
+const OUTDATED = 'was built for an older version of Sphere';
+const UPDATE = 'Its developer needs to update it before it can connect.';
+
+function describeProtocolRejection(data: Record<string, unknown>): string {
+  // The gate runs MAJOR → MINOR → SDK and attaches the protocol pair to all three, so an
+  // SDK-floor refusal also carries a perfectly good protocol pair. Report the floor that
+  // actually failed — quoting both would read as two separate faults.
+  const requiredSdk = text(data.requiredSdk);
+  if (requiredSdk) {
+    const actualSdk = text(data.actualSdk);
+    const clause = actualSdk
+      ? `it uses SDK ${actualSdk}, but this wallet requires ${requiredSdk} or newer`
+      : `it did not report an SDK version, and this wallet requires ${requiredSdk} or newer`;
+    return `${OUTDATED} — ${clause}. ${UPDATE}`;
+  }
+
+  const clientProtocol = text(data.clientProtocol);
+  const requiredProtocol = text(data.requiredProtocol);
+  const walletProtocol = text(data.walletProtocol);
+
+  if (clientProtocol && requiredProtocol) {
+    return `${OUTDATED} — it speaks Connect protocol ${clientProtocol}, but this wallet requires ${requiredProtocol} or newer. ${UPDATE}`;
+  }
+  if (clientProtocol && walletProtocol) {
+    // MAJOR mismatch: not a floor. A NEWER major is refused just the same, so "or newer"
+    // would be a lie — state both sides and leave it there.
+    return `${OUTDATED} — it speaks Connect protocol ${clientProtocol}, this wallet speaks ${walletProtocol}. ${UPDATE}`;
+  }
+  return `${OUTDATED}. ${UPDATE}`;
+}
+
+function describeNetworkRejection(data: Record<string, unknown>): string {
+  const client = describeNetwork(data.clientNetwork);
+  const wallet = describeNetwork(data.walletNetwork);
+  if (client && wallet) {
+    return `is built for ${client}, but your wallet is on ${wallet}, so it cannot connect here.`;
+  }
+  return 'is built for a different Unicity network than your wallet, so it cannot connect here.';
+}
+
 export function describeConnectRejection(data: Record<string, unknown> | undefined): string {
   const reason = data?.reason as string | undefined;
-  if (reason === 'protocol_incompatible') {
-    return 'was built for an older version of Sphere. Its developer needs to update it before it can connect.';
-  }
-  if (reason === 'network_incompatible') {
-    return 'is built for a different Unicity network than your wallet, so it cannot connect here.';
-  }
+  if (reason === 'protocol_incompatible') return describeProtocolRejection(data ?? {});
+  if (reason === 'network_incompatible') return describeNetworkRejection(data ?? {});
   return 'is not compatible with this wallet.';
 }

--- a/tests/unit/components/connectRejectionMessage.test.ts
+++ b/tests/unit/components/connectRejectionMessage.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { describeConnectRejection } from '../../../src/components/connect/rejectionMessage';
+
+/**
+ * The gate's refusal copy is the ONLY thing a developer sees when their app is turned
+ * away — the modal shows this fragment plus a bare error code. "Built for an older
+ * version" without a number tells them to upgrade without saying to what, so the
+ * versions the SDK already puts in `error.data` have to reach the sentence.
+ */
+describe('describeConnectRejection', () => {
+  it('names the SDK version the app has and the one the wallet wants', () => {
+    const s = describeConnectRejection({
+      reason: 'protocol_incompatible',
+      requiredSdk: '0.12.0-0',
+      actualSdk: '0.11.9',
+    });
+    expect(s).toContain('0.11.9');
+    expect(s).toContain('0.12.0-0');
+  });
+
+  it('still names the required SDK version when the app reported none', () => {
+    const s = describeConnectRejection({
+      reason: 'protocol_incompatible',
+      requiredSdk: '0.12.0-0',
+      actualSdk: null,
+    });
+    expect(s).toContain('0.12.0-0');
+    expect(s).not.toContain('null');
+  });
+
+  it('names both protocol versions on a protocol floor', () => {
+    const s = describeConnectRejection({
+      reason: 'protocol_incompatible',
+      clientProtocol: '2.0',
+      requiredProtocol: '2.1',
+      walletProtocol: '2.1',
+    });
+    expect(s).toContain('2.0');
+    expect(s).toContain('2.1');
+  });
+
+  it('names both protocol versions on a MAJOR mismatch', () => {
+    const s = describeConnectRejection({
+      reason: 'protocol_incompatible',
+      clientProtocol: '1.0',
+      walletProtocol: '2.1',
+    });
+    expect(s).toContain('1.0');
+    expect(s).toContain('2.1');
+  });
+
+  it('prefers the SDK floor over the protocol numbers when both are present', () => {
+    // The gate checks MAJOR → MINOR → SDK, so an SDK-floor refusal also carries the
+    // (perfectly fine) protocol pair. Quoting both would read as two separate faults.
+    const s = describeConnectRejection({
+      reason: 'protocol_incompatible',
+      walletProtocol: '2.1',
+      clientProtocol: '2.1',
+      requiredSdk: '0.12.0-0',
+      actualSdk: '0.11.9',
+    });
+    expect(s).toContain('0.11.9');
+    expect(s).not.toContain('Connect protocol');
+  });
+
+  it('falls back to the generic protocol copy when no versions were sent', () => {
+    const s = describeConnectRejection({ reason: 'protocol_incompatible' });
+    expect(s).toContain('older version of Sphere');
+    expect(s).toContain('developer');
+  });
+
+  it('names both networks on a network mismatch', () => {
+    const s = describeConnectRejection({
+      reason: 'network_incompatible',
+      walletNetwork: { id: 4 },
+      clientNetwork: { id: 1, name: 'mainnet' },
+    });
+    expect(s).toContain('mainnet');
+    expect(s).toContain('4');
+  });
+
+  it('falls back to the generic network copy when the app sent no network', () => {
+    const s = describeConnectRejection({
+      reason: 'network_incompatible',
+      walletNetwork: { id: 4 },
+      clientNetwork: null,
+    });
+    expect(s).toContain('different Unicity network');
+    expect(s).not.toContain('null');
+  });
+
+  it('falls back to the generic copy for an unknown reason or no data', () => {
+    expect(describeConnectRejection(undefined)).toBe('is not compatible with this wallet.');
+    expect(describeConnectRejection({ reason: 'something_new' })).toBe('is not compatible with this wallet.');
+  });
+
+  it('stays a fragment that reads after the dApp name', () => {
+    const s = describeConnectRejection({ reason: 'protocol_incompatible', requiredSdk: '0.12.0-0', actualSdk: '0.11.9' });
+    expect(s.startsWith('was ')).toBe(true);
+    expect(s.endsWith('.')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The "Unable to connect" modal (and the IframeAgent toast) said an app *"was built for an older version of Sphere"*, named no version, and showed a bare error code. The gate had already sent `requiredSdk` / `actualSdk` in `error.data` — the copy just never read it. Same for the network mismatch: *"a different Unicity network"* named neither side.

Before / after, for a dApp on 0.11.9 against a wallet whose floor is 0.12.0-0:

> ~~Sphere Token Launcher was built for an older version of Sphere. Its developer needs to update it before it can connect.~~
>
> Sphere Token Launcher was built for an older version of Sphere — **it uses SDK 0.11.9, but this wallet requires 0.12.0-0 or newer**. Its developer needs to update it before it can connect.

## Change

`describeConnectRejection` quotes whichever floor actually failed — SDK version, protocol floor, or MAJOR mismatch — and both networks on a network mismatch.

- The gate runs MAJOR → MINOR → SDK and attaches the protocol pair to all three, so an SDK-floor refusal also carries a perfectly good protocol pair. Only the floor that failed is reported; quoting both would read as two separate faults.
- A MAJOR mismatch says *"it speaks 1.0, this wallet speaks 2.1"* rather than *"or newer"* — a newer MAJOR is refused just the same, so "or newer" would be a lie.
- Every field is read defensively and degrades to the previous generic copy. `data` crosses postMessage from a peer whose SDK version the wallet does not control.

## No SDK release needed

`requiredSdk` / `actualSdk` already ship in the pinned 0.13.0, so this lands the fix on its own. The matching SDK PR improves `error.message` for every *other* UI.

## Tests

First tests for this module — 10 cases. Full unit suite 592/592, `tsc --noEmit` clean, lint 0 errors.

## Related

- unicity-sphere/sphere-sdk#705 — the gate's own message
