### PR TITLE
feat(security): add a Content-Security-Policy and the headers to carry it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,7 @@
 # Entrypoint for ssl-manager stage + runtime config substitution (both images)
 !deploy/entrypoint.sh
 !deploy/runtime-config.sh
+# nginx server config + security headers (COPYed in the runtime stage). The
+# whitelist above starts with `*`, so without these the COPY fails outright.
+!deploy/nginx.conf
+!deploy/security-headers.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,26 +47,13 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # fail-closed check in this script keeps a misconfigured task def from serving.
 COPY deploy/runtime-config.sh /docker-entrypoint.d/40-sphere-runtime-config.sh
 RUN chmod +x /docker-entrypoint.d/40-sphere-runtime-config.sh
-# NOTE: this echo collapses to a SINGLE line of nginx config (Dockerfile line
-# continuations), so never put an nginx `#` comment inside it — it would
-# comment out the rest of the config.
-RUN echo 'server { \
-    listen 80; \
-    server_name _; \
-    root /usr/share/nginx/html; \
-    index index.html; \
-    gzip on; \
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript; \
-    location = /index.html { \
-        add_header Cache-Control "no-cache, no-store, must-revalidate"; \
-    } \
-    location /assets/ { \
-        expires 1y; \
-        add_header Cache-Control "public, immutable"; \
-    } \
-    location / { \
-        try_files $uri $uri/ /index.html; \
-        add_header Cache-Control "no-cache, no-store, must-revalidate"; \
-    } \
-}' > /etc/nginx/conf.d/default.conf
+# Real files rather than a `RUN echo '…'`. The old form wrapped the config in a
+# single-quoted shell string, and every CSP keyword source ('self', 'none') uses that
+# same delimiter — the shell would strip the quotes and ship `script-src self`, a
+# valid-but-matches-nothing policy that passes `nginx -t` and blanks the page.
+COPY deploy/nginx.conf /etc/nginx/conf.d/default.conf
+# Baked default; runtime-config.sh rewrites it from the container env before nginx
+# starts. Must NOT live under conf.d/ — stock nginx.conf includes conf.d/*.conf at
+# http level, where these add_header directives would sit at the wrong level.
+COPY deploy/security-headers.conf /etc/nginx/sphere-security-headers.conf
 EXPOSE 80

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -121,30 +121,26 @@ server {
     ssl_stapling_verify on;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    include /etc/nginx/sphere-security-headers.conf;
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
     location = /index.html {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
+        include /etc/nginx/sphere-security-headers.conf;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
     location /assets/ {
         expires 1y;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
+        include /etc/nginx/sphere-security-headers.conf;
         add_header Cache-Control "public, immutable";
     }
     location / {
         try_files \$uri \$uri/ /index.html;
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
+        include /etc/nginx/sphere-security-headers.conf;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 }
@@ -161,14 +157,21 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
+    # This branch shipped NO security headers at all, so a failed certificate
+    # acquisition silently dropped every one of them. Repeated per location because
+    # nginx discards inherited add_header from any level that declares its own.
+    include /etc/nginx/sphere-security-headers.conf;
+
     # runtime-config.js carries per-environment flags rewritten at container
     # start; heuristic caching would pin stale flag values across env flips
     # (the other server blocks get this via their no-cache location /).
     location = /runtime-config.js {
+        include /etc/nginx/sphere-security-headers.conf;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
     location / {
         try_files \$uri \$uri/ /index.html;
+        include /etc/nginx/sphere-security-headers.conf;
     }
 }
 NGINX

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,45 @@
+# Server config for the wallet image.
+#
+# Was a `RUN echo '…' > default.conf` in the Dockerfile. It had to move to a real
+# file before a CSP could be added: that echo wraps the whole config in a SINGLE-QUOTED
+# shell string, and every CSP keyword source — 'self', 'none' — uses the same
+# delimiter. The shell strips the quotes, leaving `script-src self`, which is a
+# syntactically VALID policy (bare `self` parses as a hostname) that matches nothing.
+# `nginx -t` passes, CI goes green, and the browser blocks every script on the page.
+
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # nginx does NOT merge add_header across levels: a location declaring ANY
+    # add_header of its own discards every inherited one. All three locations below
+    # set Cache-Control, so a server-level-only policy would reach ZERO documents —
+    # while still passing a "did we add the header?" review. Hence the repeated
+    # include. Do not DRY this away.
+    #
+    # The file is regenerated from the container env at start by
+    # deploy/runtime-config.sh, because connect-src carries per-environment backend
+    # origins and this image is built once and promoted.
+    include /etc/nginx/sphere-security-headers.conf;
+
+    location = /index.html {
+        include /etc/nginx/sphere-security-headers.conf;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    location /assets/ {
+        expires 1y;
+        include /etc/nginx/sphere-security-headers.conf;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+        include /etc/nginx/sphere-security-headers.conf;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}

--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -203,7 +203,7 @@ if [ -w "$(dirname "$HEADERS_CONF")" ]; then
 
   cat > "$HEADERS_CONF" <<EOF
 # Generated at container start by sphere-runtime-config — do not edit.
-add_header $CSP_HEADER "default-src 'self'; base-uri 'self'; object-src 'none'; worker-src 'none'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-src https: http://localhost:* http://127.0.0.1:*; connect-src $CONNECT; upgrade-insecure-requests" always;
+add_header $CSP_HEADER "default-src 'self'; base-uri 'self'; object-src 'none'; worker-src 'none'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-src https: http://localhost:* http://127.0.0.1:*; connect-src $CONNECT; upgrade-insecure-requests" always;
 add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -161,3 +161,54 @@ done
 find "$WEBROOT" -type f -name '*.js' -exec sed -i -f "$SED_SCRIPT" {} \;
 
 log "applied runtime config to JS assets in $WEBROOT"
+
+# ── Content-Security-Policy ──────────────────────────────────────────────────
+# Regenerated here rather than baked, because connect-src carries per-environment
+# backend origins and this image is built once and promoted unchanged.
+#
+# The file COPYed at build time holds `.invalid` placeholders (RFC 2606, can never
+# resolve), so if this block does not run the failure mode is a blocked-and-reported
+# request rather than a silent bypass.
+#
+# nginx has not started yet — the stock entrypoint runs /docker-entrypoint.d hooks
+# first — so rewriting an included conf file here is safe and needs no reload.
+HEADERS_CONF="${SPHERE_HEADERS_CONF:-/etc/nginx/sphere-security-headers.conf}"
+
+if [ -w "$(dirname "$HEADERS_CONF")" ]; then
+  # Origin (scheme://host[:port]) of a URL — CSP matches origins, not paths, and a
+  # trailing path in a source expression silently narrows the match.
+  origin_of() {
+    printf '%s' "$1" | sed -n 's|^\(https\{0,1\}://[^/]*\).*|\1|p'
+  }
+
+  CONNECT="'self'"
+  for u in "${SPHERE_API_URL-}" "${WALLET_API_URL-}" "${AGGREGATOR_URL-}" \
+           "${SUBSCRIPTION_API_URL-}" "${TRUSTBASE_URL-}"; do
+    o=$(origin_of "$u")
+    [ -n "$o" ] && CONNECT="$CONNECT $o"
+  done
+
+  # Fixed destinations the SDK reaches regardless of environment: Nostr relays over
+  # websocket, the price feed, IPFS, the market API, and Sentry's ingest host.
+  CONNECT="$CONNECT wss://relay.unicity.network wss://sphere-relay.unicity.network"
+  CONNECT="$CONNECT wss://nostr-relay.testnet.unicity.network"
+  CONNECT="$CONNECT wss://relay.damus.io wss://relay.nostr.band wss://nos.lol"
+  CONNECT="$CONNECT https://api.coingecko.com https://market-api.unicity.network"
+  CONNECT="$CONNECT https://unicity-ipfs1.dyndns.org"
+  CONNECT="$CONNECT https://o4511695062237184.ingest.de.sentry.io"
+
+  # Report-Only until staging reports are clean. Flip the header NAME to enforce —
+  # nothing else about the policy changes.
+  CSP_HEADER="${SPHERE_CSP_HEADER_NAME:-Content-Security-Policy-Report-Only}"
+
+  cat > "$HEADERS_CONF" <<EOF
+# Generated at container start by sphere-runtime-config — do not edit.
+add_header $CSP_HEADER "default-src 'self'; base-uri 'self'; object-src 'none'; worker-src 'none'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-src https: http://localhost:* http://127.0.0.1:*; connect-src $CONNECT; upgrade-insecure-requests" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+EOF
+  log "wrote $HEADERS_CONF ($CSP_HEADER)"
+else
+  log "WARNING: $(dirname "$HEADERS_CONF") not writable — keeping the baked policy with .invalid placeholders"
+fi

--- a/deploy/security-headers.conf
+++ b/deploy/security-headers.conf
@@ -1,0 +1,26 @@
+# Security headers for the wallet origin.
+#
+# BAKED DEFAULT ONLY. deploy/runtime-config.sh regenerates this file at container
+# start, because connect-src carries per-environment backend origins and this image is
+# built once and promoted. The `.invalid` placeholders below are RFC 2606 reserved and
+# can never resolve, so if the entrypoint hook did not run the failure mode is a
+# BLOCKED and reported request — never a silent bypass.
+#
+# Included once per location as well as at server level: nginx drops inherited
+# add_header directives from any level that declares its own. See deploy/nginx.conf.
+#
+# Report-Only for now. Enforcement is a follow-up once staging reports are clean —
+# a wrong connect-src does not degrade, it stops sends and balance loading.
+
+add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; worker-src 'none'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-src https: http://localhost:* http://127.0.0.1:*; connect-src 'self' https://sphere-api.invalid https://wallet-api.invalid; upgrade-insecure-requests" always;
+
+# Not a CSP directive and not superseded by frame-ancestors: still honoured by older
+# browsers, and DENY rather than SAMEORIGIN because the agent iframe runs with
+# allow-same-origin and could otherwise self-navigate to this origin.
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+# `always` on every line above is load-bearing: without it add_header applies only to
+# a fixed list of success/redirect statuses. A 404 here returns an HTML document, and
+# today it carries no headers at all.

--- a/deploy/security-headers.conf
+++ b/deploy/security-headers.conf
@@ -12,7 +12,7 @@
 # Report-Only for now. Enforcement is a follow-up once staging reports are clean —
 # a wrong connect-src does not degrade, it stops sends and balance loading.
 
-add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; worker-src 'none'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-src https: http://localhost:* http://127.0.0.1:*; connect-src 'self' https://sphere-api.invalid https://wallet-api.invalid; upgrade-insecure-requests" always;
+add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; worker-src 'none'; form-action 'self'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https:; media-src 'self' blob: https:; frame-src https: http://localhost:* http://127.0.0.1:*; connect-src 'self' https://sphere-api.invalid https://wallet-api.invalid; upgrade-insecure-requests" always;
 
 # Not a CSP directive and not superseded by frame-ancestors: still honoured by older
 # browsers, and DENY rather than SAMEORIGIN because the agent iframe runs with

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
         "@unicitylabs/sphere-sdk": "0.13.1",
-        "@unicitylabs/sphere-ui": "^0.1.34",
+        "@unicitylabs/sphere-ui": "^0.1.35",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
         "lucide-react": "^0.552.0",
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.34.tgz",
-      "integrity": "sha512-bUPS9C1v6pTtugixm34v19AftmvJwciwR90a9E8e7pHIrGwCPwSgm4+55G5bVjfdE6AzxS0kS7MI+hg+krIgXg==",
+      "version": "0.1.35",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.35.tgz",
+      "integrity": "sha512-hbjqZ1+UpKqiv67NeVeFSvFbbWKKAxn4FLeWMcY/yBuBYXvu0Z6lRnZw2EOOQDhnWm3cgF616zDlxQW+HVyXCA==",
       "dependencies": {
         "framer-motion": "^11.18.2",
         "lucide-react": ">=0.400.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
     "@unicitylabs/sphere-sdk": "0.13.1",
-    "@unicitylabs/sphere-ui": "^0.1.34",
+    "@unicitylabs/sphere-ui": "^0.1.35",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",
     "lucide-react": "^0.552.0",

--- a/public/boot.js
+++ b/public/boot.js
@@ -1,0 +1,46 @@
+/**
+ * Pre-React boot work, in a file rather than inline in index.html.
+ *
+ * Both of these have to run before the module bundle, and both used to be inline
+ * <script> blocks. Inline script is exactly what a Content-Security-Policy cannot
+ * distinguish from an injected one, so allowing it would make `script-src 'self'`
+ * meaningless on an origin that holds a mnemonic seed. A same-origin classic script
+ * achieves the same ordering — /runtime-config.js already proves that — with no
+ * 'unsafe-inline' allowance and no hash to keep in sync.
+ *
+ * Nonces would be the other option and are the wrong tool here: this repo builds one
+ * image and promotes it, so a build-time nonce is identical across environments, and
+ * the GitHub Pages deployment can never have a per-request one.
+ *
+ * Keep this file dependency-free and synchronous. It is a classic script, not a module.
+ */
+(function () {
+  // ── GitHub Pages SPA path restore ────────────────────────────────────────
+  // The root 404.html redirects deep links from /base/{route}?qs to
+  // /base/?p=/{route}&qs; rewrite back before React Router reads the URL.
+  // No-op in production, where no ?p= is present.
+  var params = new URLSearchParams(window.location.search);
+  var p = params.get('p');
+  if (p) {
+    params.delete('p');
+    var base = window.location.pathname.replace(/\/$/, '');
+    var remaining = params.toString();
+    window.history.replaceState(
+      null,
+      '',
+      base + p + (remaining ? '?' + remaining : '') + window.location.hash
+    );
+  }
+
+  // ── Theme, applied before first paint ────────────────────────────────────
+  // Unconditionally dark. The app IS dark-only: useTheme.getStoredTheme() returns
+  // 'dark' on every path and migrates any stored 'light' away on module load.
+  //
+  // This used to read localStorage('sphere-theme') and fall back to
+  // prefers-color-scheme. Two bugs in one: the key was hyphenated while every writer
+  // uses STORAGE_KEYS.THEME ('sphere_theme'), so the lookup always missed — and the
+  // matchMedia fallback then applied `light` on a light-preferring machine, which
+  // React immediately overwrote with `dark`. That flash was the very thing the guard
+  // existed to prevent. Restore the storage read only if a light theme comes back.
+  document.documentElement.classList.add('dark');
+})();

--- a/src/index.html
+++ b/src/index.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="theme-color" content="#0a0a0a" />
     <title>Unicity Agent Sphere</title>
-    <!-- Splash screen fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Geist:wght@400;500&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <!-- Fonts are self-hosted via @unicitylabs/sphere-ui (>= 0.1.35), which now
+         ships the woff2 files instead of a remote @import. These links were also
+         never the whole story: sphere-ui's stylesheet made its own request to
+         Google and, being emitted later, won the cascade. -->
     <!-- Pre-React boot work: SPA path restore and the theme class. In a file, not
          inline, so script-src can be 'self' — a CSP cannot tell our inline script
          from an injected one. Classic script: runs before the module bundle. -->

--- a/src/index.html
+++ b/src/index.html
@@ -10,32 +10,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Geist:wght@400;500&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script>
-      // GitHub Pages SPA path restore. The root 404.html redirects deep links
-      // from /base/{route}?qs to /base/?p=/{route}&qs; rewrite back before
-      // React Router reads the URL. No-op in production (no ?p= present).
-      (function() {
-        var params = new URLSearchParams(window.location.search);
-        var p = params.get('p');
-        if (!p) return;
-        params.delete('p');
-        var base = window.location.pathname.replace(/\/$/, '');
-        var remaining = params.toString();
-        window.history.replaceState(
-          null, '',
-          base + p + (remaining ? '?' + remaining : '') + window.location.hash
-        );
-      })();
-    </script>
-    <script>
-      // Prevent FOUC by applying theme before React loads
-      (function() {
-        const stored = localStorage.getItem('sphere-theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = stored || (prefersDark ? 'dark' : 'light');
-        document.documentElement.classList.add(theme);
-      })();
-    </script>
+    <!-- Pre-React boot work: SPA path restore and the theme class. In a file, not
+         inline, so script-src can be 'self' — a CSP cannot tell our inline script
+         from an injected one. Classic script: runs before the module bundle. -->
+    <script src="/boot.js"></script>
     <!-- Runtime-swappable public config for build-once/promote-many Docker
          images (window.__SPHERE_RUNTIME_CONFIG__). Classic script: executes
          before the module bundle below. Rewritten at container start by

--- a/tests/unit/config/indexHtmlScripts.test.ts
+++ b/tests/unit/config/indexHtmlScripts.test.ts
@@ -63,6 +63,25 @@ describe('index.html script origins', () => {
     expect(bundle).toBeGreaterThan(runtime);
   });
 
+  it('has no inline script at all, which is what lets script-src be self', () => {
+    // A CSP cannot distinguish our inline block from an injected one, so allowing
+    // 'unsafe-inline' would make the policy meaningless on an origin holding a seed.
+    // Both former inline blocks live in public/boot.js.
+    const inline = [...html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/g)]
+      .filter(([, attrs, body]) => !/\bsrc=/.test(attrs) && body.trim() !== '');
+    expect(inline).toEqual([]);
+  });
+
+  it('loads boot.js before the module bundle', () => {
+    // boot.js applies the theme class and restores the SPA path; both must happen
+    // before React reads the URL or paints.
+    const sources = scriptSources();
+    const boot = sources.findIndex((s) => s.includes('boot.js'));
+    const bundle = sources.findIndex((s) => s.includes('main.tsx'));
+    expect(boot).toBeGreaterThanOrEqual(0);
+    expect(bundle).toBeGreaterThan(boot);
+  });
+
   it('has exactly the Google Fonts pair as its only cross-origin links', () => {
     // A tripwire, not a pin: self-hosting the fonts is a separate change, and when it
     // lands this expectation becomes an empty array.

--- a/tests/unit/config/indexHtmlScripts.test.ts
+++ b/tests/unit/config/indexHtmlScripts.test.ts
@@ -82,10 +82,11 @@ describe('index.html script origins', () => {
     expect(bundle).toBeGreaterThan(boot);
   });
 
-  it('has exactly the Google Fonts pair as its only cross-origin links', () => {
-    // A tripwire, not a pin: self-hosting the fonts is a separate change, and when it
-    // lands this expectation becomes an empty array.
+  it('links to no third-party origin either', () => {
+    // Fonts are self-hosted via sphere-ui >= 0.1.35, so nothing in this document
+    // should reach outside our own origin — not a script, not a stylesheet, not a
+    // preconnect hint. That is what makes font-src 'self' possible.
     const hosts = [...new Set(linkHrefs().map(hostOf).filter((h): h is string => h !== null))];
-    expect(hosts.sort()).toEqual(['fonts.googleapis.com', 'fonts.gstatic.com']);
+    expect(hosts).toEqual([]);
   });
 });


### PR DESCRIPTION
Follow-up to #461 (removing the Google tag), which was the first blocker.

**Ships `Report-Only`.** A wrong `connect-src` does not degrade gracefully — it stops sends and balance loading. Enforcement is a follow-up once staging reports are clean.

## The starting point is worse than "no CSP"

**Production and staging serve zero security headers today.** No CSP, no HSTS, no `X-Content-Type-Options`, no `X-Frame-Options`.

The HSTS/nosniff/XFO in `deploy/entrypoint.sh` belong to `Dockerfile.ssl`, which **CI never builds** — `docker-build.yml` passes no `file:`, so the pushed image is the default `Dockerfile`, and that sets only `Cache-Control`. So the wallet is framable by any origin right now, and `frame-ancestors 'none'` is the directive doing the most real work here.

## Four things had to be true before a policy could exist

**1 · No inline script.** A CSP cannot tell our inline block from an injected one, so `'unsafe-inline'` would make `script-src` meaningless on an origin holding a mnemonic. Both blocks move to `public/boot.js`, a classic same-origin script — `/runtime-config.js` already proves that ordering works before the module bundle.

Nonces are the wrong tool here: this repo builds one image and promotes it, so a build-time nonce is identical across environments, and the GitHub Pages deployment can never have a per-request one.

**2 · The nginx config had to leave the Dockerfile.** It was built by `RUN echo '…'` — a **single-quoted shell string**, and every CSP keyword source (`'self'`, `'none'`) uses that same delimiter:

```
$ sh -c "echo 'add_header CSP \"script-src 'self'\" always;'"
add_header CSP "script-src self" always;
```

The quotes vanish. `script-src self` is a **valid** policy — bare `self` parses as a hostname — matching nothing. `nginx -t` passes, CI goes green, the page is blank. Verified by reproduction, not inferred. Now `deploy/nginx.conf`, `COPY`ed in.

**3 · `add_header` does not inherit.** nginx drops inherited `add_header` at any level that declares one of its own, and all three locations set `Cache-Control`. A server-level-only policy would have reached **zero documents** while still passing a "did we add the header?" review. Every location re-includes the headers file — that repetition is load-bearing, not something to DRY away.

**4 · `always` on everything.** Without it `add_header` applies only to a fixed list of success/redirect statuses. A 404 here returns an HTML document and today carries no headers at all.

## Per-environment connect-src

The image is built once and promoted, so `runtime-config.sh` now regenerates the headers file from the container env before nginx starts — the same hook that already rewrites `runtime-config.js`. URLs are reduced to origins (`https://api…/v1/x` → `https://api…`), since CSP matches origins and a trailing path silently narrows the match.

The baked default keeps RFC 2606 `.invalid` placeholders, so a hook that did not run produces **blocked-and-reported** requests rather than a silent bypass.

## Verified against a running container

Built the image, `nginx -t` passes, and:

| Check | Result |
|---|---|
| Headers on `/` | ✅ CSP, XFO, nosniff, Referrer-Policy |
| Headers on `/assets/…` | ✅ 3 — proves the per-location include works despite `Cache-Control` |
| Headers on a 404 | ✅ 3 — previously **none at all** |
| `connect-src` from env | ✅ path stripped to origin, fixed hosts appended |
| Inline `<script>` in served HTML | ✅ 0 |
| `boot.js` served, before the bundle | ✅ 200 |

## A bug fixed along the way

The theme guard read `localStorage('sphere-theme')` while every writer uses `STORAGE_KEYS.THEME` = `'sphere_theme'`. The lookup always missed, so the `matchMedia` fallback applied `light` on a light-preferring machine — which React then overwrote with `dark`. That flash is exactly what the guard existed to prevent.

Fixing the key would not have been enough: `useTheme.getStoredTheme()` returns `'dark'` on every path (light was removed and is migrated away), so the guard now simply sets it.

## The SSL image

Same include, including its **no-certificate branch, which emitted no headers at all** — a failed cert acquisition silently dropped every one. `X-Frame-Options` there goes `SAMEORIGIN` → `DENY` to match `frame-ancestors 'none'`; SAMEORIGIN is not safe here, because the agent iframe runs with `allow-same-origin` and could self-navigate to this origin.

## What this does NOT fix — please do not let it be reported as "the wallet is protected"

- **The agent-frame chain.** `AgentPage` frames an arbitrary `?url=` with a live Connect host, and `config/activities.ts` advertises "Load any URL". `frame-src` cannot express "any URL the user typed" — that *is* the feature. `frame-src https:` is the ceiling. Already in the 2026-07-23 audit.
- **Malicious browser extensions** bypass page CSP entirely and can read IndexedDB.
- **The wallet password is still opt-in** (#449), so a wallet created without one keeps its mnemonic in the clear.

## Deliberately deferred

**Google Fonts stay allowed** in `style-src`/`font-src`. Self-hosting is a separate change in **sphere-ui**, whose `tokens.css` carries a remote `@import` that Vite does not inline — I verified the built CSS still starts with `@import"https://fonts.googleapis.com/…"`, so deleting the `<link>` tags alone would **not** have removed them. That fix also affects backoffice and dev-portal.

**Excluding `vm` from `vite-plugin-node-polyfills`**, which would drop `vm-browserify`'s never-called `eval()` from the bundle. It broke an unrelated wallet-lock test in the full suite, and CSP blocks `eval` at **call** time, so `script-src 'self'` is unaffected by an uncalled function. Not worth the collateral here.

## Rollout

Report-Only on staging first. **A CSP violation is not a JS error**, so Sentry will not see it — wire `securitypolicyviolation` to a Sentry message, or set `report-to`, before concluding anything from silence. Then a full pass: connect, send, receive, swap, chat, an agent iframe, splash, faucet. Flipping to enforce is a one-word change to the header name.

## Verification

Image builds · `nginx -t` passes · **613** tests · eslint 0 errors.