### PR TITLE
chore: stop loading Google Analytics on the wallet origin

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,14 +10,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Geist:wght@400;500&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J2S6VSBDSH"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-J2S6VSBDSH');
-    </script>
     <script>
       // GitHub Pages SPA path restore. The root 404.html redirects deep links
       // from /base/{route}?qs to /base/?p=/{route}&qs; rewrite back before

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -74,16 +74,15 @@ if (SENTRY_DSN) {
       // (SPHERE-M/1G) — until then these are unactionable lifecycle noise.
       'The database connection is closing',
     ],
-    // Errors thrown by injected extension scripts (other wallets) and the GA
-    // tag are not ours. blob: is safe to deny wholesale — first-party code
-    // never executes from blob: URLs (createObjectURL is only used for backup
-    // file downloads); extensions injecting code via blob: do (SPHERE-1F).
+    // Errors thrown by injected extension scripts (other wallets) are not ours.
+    // blob: is safe to deny wholesale — first-party code never executes from
+    // blob: URLs (createObjectURL is only used for backup file downloads);
+    // extensions injecting code via blob: do (SPHERE-1F).
     denyUrls: [
       /^chrome-extension:\/\//,
       /^moz-extension:\/\//,
       /^safari-(?:web-)?extension:\/\//,
       /^blob:/,
-      /googletagmanager\.com/,
     ],
   });
 }

--- a/tests/unit/config/indexHtmlScripts.test.ts
+++ b/tests/unit/config/indexHtmlScripts.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The wallet origin holds the mnemonic seed, the private keys and the wallet state in
+ * localStorage/IndexedDB. Any script served from a third party runs there with full DOM
+ * and storage access, and its contents can change without a deploy or a review on our
+ * side — a bundled npm dependency is pinned by the lockfile, a CDN <script src> is not.
+ *
+ * The Google tag also could not be pinned even in principle: gtag.js has no stable
+ * content, so Subresource Integrity does not apply to it.
+ *
+ * The load-bearing assertion here is the same-origin one. It is not about Google — it
+ * fails for ANY future CDN script added to this document, which is the regression this
+ * file exists to prevent.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const html = readFileSync(resolve(__dirname, '../../../src/index.html'), 'utf8');
+
+/** `src="…"` of every <script> in the document, in order. */
+function scriptSources(): string[] {
+  return [...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+/** `href="…"` of every <link> in the document. */
+function linkHrefs(): string[] {
+  return [...html.matchAll(/<link\b[^>]*\bhref=["']([^"']+)["']/g)].map((m) => m[1]);
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null; // relative — same-origin by construction
+  }
+}
+
+describe('index.html script origins', () => {
+  it('executes no script from a third-party origin', () => {
+    const external = scriptSources().filter((s) => hostOf(s) !== null);
+    // Vite rewrites relative sources at build time; anything absolute here ships as-is.
+    expect(external).toEqual([]);
+  });
+
+  it('loads nothing from googletagmanager.com', () => {
+    // Note for future greps: "googletagmanager" does NOT contain the substring "gtag"
+    // (…le-tag-man…), so searching only for `gtag` misses it.
+    expect(html).not.toMatch(/googletagmanager\.com/);
+  });
+
+  it('declares no gtag/dataLayer globals', () => {
+    expect(html).not.toMatch(/\bdataLayer\b/);
+    expect(html).not.toMatch(/\bgtag\s*\(/);
+  });
+
+  it('still loads the runtime config before the module bundle', () => {
+    // Deleting the analytics block must not disturb script ORDER: runtime-config.js is a
+    // classic script that has to execute before the module bundle reads its values.
+    const sources = scriptSources();
+    const runtime = sources.findIndex((s) => s.includes('runtime-config.js'));
+    const bundle = sources.findIndex((s) => s.includes('main.tsx'));
+    expect(runtime).toBeGreaterThanOrEqual(0);
+    expect(bundle).toBeGreaterThan(runtime);
+  });
+
+  it('has exactly the Google Fonts pair as its only cross-origin links', () => {
+    // A tripwire, not a pin: self-hosting the fonts is a separate change, and when it
+    // lands this expectation becomes an empty array.
+    const hosts = [...new Set(linkHrefs().map(hostOf).filter((h): h is string => h !== null))];
+    expect(hosts.sort()).toEqual(['fonts.googleapis.com', 'fonts.gstatic.com']);
+  });
+});


### PR DESCRIPTION
## Why

`gtag.js` was served from Google's CDN **into the origin that holds the mnemonic seed, the private keys and the wallet state**. A remote script there has full DOM, `localStorage` and IndexedDB access, and its contents can change at any moment with no deploy and no review on our side.

This is a different class of risk from Sentry, which ships as the npm package `@sentry/react`, is pinned by the lockfile and is served from our own origin. And gtag.js cannot be pinned even in principle — it has no stable content, so Subresource Integrity does not apply to it.

## It was also leaking, and one leg is unconditional

The router is `BrowserRouter`, so the wallet's query strings are **real query strings**, and a bare `gtag('config')` sends `page_location` as the full href. Verified reaching Google today:

| Param | Condition | Why |
|---|---|---|
| `?origin=<dApp origin>` | **unconditional** | The Connect popup opens `/connect?origin=…` in a **new window** (`sphere-sdk` `autoConnect.ts:209`). That is an initial document load, so the single automatic `page_view` already carries it. No GA console setting suppresses this one. |
| `?url=<third-party app URL>` | GA history toggle | `AgentPage.tsx:13` reads it but **never strips it**, so it stays in the address bar for the whole session and rides along on every later page_view. |
| `?nametag=<contact handle>` | GA history toggle | Stripped on mount by `DMChatSection`, but the strip is itself a second history event — the first already carried it. |

So Google has been learning **which dApps each user connects to**, on every connect, regardless of settings.

`src/utils/sentryScrub.ts:60-74` `redactUrl()` already redacts every query *and fragment* value before anything reaches Sentry, and its comment names `?nametag=`, `?join=`, `?url=`, `?origin=` explicitly. The wallet was scrubbing these for one third party and handing them to another in the clear.

*(An earlier draft of this claim also listed `?join=` group invite codes. **Withdrawn** — `GroupItem.tsx:136` puts the code in a `#` fragment, which `BrowserRouter` never parses. That turns out to be a separate live bug: the app-generated invite link does not work. Filed separately.)*

## What changed

- `src/index.html` — the tag block, 8 lines.
- `src/instrument.ts` — the now-dead `googletagmanager` entry in Sentry's `denyUrls`. Removing a `denyUrls` entry can only *admit* events, never lose them, and no other source of those frames remains (cross-origin iframe errors do not reach the parent's `onerror`).

Nothing else in the app reads `window.gtag` or `window.dataLayer` — verified across `src/`, `tests/`, `public/`, `deploy/`, `.github/` and git history. No GTM container exists anywhere, so nothing is hidden in a GTM UI.

> Grep trap worth knowing: `googletagmanager` does **not** contain the substring `gtag` (`…le-tag-man…`). Searching only for `gtag` misses `instrument.ts`.

## Test

`tests/unit/config/indexHtmlScripts.test.ts`. The load-bearing assertion is **not** about Google — it is that **no `<script src>` in the document points at a third-party origin**, so it fails for any future CDN script, which is the actual regression worth preventing. It also pins that `runtime-config.js` still executes before the module bundle, since deleting a block from `<head>` must not disturb script order.

Three of the five cases fail with the tag restored (verified by stashing the change and re-running).

## What this costs

**GA stops receiving data.** Nothing in the app ever called `gtag()` or read `dataLayer`, so there is no instrumentation to port — the whole surface was the automatic `page_view`. Any linked GA4 audience or Google Ads remarketing list stops filling.

A server-side relay through `sphere-api` is planned (`docs/superpowers/plans/2026-07-28-analytics-off-wallet-origin.md`) and will restore page views with a payload that carries a route *pattern* instead of a URL — so the leak becomes structurally impossible rather than filtered. Until it ships there are no wallet analytics.

Note for whoever reviews the GA property: the event set today is whatever **Enhanced Measurement** is configured to, which is a console setting invisible to this repo. Worth a screenshot of Admin → Data Streams before this merges, purely as a record.

## Verification

`vite build` clean · **597** tests (85 files) · eslint 0 errors.

Rollback is a `git revert` of nine lines across two files. Zero runtime behaviour change — the app never read the globals.