### PR TITLE
feat(telemetry): send page views to our own backend instead of a Google tag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { lazy, Suspense, useEffect } from 'react';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import { DashboardLayout } from './components/layout/DashboardLayout';
 import { IntroPage } from './pages/IntroPage';
 import { HomePage } from './pages/HomePage';
@@ -7,6 +7,7 @@ import { AgentPage } from './pages/AgentPage';
 import { ConnectPage } from './pages/ConnectPage';
 import { DesktopShell } from './components/desktop/DesktopShell';
 import { useSphereEvents } from './sdk';
+import { trackPageView } from './services/telemetry';
 
 // Retry wrapper: auto-reload page once on chunk load failure (stale deployment)
 function lazyWithRetry(importFn: () => Promise<{ default: React.ComponentType }>) {
@@ -65,7 +66,18 @@ export function AppRoutes() {
   );
 }
 
+/**
+ * Page views, sent to our own backend rather than to a third-party tag on this origin.
+ * Keyed on pathname only: the search string is deliberately not a dependency, because
+ * it must never travel and re-firing on a param change would send nothing new anyway.
+ */
+function usePageViewTelemetry(): void {
+  const { pathname } = useLocation();
+  useEffect(() => { trackPageView(pathname); }, [pathname]);
+}
+
 export default function App() {
   useSphereEvents();
+  usePageViewTelemetry();
   return <AppRoutes />;
 }

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -50,6 +50,13 @@ export const STORAGE_KEYS = {
   // secure default (DEFAULT_AUTO_LOCK_MINUTES).
   AUTO_LOCK_TIMEOUT: 'sphere_auto_lock_timeout',
 
+  // Opaque per-browser id for page-view telemetry (services/telemetry.ts).
+  // Random, or adopted from the `_ga` cookie the removed Google tag left behind —
+  // never derived from the wallet identity, which is non-resettable and
+  // deanonymising against a public ledger. Carries the `sphere_` prefix so wallet
+  // deletion resets the analytics identity too.
+  TELEMETRY_CLIENT_ID: 'sphere_telemetry_client_id',
+
   // Timestamp of the most recent wallet lock, in any tab. Read on mount /
   // pageshow / visibilitychange so a tab that never re-runs initialize() — a
   // bfcache restore, or a hidden tab that missed the lock BroadcastChannel

--- a/src/services/telemetry.ts
+++ b/src/services/telemetry.ts
@@ -1,0 +1,173 @@
+/**
+ * First-party page-view telemetry.
+ *
+ * Replaces the Google tag that used to run on this origin (removed in #461). A remote
+ * script on the origin that holds the mnemonic seed and the private keys has full DOM
+ * and storage access and can change without a deploy — and gtag sent `page_location`
+ * as the full href, so Google received the Connect popup's `?origin=<dApp>` on every
+ * connect, plus `?url=` and `?nametag=`.
+ *
+ * The rule that makes this safe is one line long: **this module never sends a URL.**
+ * It sends the matched route PATTERN and nothing else; sphere-api builds page_location
+ * from the pattern plus a trusted origin. So there is no query string to strip and no
+ * denylist to keep current — which matters, because external agents deep-link into the
+ * wallet with parameters no first-party code produces (see the defensive strips in
+ * DMChatSection).
+ *
+ * Never send: the query string or fragment, a `:param` VALUE, an address, a pubkey, a
+ * nametag, a token id, an amount, a tx hash, the JWT, or the subscription key.
+ */
+import { matchPath } from 'react-router-dom';
+import { STORAGE_KEYS } from '../config/storageKeys';
+import { detectEnvironment } from '../config/sentry';
+
+/**
+ * Route patterns this module may report, mirroring the `path=` props in App.tsx and the
+ * allow-list in sphere-api. A path that matches none of these is not sent at all —
+ * failing closed, because the alternative is guessing whether an unknown segment is a
+ * page name or somebody's nametag.
+ */
+const ROUTE_PATTERNS: readonly string[] = [
+  '/',
+  '/about',
+  '/agents/:agentId',
+  '/apps/:slug',
+  '/connect',
+  '/developers',
+  '/developers/docs',
+  '/explore',
+  '/explore-agents',
+  '/home',
+  '/markets',
+];
+
+/** GA rolls a session after 30 minutes of inactivity; match it or the numbers disagree. */
+const SESSION_IDLE_MS = 30 * 60 * 1000;
+
+const SESSION_ID_KEY   = 'sphere_telemetry_session_id';
+const SESSION_SEEN_KEY = 'sphere_telemetry_session_seen';
+
+/**
+ * `VITE_SPHERE_API_URL` sed-substitutes to an EMPTY STRING in the Docker image when
+ * SPHERE_API_URL is unset, and `??` does not catch `''` — the other consumers fall back
+ * to the wallet's own origin and post into the void. Telemetry treats that as "disabled"
+ * instead: it is better to lose page views than to POST them at ourselves.
+ */
+function apiBase(): string | null {
+  const raw = import.meta.env.VITE_SPHERE_API_URL as string | undefined;
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  return trimmed ? trimmed.replace(/\/+$/, '') : null;
+}
+
+/** GA's client-id shape: `<int>.<int>`. */
+function mintClientId(): string {
+  const rand = Math.floor(Math.random() * 2 ** 31);
+  return `${rand}.${Math.floor(Date.now() / 1000)}`;
+}
+
+/**
+ * The `_ga` cookie is FIRST-PARTY — gtag.js wrote it on our own domain — so it survives
+ * the tag's removal and keeps its two-year expiry; it simply stops being refreshed.
+ * Adopting it means returning users are not all re-registered as new at the cutover.
+ *
+ * This is not the rejected "keep gtag running during a migration" idea: no third-party
+ * script executes, we only read a value it already left behind. The window is finite —
+ * the longer this ships after #461, the fewer users are carried over.
+ *
+ * Format: `_ga=GA1.1.<random>.<timestamp>`; the client id is the last two parts.
+ */
+function adoptGaCookie(): string | null {
+  const match = /(?:^|;\s*)_ga=([^;]+)/.exec(document.cookie);
+  if (!match) return null;
+  const parts = match[1].split('.');
+  if (parts.length < 4) return null;
+  const candidate = `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+  return /^\d{1,20}\.\d{1,20}$/.test(candidate) ? candidate : null;
+}
+
+/**
+ * Stable per-browser id. Deliberately random and never derived from the wallet identity:
+ * `directAddress` and `chainPubkey` are non-resettable and, against a public ledger,
+ * deanonymising. Stored under the `sphere_` prefix so wallet deletion
+ * (clearAllSphereData) resets it along with everything else.
+ */
+export function getOrCreateClientId(): string {
+  const existing = localStorage.getItem(STORAGE_KEYS.TELEMETRY_CLIENT_ID);
+  if (existing) return existing;
+
+  const id = adoptGaCookie() ?? mintClientId();
+  localStorage.setItem(STORAGE_KEYS.TELEMETRY_CLIENT_ID, id);
+  return id;
+}
+
+function getSessionId(now: number): string {
+  const seen = Number(sessionStorage.getItem(SESSION_SEEN_KEY) ?? 0);
+  const current = sessionStorage.getItem(SESSION_ID_KEY);
+
+  if (!current || !Number.isFinite(seen) || now - seen > SESSION_IDLE_MS) {
+    const fresh = String(Math.floor(now / 1000));
+    sessionStorage.setItem(SESSION_ID_KEY, fresh);
+    sessionStorage.setItem(SESSION_SEEN_KEY, String(now));
+    return fresh;
+  }
+  sessionStorage.setItem(SESSION_SEEN_KEY, String(now));
+  return current;
+}
+
+/**
+ * Matched pattern for a pathname, or null when nothing matches.
+ *
+ * Refuses anything carrying a query or fragment. Only the pattern is ever sent, so such
+ * an input could not leak on its own — but `matchPath` would happily let `:agentId`
+ * swallow `dm?nametag=alice`, and an invariant that depends on a caller's discipline
+ * two files away is not one worth relying on.
+ */
+export function routePatternFor(pathname: string): string | null {
+  if (pathname.includes('?') || pathname.includes('#')) return null;
+  for (const pattern of ROUTE_PATTERNS) {
+    if (matchPath({ path: pattern, end: true }, pathname)) return pattern;
+  }
+  return null;
+}
+
+let lastSentAt = 0;
+
+/**
+ * Best-effort, like the existing pingOpenApp: failures are swallowed, because a page
+ * view is never worth an error a user can see.
+ *
+ * `fetch(..., { keepalive: true })` rather than sendBeacon: sphere-api parses
+ * application/json only, so a default Blob beacon 415s, and a JSON Blob triggers a
+ * preflight whose failure the page cannot observe.
+ */
+export function trackPageView(pathname: string): void {
+  // Production only. The GA property has been mixing localhost, Pages previews and
+  // staging with no environment dimension; this is where that stops.
+  if (detectEnvironment() !== 'production') return;
+
+  const base = apiBase();
+  if (!base) return;
+
+  const route = routePatternFor(pathname);
+  if (!route) return;
+
+  const now = Date.now();
+  const engagement = lastSentAt ? Math.min(now - lastSentAt, 3_600_000) : 0;
+  lastSentAt = now;
+
+  try {
+    void fetch(`${base}/api/analytics/collect`, {
+      method:    'POST',
+      keepalive: true,
+      headers:   { 'Content-Type': 'application/json', 'X-Client': 'sphere' },
+      body: JSON.stringify({
+        client_id:            getOrCreateClientId(),
+        session_id:           getSessionId(now),
+        route,
+        engagement_time_msec: engagement,
+      }),
+    }).catch(() => {});
+  } catch {
+    // Storage disabled, quota exhausted, or fetch unavailable — never surface.
+  }
+}

--- a/tests/unit/services/telemetry.test.ts
+++ b/tests/unit/services/telemetry.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The one rule this module has to keep: it never sends a URL.
+ *
+ * The Google tag it replaces sent `page_location` as the full href, so the Connect
+ * popup's `?origin=<dApp>` reached Google on every connect, along with `?url=` and
+ * `?nametag=`. Sending a route PATTERN instead makes that structurally impossible
+ * rather than filtered — which matters, because external agents deep-link into the
+ * wallet with parameters no first-party code produces, so a denylist could never be
+ * complete.
+ *
+ * Most of these therefore assert on what is ABSENT from the request body.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../src/config/sentry', () => ({
+  detectEnvironment: () => 'production',
+  SENTRY_DSN: '',
+}));
+
+import { getOrCreateClientId, routePatternFor, trackPageView } from '../../../src/services/telemetry';
+import { STORAGE_KEYS } from '../../../src/config/storageKeys';
+
+const fetchMock = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
+
+function bodyOf(call: number): Record<string, unknown> {
+  const init = fetchMock.mock.calls[call]![1] as RequestInit;
+  return JSON.parse(init.body as string);
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubEnv('VITE_SPHERE_API_URL', 'https://api.example');
+  localStorage.clear();
+  sessionStorage.clear();
+  document.cookie = '_ga=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  fetchMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('routePatternFor', () => {
+  it('returns the pattern, never the path, for a parameterised route', () => {
+    // `custom` is exactly the value that pairs with a ?url= naming a third-party app.
+    expect(routePatternFor('/agents/custom')).toBe('/agents/:agentId');
+    expect(routePatternFor('/agents/dm')).toBe('/agents/:agentId');
+    expect(routePatternFor('/apps/some-slug')).toBe('/apps/:slug');
+  });
+
+  it('matches static routes exactly', () => {
+    expect(routePatternFor('/')).toBe('/');
+    expect(routePatternFor('/connect')).toBe('/connect');
+    expect(routePatternFor('/developers/docs')).toBe('/developers/docs');
+  });
+
+  it('fails closed on anything it does not recognise', () => {
+    // Guessing whether an unknown segment is a page name or somebody's nametag is
+    // exactly the judgement this must not make.
+    expect(routePatternFor('/agents/dm/extra')).toBeNull();
+    expect(routePatternFor('/totally/new/page')).toBeNull();
+  });
+});
+
+describe('trackPageView', () => {
+  it('sends the pattern and no URL', () => {
+    trackPageView('/agents/custom');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = bodyOf(0);
+    expect(body.route).toBe('/agents/:agentId');
+    expect(JSON.stringify(body)).not.toContain('custom');
+  });
+
+  it('cannot leak a query string or fragment, because it is never given one', () => {
+    // The caller passes a pathname; even if it did not, matching would reject it.
+    trackPageView('/agents/dm?nametag=alice');
+    trackPageView('/connect?origin=https://dapp.example');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('identifies the client so the server can pick the right property', () => {
+    trackPageView('/home');
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>)['X-Client']).toBe('sphere');
+    expect(init.keepalive).toBe(true);
+  });
+
+  it('stays silent for a route it does not know', () => {
+    trackPageView('/totally/new/page');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the API base is empty, instead of posting at our own origin', () => {
+    // The Docker image sed-substitutes an unset SPHERE_API_URL to '', and `??` does not
+    // catch ''. Other consumers fall back to the wallet origin; telemetry must not.
+    vi.stubEnv('VITE_SPHERE_API_URL', '');
+    trackPageView('/home');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws, whatever the network does', () => {
+    fetchMock.mockImplementationOnce(() => { throw new Error('offline'); });
+    expect(() => trackPageView('/home')).not.toThrow();
+  });
+});
+
+describe('client id', () => {
+  it('is stable across calls and persisted under the sphere_ prefix', () => {
+    const first = getOrCreateClientId();
+    expect(getOrCreateClientId()).toBe(first);
+    // The prefix is what makes clearAllSphereData() reset the analytics identity too.
+    expect(localStorage.getItem(STORAGE_KEYS.TELEMETRY_CLIENT_ID)).toBe(first);
+    expect(STORAGE_KEYS.TELEMETRY_CLIENT_ID.startsWith('sphere_')).toBe(true);
+  });
+
+  it('has the opaque GA shape and carries nothing about the wallet', () => {
+    expect(getOrCreateClientId()).toMatch(/^\d+\.\d+$/);
+  });
+
+  it('adopts the id left behind in the _ga cookie, so returning users survive the cutover', () => {
+    // _ga is first-party: the removed tag wrote it on our own domain, and it keeps its
+    // two-year expiry. Reading it is not "keeping gtag around" — no script runs.
+    document.cookie = '_ga=GA1.1.1837465102.1753660800';
+    expect(getOrCreateClientId()).toBe('1837465102.1753660800');
+  });
+
+  it('mints a fresh id when the cookie is absent or malformed', () => {
+    document.cookie = '_ga=nonsense';
+    const id = getOrCreateClientId();
+    expect(id).toMatch(/^\d+\.\d+$/);
+    expect(id).not.toBe('nonsense');
+  });
+
+  it('prefers the value already stored over the cookie', () => {
+    localStorage.setItem(STORAGE_KEYS.TELEMETRY_CLIENT_ID, '111.222');
+    document.cookie = '_ga=GA1.1.1837465102.1753660800';
+    expect(getOrCreateClientId()).toBe('111.222');
+  });
+});


### PR DESCRIPTION
Restores the page views lost with the tag in #461, through the relay in `sphere-api#58`.

**Merge order:** #461 first, then `sphere-api#58` **deployed**, then this. Until the relay is live and configured, this posts to an endpoint that answers 204 and drops — harmless, but pointless.

## The rule

**This module never sends a URL.** It sends the matched route *pattern* — `/agents/:agentId`, not `/agents/custom?url=https://…` — and the server builds `page_location` from that pattern plus an origin it already trusts.

That makes the leak **structurally impossible rather than filtered**, which is the whole point: `DMChatSection` defensively strips `?product=`, `?image=`, `?price=`, `?purchased=` — parameters no first-party code produces. External agents deep-link in with arbitrary query strings, so a denylist could never be complete. There is no denylist here.

`routePatternFor()` additionally refuses any input carrying a `?` or `#`. Strictly speaking it could not leak anyway, since only the pattern is sent — but `matchPath` would happily let `:agentId` swallow `dm?nametag=alice`, and an invariant that depends on a caller's discipline two files away is not one worth relying on. *(My own test caught this: it asserted no request for a query-bearing path, and the code sent one. Fixed in the code rather than the test.)*

Unrecognised paths **fail closed**. Guessing whether an unknown segment is a page name or somebody's nametag is exactly the judgement this must not make.

## client_id, and not losing every returning user

Opaque and random, **never derived from `directAddress` or `chainPubkey`** — those are non-resettable and, against a public ledger, deanonymising. Stored under the `sphere_` prefix, so `clearAllSphereData()` resets the analytics identity along with the wallet.

**On first run it adopts the id from the `_ga` cookie if one is still there.** That cookie is *first-party* — the removed tag wrote it on our own domain and it keeps its two-year expiry — so returning users are not all re-registered as new at the cutover.

This is **not** the "keep gtag running during the migration" idea that was rejected: no third-party script executes, we only read a value it already left behind. The window is finite, though — the longer this lags #461, the fewer users carry over.

## Two things that will look like regressions and are not

**Traffic will drop.** This is gated on `detectEnvironment() === 'production'`. The GA property has been mixing localhost, GitHub Pages previews and staging with no environment dimension, so some of the old numbers were never real.

**An empty `VITE_SPHERE_API_URL` disables telemetry** rather than falling back to the wallet's own origin. The Docker image sed-substitutes an unset `SPHERE_API_URL` to `''`, and `??` does not catch `''` — the other three consumers (`marketplaceApi`, `userApi`, `useMaintenanceStatus`) inherit that and quietly post at themselves. Losing page views beats that. Worth fixing in those three separately.

## Transport

`fetch(..., { keepalive: true })`, **not `sendBeacon`**: sphere-api parses `application/json` only, so a default Blob beacon 415s, and a JSON Blob triggers a preflight whose failure the page cannot observe. Failures are swallowed, like the existing best-effort `pingOpenApp`.

`session_id` rolls over after 30 minutes of inactivity, matching GA's own rule, and `engagement_time_msec` is sent — without both, GA counts no session and Realtime stays empty.

## Tests

14 cases in `tests/unit/services/telemetry.test.ts`, weighted toward what must be **absent** from the payload:

- the pattern is sent and the value (`custom`) appears nowhere in the body
- a path carrying `?nametag=` or `?origin=` produces no request at all
- unknown paths are silent
- an empty API base sends nothing
- `client_id` is stable, prefixed, and has the opaque shape
- the `_ga` cookie is adopted; a malformed one is ignored; a stored id wins over the cookie
- nothing throws when the network does

## Verification

`vite build` clean · **606** tests (85 files, 14 new) · eslint 0 errors.