### PR TITLE
feat: standalone (SDK) projects in Explore and on the desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
         "@unicitylabs/sphere-sdk": "0.13.1",
-        "@unicitylabs/sphere-ui": "^0.1.35",
+        "@unicitylabs/sphere-ui": "^0.1.36",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
         "lucide-react": "^0.552.0",
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
-      "version": "0.1.35",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.35.tgz",
-      "integrity": "sha512-hbjqZ1+UpKqiv67NeVeFSvFbbWKKAxn4FLeWMcY/yBuBYXvu0Z6lRnZw2EOOQDhnWm3cgF616zDlxQW+HVyXCA==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.36.tgz",
+      "integrity": "sha512-rziaEOeUej8Cl62wDtfzWZGK1ips4DrhkQU1sLue4/HLz+qDxxliAsLveZwWvhRghxoIqW6w5V/y63xDuLh2Rw==",
       "dependencies": {
         "framer-motion": "^11.18.2",
         "lucide-react": ">=0.400.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
     "@unicitylabs/sphere-sdk": "0.13.1",
-    "@unicitylabs/sphere-ui": "^0.1.35",
+    "@unicitylabs/sphere-ui": "^0.1.36",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",
     "lucide-react": "^0.552.0",

--- a/src/components/desktop/DesktopLayout.tsx
+++ b/src/components/desktop/DesktopLayout.tsx
@@ -15,6 +15,7 @@ import { WalletRequiredBlocker } from '../agents/WalletRequiredBlocker';
 import { ActivityTicker } from '../activity';
 import { Footer } from '../layout/Footer';
 import { normalizeUrl } from '../../utils/normalizeUrl';
+import { isHttpsUrl } from '../../utils/isHttpsUrl';
 
 const CUSTOM_URL_PRESETS = [
   { label: 'Sphere Connect Example', url: 'https://unicity-sphere.github.io/sphere-sdk-connect-example/' },
@@ -63,8 +64,19 @@ export function DesktopLayout() {
   const renderTabContent = (tabId: string, appId: string, url?: string) => {
     const agent = getAgentConfig(appId);
 
-    // Custom URL iframe tab
-    if (url) {
+    // Custom URL iframe tab. `tab.url` is untrusted at READ time too, not
+    // just at write time — InstalledProjectIcon and ProjectPage already gate
+    // with isHttpsUrl before ever calling openTab, but that closes the write
+    // side only. `openTabs` is restored from localStorage (useDesktopState's
+    // loadState()), which is user-writable via devtools regardless of what
+    // our code writes, and a tab persisted BEFORE those write-side gates
+    // existed would otherwise still reach the iframe unchanged on every load
+    // from now on. Re-check here so a non-https `url` never becomes
+    // `iframeUrl`. Falling through (no `url`) lands on the `case 'custom'`
+    // branch below, which shows the "Load Custom URL" prompt — the same
+    // screen a custom tab with no URL yet already shows, not a new empty
+    // state invented for this gate.
+    if (url && isHttpsUrl(url)) {
       const customAgent: AgentConfig = {
         id: tabId,
         name: url,

--- a/src/components/desktop/InstalledProjectIcon.tsx
+++ b/src/components/desktop/InstalledProjectIcon.tsx
@@ -6,6 +6,7 @@ import { InstalledProjectIcon as InstalledProjectIconUI } from '@unicitylabs/sph
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { useInstalledProjects } from '../../hooks/useInstalledProjects';
 import type { ProjectSummary } from '../../services/marketplaceApi';
+import { isHttpsUrl } from '../../utils/isHttpsUrl';
 
 interface InstalledProjectIconProps {
   project: ProjectSummary & { appUrl?: string | null; websiteUrl?: string | null };
@@ -66,28 +67,40 @@ export function InstalledProjectIcon({
     setMenuOpen((prev) => !prev);
   };
 
+  // window.open is an unsanitised navigation sink — unlike a JSX `href`, React
+  // applies no protocol checking to it at all. This app is the wallet (the
+  // origin holding the user's keys), and repoUrl/websiteUrl are project data
+  // that can reach this component via an admin/migration/seed path that skips
+  // normal write-side validation, so gate on isHttpsUrl before ever rendering
+  // an entry that calls it — a non-https value gets no menu item at all,
+  // rather than a menu item whose click would fail safe.
   const menuItems = [
-    ...(project.type === 'sdk' && project.repoUrl
-      ? [{
-          label: 'Open repository',
-          icon: ExternalLink,
-          onClick: () => window.open(project.repoUrl!, '_blank', 'noopener,noreferrer'),
-        }]
-      : project.appUrl
-        ? [{
-            label: 'Open in Tab',
-            icon: Globe,
-            onClick: () => {
-              openTab('custom', { url: project.appUrl!, label: project.name });
-              navigate(`/agents/custom?url=${encodeURIComponent(project.appUrl!)}`);
-            },
-          }]
-        : []),
-    ...(project.websiteUrl
+    // Branch on type first so this list can never disagree with launchUrl,
+    // which forbids framing for `sdk` unconditionally: an sdk record must
+    // never offer "Open in Tab", even if it carries a stray appUrl.
+    ...(project.type === 'sdk'
+      ? (project.repoUrl && isHttpsUrl(project.repoUrl)
+          ? [{
+              label: 'Open repository',
+              icon: ExternalLink,
+              onClick: () => window.open(project.repoUrl!, '_blank', 'noopener,noreferrer'),
+            }]
+          : [])
+      : (project.appUrl
+          ? [{
+              label: 'Open in Tab',
+              icon: Globe,
+              onClick: () => {
+                openTab('custom', { url: project.appUrl!, label: project.name });
+                navigate(`/agents/custom?url=${encodeURIComponent(project.appUrl!)}`);
+              },
+            }]
+          : [])),
+    ...(project.websiteUrl && isHttpsUrl(project.websiteUrl)
       ? [{
           label: 'Open Website',
           icon: ExternalLink,
-          onClick: () => window.open(project.websiteUrl!, '_blank'),
+          onClick: () => window.open(project.websiteUrl!, '_blank', 'noopener,noreferrer'),
         }]
       : []),
     {

--- a/src/components/desktop/InstalledProjectIcon.tsx
+++ b/src/components/desktop/InstalledProjectIcon.tsx
@@ -50,7 +50,18 @@ export function InstalledProjectIcon({
   // X-Frame-Options: deny, so the in-app frame would render blank. Falling
   // through to the project page gives the user the repo and website buttons,
   // the description and the install command instead.
-  const launchUrl = isStandalone(project) ? null : (project.appUrl ?? project.websiteUrl);
+  //
+  // This is the most dangerous sink in the app: openTab persists the value
+  // into DesktopTab.url in localStorage, DesktopLayout turns it into
+  // iframeUrl, and IframeAgent renders <iframe src={activeUrl}> with no
+  // sandbox attribute. A non-https `src` (e.g. `javascript:`) on an
+  // unsandboxed iframe executes with the wallet's own origin. Gate the
+  // chosen candidate with isHttpsUrl before it is usable — if appUrl is
+  // present but unsafe, do NOT fall back to websiteUrl (same nullish-only
+  // fallback semantics as before); if the result fails the check, treat it
+  // exactly like a project with no launch URL at all.
+  const candidateLaunchUrl = isStandalone(project) ? null : (project.appUrl ?? project.websiteUrl);
+  const launchUrl = candidateLaunchUrl && isHttpsUrl(candidateLaunchUrl) ? candidateLaunchUrl : null;
 
   const handleClick = () => {
     void ping(project.slug);
@@ -87,7 +98,7 @@ export function InstalledProjectIcon({
               onClick: () => window.open(project.repoUrl!, '_blank', 'noopener,noreferrer'),
             }]
           : [])
-      : (project.appUrl
+      : (project.appUrl && isHttpsUrl(project.appUrl)
           ? [{
               label: 'Open in Tab',
               icon: Globe,

--- a/src/components/desktop/InstalledProjectIcon.tsx
+++ b/src/components/desktop/InstalledProjectIcon.tsx
@@ -53,13 +53,16 @@ export function InstalledProjectIcon({
   //
   // This is the most dangerous sink in the app: openTab persists the value
   // into DesktopTab.url in localStorage, DesktopLayout turns it into
-  // iframeUrl, and IframeAgent renders <iframe src={activeUrl}> with no
-  // sandbox attribute. A non-https `src` (e.g. `javascript:`) on an
-  // unsandboxed iframe executes with the wallet's own origin. Gate the
-  // chosen candidate with isHttpsUrl before it is usable — if appUrl is
-  // present but unsafe, do NOT fall back to websiteUrl (same nullish-only
-  // fallback semantics as before); if the result fails the check, treat it
-  // exactly like a project with no launch URL at all.
+  // iframeUrl, and IframeAgent renders <iframe src={activeUrl}>. The frame
+  // does carry a sandbox attribute (AGENT_IFRAME_SANDBOX), but it includes
+  // both allow-scripts and allow-same-origin, which together leave a framed
+  // page free to script in its own inherited origin — the sandbox grants no
+  // protection against a malicious `src` (e.g. `javascript:`) itself; the
+  // https gate below is what protects the origin. Gate the chosen candidate
+  // with isHttpsUrl before it is usable — if appUrl is present but unsafe,
+  // do NOT fall back to websiteUrl (same nullish-only fallback semantics as
+  // before); if the result fails the check, treat it exactly like a project
+  // with no launch URL at all.
   const candidateLaunchUrl = isStandalone(project) ? null : (project.appUrl ?? project.websiteUrl);
   const launchUrl = candidateLaunchUrl && isHttpsUrl(candidateLaunchUrl) ? candidateLaunchUrl : null;
 

--- a/src/components/desktop/InstalledProjectIcon.tsx
+++ b/src/components/desktop/InstalledProjectIcon.tsx
@@ -7,6 +7,7 @@ import { useDesktopState } from '../../hooks/useDesktopState';
 import { useInstalledProjects } from '../../hooks/useInstalledProjects';
 import type { ProjectSummary } from '../../services/marketplaceApi';
 import { isHttpsUrl } from '../../utils/isHttpsUrl';
+import { isStandalone } from '../../utils/isStandalone';
 
 interface InstalledProjectIconProps {
   project: ProjectSummary & { appUrl?: string | null; websiteUrl?: string | null };
@@ -44,12 +45,12 @@ export function InstalledProjectIcon({
     return () => document.removeEventListener('mousedown', handler);
   }, [menuOpen]);
 
-  // A `sdk` project has nothing to launch: it runs on the user's own machine.
-  // Its repository must never go through openTab — GitHub sends
+  // A `standalone` project has nothing to launch: it runs on the user's own
+  // machine. Its repository must never go through openTab — GitHub sends
   // X-Frame-Options: deny, so the in-app frame would render blank. Falling
   // through to the project page gives the user the repo and website buttons,
   // the description and the install command instead.
-  const launchUrl = project.type === 'sdk' ? null : (project.appUrl ?? project.websiteUrl);
+  const launchUrl = isStandalone(project) ? null : (project.appUrl ?? project.websiteUrl);
 
   const handleClick = () => {
     void ping(project.slug);
@@ -76,9 +77,9 @@ export function InstalledProjectIcon({
   // rather than a menu item whose click would fail safe.
   const menuItems = [
     // Branch on type first so this list can never disagree with launchUrl,
-    // which forbids framing for `sdk` unconditionally: an sdk record must
-    // never offer "Open in Tab", even if it carries a stray appUrl.
-    ...(project.type === 'sdk'
+    // which forbids framing for `standalone` unconditionally: a standalone
+    // record must never offer "Open in Tab", even if it carries a stray appUrl.
+    ...(isStandalone(project)
       ? (project.repoUrl && isHttpsUrl(project.repoUrl)
           ? [{
               label: 'Open repository',

--- a/src/components/desktop/InstalledProjectIcon.tsx
+++ b/src/components/desktop/InstalledProjectIcon.tsx
@@ -43,7 +43,12 @@ export function InstalledProjectIcon({
     return () => document.removeEventListener('mousedown', handler);
   }, [menuOpen]);
 
-  const launchUrl = project.appUrl ?? project.websiteUrl;
+  // A `sdk` project has nothing to launch: it runs on the user's own machine.
+  // Its repository must never go through openTab — GitHub sends
+  // X-Frame-Options: deny, so the in-app frame would render blank. Falling
+  // through to the project page gives the user the repo and website buttons,
+  // the description and the install command instead.
+  const launchUrl = project.type === 'sdk' ? null : (project.appUrl ?? project.websiteUrl);
 
   const handleClick = () => {
     void ping(project.slug);
@@ -62,16 +67,22 @@ export function InstalledProjectIcon({
   };
 
   const menuItems = [
-    ...(project.appUrl
+    ...(project.type === 'sdk' && project.repoUrl
       ? [{
-          label: 'Open in Tab',
-          icon: Globe,
-          onClick: () => {
-            openTab('custom', { url: project.appUrl!, label: project.name });
-            navigate(`/agents/custom?url=${encodeURIComponent(project.appUrl!)}`);
-          },
+          label: 'Open repository',
+          icon: ExternalLink,
+          onClick: () => window.open(project.repoUrl!, '_blank', 'noopener,noreferrer'),
         }]
-      : []),
+      : project.appUrl
+        ? [{
+            label: 'Open in Tab',
+            icon: Globe,
+            onClick: () => {
+              openTab('custom', { url: project.appUrl!, label: project.name });
+              navigate(`/agents/custom?url=${encodeURIComponent(project.appUrl!)}`);
+            },
+          }]
+        : []),
     ...(project.websiteUrl
       ? [{
           label: 'Open Website',

--- a/src/components/marketplace/FeaturedProjectCard.tsx
+++ b/src/components/marketplace/FeaturedProjectCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { FeaturedProjectCard as UiFeaturedProjectCard } from '@unicitylabs/sphere-ui';
 import type { ProjectSummary, ProjectMetrics } from '../../services/marketplaceApi';
+import { isStandalone } from '../../utils/isStandalone';
 
 interface FeaturedProjectCardProps {
   project: ProjectSummary;
@@ -21,8 +22,9 @@ export function FeaturedProjectCard({ project, metrics }: FeaturedProjectCardPro
           release cycle plus a dependency bump in every consumer). This card's
           banner ribbon ("Featured") sits at top-3 right-3, and the logo/title
           sit in a separate row below the banner — top-3 left-3 is free on both
-          counts. Driven off project.type (never off the absence of appUrl). */}
-      {project.type === 'sdk' && (
+          counts. Driven off project.type via isStandalone (never off the
+          absence of appUrl). */}
+      {isStandalone(project) && (
         <span
           className="absolute top-3 left-3 z-20 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-white/80 text-[10px] font-mono uppercase tracking-wider pointer-events-none"
         >

--- a/src/components/marketplace/FeaturedProjectCard.tsx
+++ b/src/components/marketplace/FeaturedProjectCard.tsx
@@ -15,7 +15,20 @@ export function FeaturedProjectCard({ project, metrics }: FeaturedProjectCardPro
   const ratingCount = metrics?.ratingCount ?? 0;
 
   return (
-    <Link to={`/apps/${project.slug}`} draggable={false}>
+    <Link to={`/apps/${project.slug}`} draggable={false} className="relative block">
+      {/* Same overlay as ProjectCard.tsx (sphere-ui doesn't know about project
+          types, and its version is CI-bumped, so touching it there means a
+          release cycle plus a dependency bump in every consumer). This card's
+          banner ribbon ("Featured") sits at top-3 right-3, and the logo/title
+          sit in a separate row below the banner — top-3 left-3 is free on both
+          counts. Driven off project.type (never off the absence of appUrl). */}
+      {project.type === 'sdk' && (
+        <span
+          className="absolute top-3 left-3 z-20 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-white/80 text-[10px] font-mono uppercase tracking-wider pointer-events-none"
+        >
+          STANDALONE
+        </span>
+      )}
       <UiFeaturedProjectCard
         name={project.name}
         tagline={project.tagline}

--- a/src/components/marketplace/FeaturedProjectCard.tsx
+++ b/src/components/marketplace/FeaturedProjectCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import { FeaturedProjectCard as UiFeaturedProjectCard } from '@unicitylabs/sphere-ui';
 import type { ProjectSummary, ProjectMetrics } from '../../services/marketplaceApi';
-import { isStandalone } from '../../utils/isStandalone';
+import { isStandalone, supportsQuests } from '../../utils/isStandalone';
 
 interface FeaturedProjectCardProps {
   project: ProjectSummary;
@@ -38,7 +38,11 @@ export function FeaturedProjectCard({ project, metrics }: FeaturedProjectCardPro
         bannerUrl={project.bannerUrl}
         accentColor={project.accentColor}
         users={users}
-        quests={quests}
+        // See ProjectCard.tsx's identical comment: sphere-ui defaults an
+        // absent `quests` to 0 and renders the stat unconditionally either
+        // way, but this repo's own value should still only ever be a real
+        // quest count for a type that has quests, not an asserted 0.
+        quests={supportsQuests(project.type) ? quests : undefined}
         positivePercent={positivePercent}
         ratingCount={ratingCount}
       />

--- a/src/components/marketplace/ProjectCard.tsx
+++ b/src/components/marketplace/ProjectCard.tsx
@@ -23,7 +23,18 @@ export function ProjectCard({ project, metrics }: ProjectCardProps) {
   const ratingCount = metrics?.ratingCount ?? 0;
 
   return (
-    <Link to={`/apps/${project.slug}`}>
+    <Link to={`/apps/${project.slug}`} className="relative block">
+      {/* sphere-ui's MarketplaceProjectCard doesn't know about project types, and
+          its version is bumped by CI — adding a type-aware badge there would mean
+          a release cycle plus a dependency bump in every consumer. Overlay it here
+          instead, driven off project.type (never off the absence of appUrl). */}
+      {project.type === 'sdk' && (
+        <span
+          className="absolute top-3 left-3 z-20 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-white/80 text-[10px] font-mono uppercase tracking-wider pointer-events-none"
+        >
+          STANDALONE
+        </span>
+      )}
       <MarketplaceProjectCard
         name={project.name}
         tagline={project.tagline}

--- a/src/components/marketplace/ProjectCard.tsx
+++ b/src/components/marketplace/ProjectCard.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { MarketplaceProjectCard } from '@unicitylabs/sphere-ui';
 import type { ProjectSummary, ProjectMetrics } from '../../services/marketplaceApi';
 import { useInstalledProjects } from '../../hooks/useInstalledProjects';
-import { isStandalone } from '../../utils/isStandalone';
+import { isStandalone, supportsQuests } from '../../utils/isStandalone';
 
 interface ProjectCardProps {
   project: ProjectSummary;
@@ -45,7 +45,16 @@ export function ProjectCard({ project, metrics }: ProjectCardProps) {
         accentColor={project.accentColor}
         category={project.category}
         users={users}
-        quests={quests}
+        // sphere-ui defaults an absent `quests` prop to 0 and renders the
+        // "Active quests" stat unconditionally either way (checked in its
+        // compiled output — there's no `quests !== undefined &&` guard, only
+        // `quests = 0` as a default param), so passing undefined doesn't
+        // currently change what's on screen for a project whose type has no
+        // quests. Passing it anyway is still wrong: it's a real quest count
+        // for `activeQuests`/`stats.activeQuests`, not a 0 this project
+        // actually has, and it costs nothing to be honest about that —
+        // forward-compatible if sphere-ui ever adds the presence check.
+        quests={supportsQuests(project.type) ? quests : undefined}
         positivePercent={positivePercent}
         ratingCount={ratingCount}
         installState={installed ? 'installed' : 'available'}

--- a/src/components/marketplace/ProjectCard.tsx
+++ b/src/components/marketplace/ProjectCard.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { MarketplaceProjectCard } from '@unicitylabs/sphere-ui';
 import type { ProjectSummary, ProjectMetrics } from '../../services/marketplaceApi';
 import { useInstalledProjects } from '../../hooks/useInstalledProjects';
+import { isStandalone } from '../../utils/isStandalone';
 
 interface ProjectCardProps {
   project: ProjectSummary;
@@ -27,8 +28,9 @@ export function ProjectCard({ project, metrics }: ProjectCardProps) {
       {/* sphere-ui's MarketplaceProjectCard doesn't know about project types, and
           its version is bumped by CI — adding a type-aware badge there would mean
           a release cycle plus a dependency bump in every consumer. Overlay it here
-          instead, driven off project.type (never off the absence of appUrl). */}
-      {project.type === 'sdk' && (
+          instead, driven off project.type via isStandalone (never off the
+          absence of appUrl). */}
+      {isStandalone(project) && (
         <span
           className="absolute top-3 left-3 z-20 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-white/80 text-[10px] font-mono uppercase tracking-wider pointer-events-none"
         >

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -12,6 +12,7 @@ import {
   fetchCategories,
 } from '../services/marketplaceApi';
 import { useMarketplaceEnabled } from './useMaintenanceStatus';
+import type { ProjectType } from '../utils/isStandalone';
 
 // Every query below talks to the sphere-api marketplace/metrics routes, which the
 // maintenance gate answers with 503 while `sphere` is under maintenance. Gating on
@@ -19,7 +20,7 @@ import { useMarketplaceEnabled } from './useMaintenanceStatus';
 // the browser never logs the (expected) 503s as red console errors. The wallet core
 // is unaffected — it talks to the chain/SDK, not sphere-api.
 
-export function useProjects(params?: { type?: 'app' | 'skill' | 'sdk'; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
+export function useProjects(params?: { type?: ProjectType; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'projects', params],
@@ -29,7 +30,7 @@ export function useProjects(params?: { type?: 'app' | 'skill' | 'sdk'; category?
   });
 }
 
-export function useFeaturedProjects(type?: 'app' | 'skill' | 'sdk') {
+export function useFeaturedProjects(type?: ProjectType) {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'featured', type],

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -50,12 +50,18 @@ export function useProject(slug: string, preview?: boolean) {
   });
 }
 
-export function useProjectQuests(slug: string) {
+/**
+ * `enabled` lets a caller skip the request entirely once it already knows
+ * (from the project's own data) that this project's type doesn't support
+ * quests — e.g. `useProjectQuests(slug, supportsQuests(project?.type))` on
+ * ProjectPage. Defaults to `true` so existing callers are unaffected.
+ */
+export function useProjectQuests(slug: string, enabled = true) {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'project-quests', slug],
     queryFn: () => fetchProjectQuests(slug),
-    enabled: marketplaceEnabled && !!slug,
+    enabled: marketplaceEnabled && !!slug && enabled,
   });
 }
 

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -19,7 +19,7 @@ import { useMarketplaceEnabled } from './useMaintenanceStatus';
 // the browser never logs the (expected) 503s as red console errors. The wallet core
 // is unaffected — it talks to the chain/SDK, not sphere-api.
 
-export function useProjects(params?: { type?: 'app' | 'skill'; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
+export function useProjects(params?: { type?: 'app' | 'skill' | 'sdk'; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'projects', params],
@@ -29,7 +29,7 @@ export function useProjects(params?: { type?: 'app' | 'skill'; category?: string
   });
 }
 
-export function useFeaturedProjects(type?: 'app' | 'skill') {
+export function useFeaturedProjects(type?: 'app' | 'skill' | 'sdk') {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
     queryKey: ['marketplace', 'featured', type],

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -102,15 +102,16 @@ function HeroDivider() {
 export function ExplorePage() {
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState<string | null>(null);
+  const [activeType, setActiveType] = useState<'app' | 'sdk'>('app');
   // Proactive maintenance status — the hook polls the allowlisted status endpoint
   // and also listens for `maintenance:forced`, so the marketplace queries (gated on
   // the same status) never fire requests that would 503 during maintenance.
   const { data: maintenance } = useMaintenanceStatus();
 
-  // Data — always filtered for apps only
-  const { data: projectsData, isLoading } = useProjects({ type: 'app' });
+  // Data — filtered by the active tab (apps vs. standalone SDK projects)
+  const { data: projectsData, isLoading } = useProjects({ type: activeType });
   const allItems = projectsData?.projects ?? [];
-  const { data: featured } = useFeaturedProjects('app');
+  const { data: featured } = useFeaturedProjects(activeType);
 
   // Single batch request for live metrics across every project on this page
   const allProjectIds = useMemo(
@@ -147,8 +148,8 @@ export function ExplorePage() {
   }, [allItems, metricsByProject]);
 
   const categories = APP_CATEGORIES;
-  const itemLabel = 'projects';
-  const searchPlaceholder = 'Search projects...';
+  const itemLabel = activeType === 'sdk' ? 'standalone projects' : 'projects';
+  const searchPlaceholder = activeType === 'sdk' ? 'Search standalone projects...' : 'Search projects...';
 
   if (maintenance?.enabled) {
     return <MaintenanceScreen message={maintenance.message} />;
@@ -214,6 +215,25 @@ export function ExplorePage() {
       {/* Search + Filter */}
       <section className="px-4 sm:px-6 pb-8">
         <div className="space-y-4">
+          <div className="inline-flex p-0.5 bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/8 rounded-lg mb-4">
+            {([
+              { key: 'app' as const, label: 'Apps' },
+              { key: 'sdk' as const, label: 'Standalone' },
+            ]).map(tab => (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => { setActiveType(tab.key); setCategory(null); setSearch(''); }}
+                className={
+                  activeType === tab.key
+                    ? 'px-3 py-1.5 rounded-md bg-orange-500 dark:bg-brand-orange text-white text-xs font-medium'
+                    : 'px-3 py-1.5 rounded-md text-neutral-700 dark:text-white/70 text-xs font-medium transition-colors'
+                }
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
           <div className="relative max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 dark:text-white/30" />
             <input

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -79,10 +79,10 @@ function FeaturedCarousel({ items, metricsByProject }: {
 
 const compactFormat = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
 
-function HeroStat({ value, label, compact = false }: { value: number; label: string; compact?: boolean }) {
+function HeroStat({ value, label, compact = false, testId }: { value: number; label: string; compact?: boolean; testId?: string }) {
   const display = compact ? compactFormat.format(value) : value.toLocaleString();
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center" data-testid={testId}>
       <span className="text-2xl sm:text-3xl font-bold font-mono tabular-nums text-neutral-900 dark:text-white tracking-tight">
         {display}
       </span>
@@ -108,15 +108,29 @@ export function ExplorePage() {
   // the same status) never fire requests that would 503 during maintenance.
   const { data: maintenance } = useMaintenanceStatus();
 
-  // Data — filtered by the active tab (apps vs. standalone SDK projects)
-  const { data: projectsData, isLoading } = useProjects({ type: activeType });
+  // Data — both types are always fetched (not just the active one) so the type
+  // switch can show a real count on each side and so flipping tabs is instant,
+  // reading from the already-cached query instead of refetching.
+  const { data: appProjectsData, isLoading: appLoading } = useProjects({ type: 'app' });
+  const { data: sdkProjectsData, isLoading: sdkLoading } = useProjects({ type: 'sdk' });
+  const projectsData = activeType === 'sdk' ? sdkProjectsData : appProjectsData;
+  const isLoading = activeType === 'sdk' ? sdkLoading : appLoading;
   const allItems = projectsData?.projects ?? [];
+  // Apps + standalone together — the hero stats describe the whole catalog,
+  // not just the active tab, so they must read identically on both tabs and
+  // never collapse just because the tab you happen to be on is empty.
+  const combinedItems = useMemo(
+    () => [...(appProjectsData?.projects ?? []), ...(sdkProjectsData?.projects ?? [])],
+    [appProjectsData, sdkProjectsData],
+  );
   const { data: featured } = useFeaturedProjects(activeType);
 
-  // Single batch request for live metrics across every project on this page
+  // Single batch request for live metrics across every project on this page —
+  // sourced from the combined list so hero stats and card metrics are equally
+  // live regardless of which tab is active.
   const allProjectIds = useMemo(
-    () => [...new Set([...allItems, ...(featured ?? [])].map((p) => p._id))],
-    [allItems, featured],
+    () => [...new Set([...combinedItems, ...(featured ?? [])].map((p) => p._id))],
+    [combinedItems, featured],
   );
   const { data: metricsByProject = {} } = useProjectMetricsBatch(allProjectIds);
 
@@ -136,16 +150,17 @@ export function ExplorePage() {
   // Featured items
   const featuredItems = featured ?? [];
 
-  // Hero stats — prefer live metrics, fall back to denormalized stats
+  // Hero stats — apps + standalone combined (never just the active tab), prefer
+  // live metrics, fall back to denormalized stats
   const heroStats = useMemo(() => {
-    const projects = allItems.length;
-    const users = allItems.reduce((sum, p) => {
+    const projects = combinedItems.length;
+    const users = combinedItems.reduce((sum, p) => {
       const live = metricsByProject[p._id]?.uniqueUsers;
       return sum + (live ?? p.stats.totalUsers ?? 0);
     }, 0);
-    const categoriesCount = new Set(allItems.map((p) => p.category)).size;
+    const categoriesCount = new Set(combinedItems.map((p) => p.category)).size;
     return { projects, users, categoriesCount };
-  }, [allItems, metricsByProject]);
+  }, [combinedItems, metricsByProject]);
 
   const categories = APP_CATEGORIES;
   const itemLabel = activeType === 'sdk' ? 'standalone projects' : 'projects';
@@ -192,48 +207,85 @@ export function ExplorePage() {
             transition={{ delay: 0.1 }}
             className="text-base sm:text-lg text-neutral-500 dark:text-white/65 max-w-xl mx-auto leading-relaxed"
           >
-            Games, DeFi, tools and agents — all running on Layer 3.
+            Games, DeFi, tools and agents — all running on the Sphere SDK.
           </motion.p>
 
-          {heroStats.projects > 0 && (
-            <motion.div
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.18 }}
-              className="mt-10 sm:mt-12 flex items-center justify-center gap-6 sm:gap-10"
-            >
-              <HeroStat value={heroStats.projects} label="Projects" />
-              <HeroDivider />
-              <HeroStat value={heroStats.users} label="Users" compact />
-              <HeroDivider />
-              <HeroStat value={heroStats.categoriesCount} label="Categories" />
-            </motion.div>
-          )}
+          {/* Catalog-wide totals — computed from apps + standalone combined (see
+              combinedItems above), so this row is identical no matter which tab
+              is active and never collapses just because the active tab is empty.
+              Always rendered (no `> 0` gate) — a real zero, not a vanished row. */}
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.18 }}
+            className="mt-10 sm:mt-12 flex items-center justify-center gap-6 sm:gap-10"
+          >
+            <HeroStat testId="hero-stat-projects" value={heroStats.projects} label={heroStats.projects === 1 ? 'Total Project' : 'Total Projects'} />
+            <HeroDivider />
+            <HeroStat testId="hero-stat-users" value={heroStats.users} label={heroStats.users === 1 ? 'Total User' : 'Total Users'} compact />
+            <HeroDivider />
+            <HeroStat testId="hero-stat-categories" value={heroStats.categoriesCount} label={heroStats.categoriesCount === 1 ? 'Category' : 'Categories'} />
+          </motion.div>
         </div>
+      </section>
+
+      {/* Type switch — the top-level split of the catalog: an app opens inside
+          Sphere, a standalone project is installed and run on your own machine.
+          A real segmented control, sized and faced like UI chrome (Geist, control
+          scale) rather than the hero's display type — the hero already owns that
+          register, and a filled block set in Anton at display size just reads as
+          a second banner. The hero's totals row (above) carries the counting;
+          this control only ever shows the two labels. */}
+      <section className="px-4 sm:px-6 pb-10">
+        <div className="flex justify-center">
+          <div
+            role="tablist"
+            aria-label="Project type"
+            className="relative grid grid-cols-2 gap-1 rounded-full border border-neutral-200 dark:border-white/12 bg-neutral-50 dark:bg-white/4 p-1"
+          >
+            {/* Sliding thumb — an absolutely-positioned pill sized to exactly one
+                grid column, translated by its own width + the gap to reach the
+                other column. Instant (no slide) under prefers-reduced-motion. */}
+            <span
+              aria-hidden
+              className={
+                activeType === 'sdk'
+                  ? 'absolute inset-y-1 left-1 w-[calc((100%-0.75rem)/2)] translate-x-[calc(100%+0.25rem)] rounded-full bg-orange-500 dark:bg-brand-orange shadow-md shadow-black/25 transition-transform duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none'
+                  : 'absolute inset-y-1 left-1 w-[calc((100%-0.75rem)/2)] translate-x-0 rounded-full bg-orange-500 dark:bg-brand-orange shadow-md shadow-black/25 transition-transform duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none'
+              }
+            />
+            {([
+              { key: 'app' as const, label: 'Apps' },
+              { key: 'sdk' as const, label: 'Standalone' },
+            ]).map(tab => {
+              const isActive = activeType === tab.key;
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => { setActiveType(tab.key); setCategory(null); setSearch(''); }}
+                  className={
+                    isActive
+                      ? 'relative z-10 rounded-full px-6 sm:px-8 py-2 sm:py-2.5 text-sm font-semibold text-black cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-orange-500/60 focus-visible:ring-offset-2'
+                      : 'relative z-10 rounded-full px-6 sm:px-8 py-2 sm:py-2.5 text-sm font-semibold text-neutral-500 dark:text-white/60 hover:text-neutral-900 dark:hover:text-white cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-orange-500/60 focus-visible:ring-offset-2 transition-colors'
+                  }
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <p className="mt-3 text-center text-xs sm:text-sm text-neutral-400 dark:text-white/40">
+          {activeType === 'sdk' ? 'Run on your own machine' : 'Open in Sphere'}
+        </p>
       </section>
 
       {/* Search + Filter */}
       <section className="px-4 sm:px-6 pb-8">
         <div className="space-y-4">
-          <div className="inline-flex p-0.5 bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/8 rounded-lg mb-4">
-            {([
-              { key: 'app' as const, label: 'Apps' },
-              { key: 'sdk' as const, label: 'Standalone' },
-            ]).map(tab => (
-              <button
-                key={tab.key}
-                type="button"
-                onClick={() => { setActiveType(tab.key); setCategory(null); setSearch(''); }}
-                className={
-                  activeType === tab.key
-                    ? 'px-3 py-1.5 rounded-md bg-orange-500 dark:bg-brand-orange text-white text-xs font-medium'
-                    : 'px-3 py-1.5 rounded-md text-neutral-700 dark:text-white/70 text-xs font-medium transition-colors'
-                }
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
           <div className="relative max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 dark:text-white/30" />
             <input

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -8,6 +8,7 @@ import { CategoryFilter } from '../components/marketplace/CategoryFilter';
 import { MaintenanceScreen } from '../components/MaintenanceScreen';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 import { DEV_PORTAL_URL } from '../config/devPortal';
+import { PROJECT_TYPES } from '../utils/isStandalone';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -102,7 +103,7 @@ function HeroDivider() {
 export function ExplorePage() {
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState<string | null>(null);
-  const [activeType, setActiveType] = useState<'app' | 'sdk'>('app');
+  const [activeType, setActiveType] = useState<typeof PROJECT_TYPES.APP | typeof PROJECT_TYPES.STANDALONE>(PROJECT_TYPES.APP);
   // Proactive maintenance status — the hook polls the allowlisted status endpoint
   // and also listens for `maintenance:forced`, so the marketplace queries (gated on
   // the same status) never fire requests that would 503 during maintenance.
@@ -111,17 +112,17 @@ export function ExplorePage() {
   // Data — both types are always fetched (not just the active one) so the type
   // switch can show a real count on each side and so flipping tabs is instant,
   // reading from the already-cached query instead of refetching.
-  const { data: appProjectsData, isLoading: appLoading } = useProjects({ type: 'app' });
-  const { data: sdkProjectsData, isLoading: sdkLoading } = useProjects({ type: 'sdk' });
-  const projectsData = activeType === 'sdk' ? sdkProjectsData : appProjectsData;
-  const isLoading = activeType === 'sdk' ? sdkLoading : appLoading;
+  const { data: appProjectsData, isLoading: appLoading } = useProjects({ type: PROJECT_TYPES.APP });
+  const { data: standaloneProjectsData, isLoading: standaloneLoading } = useProjects({ type: PROJECT_TYPES.STANDALONE });
+  const projectsData = activeType === PROJECT_TYPES.STANDALONE ? standaloneProjectsData : appProjectsData;
+  const isLoading = activeType === PROJECT_TYPES.STANDALONE ? standaloneLoading : appLoading;
   const allItems = projectsData?.projects ?? [];
   // Apps + standalone together — the hero stats describe the whole catalog,
   // not just the active tab, so they must read identically on both tabs and
   // never collapse just because the tab you happen to be on is empty.
   const combinedItems = useMemo(
-    () => [...(appProjectsData?.projects ?? []), ...(sdkProjectsData?.projects ?? [])],
-    [appProjectsData, sdkProjectsData],
+    () => [...(appProjectsData?.projects ?? []), ...(standaloneProjectsData?.projects ?? [])],
+    [appProjectsData, standaloneProjectsData],
   );
   const { data: featured } = useFeaturedProjects(activeType);
 
@@ -163,8 +164,8 @@ export function ExplorePage() {
   }, [combinedItems, metricsByProject]);
 
   const categories = APP_CATEGORIES;
-  const itemLabel = activeType === 'sdk' ? 'standalone projects' : 'projects';
-  const searchPlaceholder = activeType === 'sdk' ? 'Search standalone projects...' : 'Search projects...';
+  const itemLabel = activeType === PROJECT_TYPES.STANDALONE ? 'standalone projects' : 'projects';
+  const searchPlaceholder = activeType === PROJECT_TYPES.STANDALONE ? 'Search standalone projects...' : 'Search projects...';
 
   if (maintenance?.enabled) {
     return <MaintenanceScreen message={maintenance.message} />;
@@ -249,14 +250,14 @@ export function ExplorePage() {
             <span
               aria-hidden
               className={
-                activeType === 'sdk'
+                activeType === PROJECT_TYPES.STANDALONE
                   ? 'absolute inset-y-1 left-1 w-[calc((100%-0.75rem)/2)] translate-x-[calc(100%+0.25rem)] rounded-full bg-orange-500 dark:bg-brand-orange shadow-md shadow-black/25 transition-transform duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none'
                   : 'absolute inset-y-1 left-1 w-[calc((100%-0.75rem)/2)] translate-x-0 rounded-full bg-orange-500 dark:bg-brand-orange shadow-md shadow-black/25 transition-transform duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none'
               }
             />
             {([
-              { key: 'app' as const, label: 'Apps' },
-              { key: 'sdk' as const, label: 'Standalone' },
+              { key: PROJECT_TYPES.APP, label: 'Apps' },
+              { key: PROJECT_TYPES.STANDALONE, label: 'Standalone' },
             ]).map(tab => {
               const isActive = activeType === tab.key;
               return (
@@ -279,7 +280,7 @@ export function ExplorePage() {
           </div>
         </div>
         <p className="mt-3 text-center text-xs sm:text-sm text-neutral-400 dark:text-white/40">
-          {activeType === 'sdk' ? 'Run on your own machine' : 'Open in Sphere'}
+          {activeType === PROJECT_TYPES.STANDALONE ? 'Run on your own machine' : 'Open in Sphere'}
         </p>
       </section>
 

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -10,6 +10,7 @@ import { ProjectReviewsSection } from '../components/marketplace/ProjectReviewsS
 import { DiscordIcon, XIcon } from '../components/icons/SocialIcons';
 import { useDesktopState } from '../hooks/useDesktopState';
 import { useInstalledProjects } from '../hooks/useInstalledProjects';
+import { isHttpsUrl } from '../utils/isHttpsUrl';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 type MediaItem = { type: string; url: string; caption?: string };
@@ -356,7 +357,14 @@ export function ProjectPage() {
                 <button
                   type="button"
                   aria-label="copy install command"
-                  onClick={() => void navigator.clipboard.writeText(project.installCommand!)}
+                  onClick={() => {
+                    // navigator.clipboard is undefined in non-secure contexts and in
+                    // older browsers; the copy affordance is a convenience, so a
+                    // missing API or a rejected write should fail silently rather
+                    // than throw / surface an unhandled rejection.
+                    if (!navigator.clipboard) return;
+                    navigator.clipboard.writeText(project.installCommand!).catch(() => {});
+                  }}
                   className="text-neutral-500 dark:text-white/45 hover:text-neutral-900 dark:hover:text-white transition-colors cursor-pointer"
                 >
                   copy
@@ -393,9 +401,9 @@ export function ProjectPage() {
                 >
                   {installed ? <><Check className="w-4 h-4" /> On Desktop</> : <><Download className="w-4 h-4" /> Add to Desktop</>}
                 </button>
-                {project.repoUrl && (
+                {isHttpsUrl(project.repoUrl) && (
                   <a
-                    href={project.repoUrl}
+                    href={project.repoUrl!}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium border border-neutral-200 dark:border-white/8 text-neutral-600 dark:text-white/55 hover:text-neutral-900 dark:hover:text-white transition-colors"
@@ -424,8 +432,8 @@ export function ProjectPage() {
                 )}
               </>
             )}
-            {project.websiteUrl && (
-              <a href={project.websiteUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium border border-neutral-200 dark:border-white/8 text-neutral-600 dark:text-white/55 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-300 dark:hover:border-white/15 transition-colors">
+            {isHttpsUrl(project.websiteUrl) && (
+              <a href={project.websiteUrl!} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium border border-neutral-200 dark:border-white/8 text-neutral-600 dark:text-white/55 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-300 dark:hover:border-white/15 transition-colors">
                 Website <Globe className="w-3.5 h-3.5" />
               </a>
             )}

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -350,7 +350,7 @@ export function ProjectPage() {
             {/* Standalone (sdk) projects run outside Sphere — no in-app tab to
                 launch, so the install command is surfaced right above the
                 action row as a copyable terminal line. */}
-            {(project as unknown as Record<string, unknown>).type === 'sdk' && project.installCommand && (
+            {project.type === 'sdk' && project.installCommand && (
               <div className="flex items-center gap-2 mb-3 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-white/6 font-mono text-xs">
                 <span className="text-neutral-400 dark:text-white/30">$</span>
                 <span className="flex-1 truncate">{project.installCommand}</span>
@@ -372,7 +372,7 @@ export function ProjectPage() {
               </div>
             )}
           <div className="flex gap-2 shrink-0 flex-wrap">
-            {(project as unknown as Record<string, unknown>).type === 'skill' ? (
+            {project.type === 'skill' ? (
               /* Skill: Install to Astrid */
               <button
                 onClick={() => slug && toggle(slug)}
@@ -384,7 +384,7 @@ export function ProjectPage() {
               >
                 {installed ? <><Check className="w-4 h-4" /> Installed</> : <><Download className="w-4 h-4" /> Install to Astrid</>}
               </button>
-            ) : (project as unknown as Record<string, unknown>).type === 'sdk' ? (
+            ) : project.type === 'sdk' ? (
               /* Standalone (sdk): Add to Desktop, then the repository link
                  in place of "Open App" — the app tab launches its target in
                  a frame, and GitHub sends X-Frame-Options: deny, so a framed
@@ -446,11 +446,11 @@ export function ProjectPage() {
         <div className="flex gap-6 sm:gap-10 border-t border-neutral-200 dark:border-white/8 mt-6 pt-5">
           {[
             {
-              label: (project as unknown as Record<string, unknown>).type === 'skill' ? 'Installs' : 'Users',
+              label: project.type === 'skill' ? 'Installs' : 'Users',
               value: metrics?.uniqueUsers ?? project.stats.totalUsers,
               icon: Users,
             },
-            ...((project as unknown as Record<string, unknown>).type === 'skill'
+            ...(project.type === 'skill'
               ? []
               : [
                   { label: 'Quests',      value: metrics?.activeQuests     ?? project.stats.activeQuests,     icon: Target },

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -262,8 +262,13 @@ export function ProjectPage() {
 
   // appUrl reaches the wallet's most dangerous sink here: openTab persists it
   // into DesktopTab.url in localStorage, DesktopLayout turns it into
-  // iframeUrl, and IframeAgent renders <iframe src={activeUrl}> with no
-  // sandbox attribute. A non-https value must never be stored via openTab.
+  // iframeUrl, and IframeAgent renders <iframe src={activeUrl}>. The frame
+  // does carry a sandbox attribute (AGENT_IFRAME_SANDBOX), but it includes
+  // both allow-scripts and allow-same-origin, which together leave a framed
+  // page free to script in its own inherited origin — the sandbox grants no
+  // protection against a malicious `src` itself. The https gate is what
+  // protects the origin here, so a non-https value must never be stored via
+  // openTab.
   const handleAddToDesktop = () => {
     if (!project?.appUrl || !isHttpsUrl(project.appUrl)) return;
     openTab('custom', { url: project.appUrl, label: project.name });

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -224,11 +224,17 @@ export function ProjectPage() {
   const { data: project, isLoading } = useProject(slug ?? '', isPreview || undefined);
   const installed = slug ? isInstalled(slug) : false;
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-  // Standalone projects don't support quests — skip the fetch once we know
-  // that from the project's own data (before it loads, fetch optimistically
-  // rather than guess; `project` is undefined for one type, not the "no
-  // quests" type).
-  const { data: quests } = useProjectQuests(slug ?? '', !project || supportsQuests(project.type));
+  // Whether to even fetch quests, and whether to show the Quests section
+  // below, are gated on `!isStandalone`, NOT on `supportsQuests` — this is
+  // deliberately the wider check. `useProjectQuests`/the Quests section had
+  // no type gate at all before this project-type work started, so an `app`
+  // or `skill` project must keep fetching/showing quests exactly as before;
+  // only `standalone` (which structurally never has any) is new here. The
+  // narrower `supportsQuests` (app-only) governs the Quests/Completions stat
+  // TILES further down, which already excluded `skill` before this work —
+  // that's a different, pre-existing behaviour this file must not disturb.
+  // Fetch optimistically before `project` has loaded (unknown type yet).
+  const { data: quests } = useProjectQuests(slug ?? '', !project || !isStandalone(project));
   const { data: metrics } = useProjectMetrics(project?._id);
   // Quests are heavy content — collapsed by default, and collapsed per track.
   const [questsOpen, setQuestsOpen] = useState(false);
@@ -455,9 +461,11 @@ export function ProjectPage() {
               value: metrics?.uniqueUsers ?? project.stats.totalUsers,
               icon: Users,
             },
-            // Quest-derived stats — gate on capability (supportsQuests), not on
-            // type: standalone projects never have quests, so these would
-            // always read 0/0 for them.
+            // Quest-derived stats — gate on capability (supportsQuests: app
+            // only). This already excluded `skill` before this project-type
+            // work (skill shows "Installs" instead, above); supportsQuests
+            // reproduces that exactly while also fixing standalone, which
+            // this array previously forgot to exclude and so read 0/0.
             ...(supportsQuests(project.type)
               ? [
                   { label: 'Quests',      value: metrics?.activeQuests     ?? project.stats.activeQuests,     icon: Target },
@@ -506,9 +514,11 @@ export function ProjectPage() {
       {/* Quests — collapsed by default; expanded view groups quests by track,
           each track collapsed as well. Only active tracks reach this list
           (the API filters out quests of DRAFT/ENDED tracks). Gated on
-          supportsQuests: a standalone project's quest list is always empty,
-          but gate on the capability rather than relying on that emptiness. */}
-      {supportsQuests(project.type) && quests && quests.length > 0 && (
+          !isStandalone (see the useProjectQuests call above for why that's
+          the right predicate here, not supportsQuests) — a standalone
+          project's quest list is always empty, but gate on the type rather
+          than relying on that emptiness. */}
+      {!isStandalone(project) && quests && quests.length > 0 && (
         <section className="px-4 sm:px-6 pb-8">
           <div className="max-w-5xl mx-auto">
             <button

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -345,6 +345,24 @@ export function ProjectPage() {
           </div>
 
           {!isPreview && (
+          <div className="flex flex-col items-stretch sm:items-end shrink-0">
+            {/* Standalone (sdk) projects run outside Sphere — no in-app tab to
+                launch, so the install command is surfaced right above the
+                action row as a copyable terminal line. */}
+            {(project as unknown as Record<string, unknown>).type === 'sdk' && project.installCommand && (
+              <div className="flex items-center gap-2 mb-3 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-white/6 font-mono text-xs">
+                <span className="text-neutral-400 dark:text-white/30">$</span>
+                <span className="flex-1 truncate">{project.installCommand}</span>
+                <button
+                  type="button"
+                  aria-label="copy install command"
+                  onClick={() => void navigator.clipboard.writeText(project.installCommand!)}
+                  className="text-neutral-500 dark:text-white/45 hover:text-neutral-900 dark:hover:text-white transition-colors cursor-pointer"
+                >
+                  copy
+                </button>
+              </div>
+            )}
           <div className="flex gap-2 shrink-0 flex-wrap">
             {(project as unknown as Record<string, unknown>).type === 'skill' ? (
               /* Skill: Install to Astrid */
@@ -358,6 +376,34 @@ export function ProjectPage() {
               >
                 {installed ? <><Check className="w-4 h-4" /> Installed</> : <><Download className="w-4 h-4" /> Install to Astrid</>}
               </button>
+            ) : (project as unknown as Record<string, unknown>).type === 'sdk' ? (
+              /* Standalone (sdk): Add to Desktop, then the repository link
+                 in place of "Open App" — the app tab launches its target in
+                 a frame, and GitHub sends X-Frame-Options: deny, so a framed
+                 repository would render as a blank panel. A plain new-tab
+                 link avoids that entirely. */
+              <>
+                <button
+                  onClick={() => slug && toggle(slug)}
+                  className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-semibold text-sm transition-all cursor-pointer ${
+                    installed
+                      ? 'bg-green-500/15 text-green-500 border border-green-500/25 hover:bg-red-500/15 hover:text-red-400 hover:border-red-500/25'
+                      : 'bg-orange-500 dark:bg-brand-orange hover:bg-orange-600 dark:hover:bg-brand-orange-dark text-white shadow-lg shadow-orange-500/20'
+                  }`}
+                >
+                  {installed ? <><Check className="w-4 h-4" /> On Desktop</> : <><Download className="w-4 h-4" /> Add to Desktop</>}
+                </button>
+                {project.repoUrl && (
+                  <a
+                    href={project.repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium border border-neutral-200 dark:border-white/8 text-neutral-600 dark:text-white/55 hover:text-neutral-900 dark:hover:text-white transition-colors"
+                  >
+                    Open repository <ExternalLink className="w-3.5 h-3.5" />
+                  </a>
+                )}
+              </>
             ) : (
               /* App: Add to Desktop */
               <>
@@ -383,6 +429,7 @@ export function ProjectPage() {
                 Website <Globe className="w-3.5 h-3.5" />
               </a>
             )}
+          </div>
           </div>
           )}
         </div>

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -11,6 +11,7 @@ import { DiscordIcon, XIcon } from '../components/icons/SocialIcons';
 import { useDesktopState } from '../hooks/useDesktopState';
 import { useInstalledProjects } from '../hooks/useInstalledProjects';
 import { isHttpsUrl } from '../utils/isHttpsUrl';
+import { isStandalone, PROJECT_TYPES } from '../utils/isStandalone';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 type MediaItem = { type: string; url: string; caption?: string };
@@ -347,10 +348,10 @@ export function ProjectPage() {
 
           {!isPreview && (
           <div className="flex flex-col items-stretch sm:items-end shrink-0">
-            {/* Standalone (sdk) projects run outside Sphere — no in-app tab to
+            {/* Standalone projects run outside Sphere — no in-app tab to
                 launch, so the install command is surfaced right above the
                 action row as a copyable terminal line. */}
-            {project.type === 'sdk' && project.installCommand && (
+            {isStandalone(project) && project.installCommand && (
               <div className="flex items-center gap-2 mb-3 px-3 py-2 rounded-lg bg-neutral-100 dark:bg-white/6 font-mono text-xs">
                 <span className="text-neutral-400 dark:text-white/30">$</span>
                 <span className="flex-1 truncate">{project.installCommand}</span>
@@ -372,7 +373,7 @@ export function ProjectPage() {
               </div>
             )}
           <div className="flex gap-2 shrink-0 flex-wrap">
-            {project.type === 'skill' ? (
+            {project.type === PROJECT_TYPES.SKILL ? (
               /* Skill: Install to Astrid */
               <button
                 onClick={() => slug && toggle(slug)}
@@ -384,10 +385,10 @@ export function ProjectPage() {
               >
                 {installed ? <><Check className="w-4 h-4" /> Installed</> : <><Download className="w-4 h-4" /> Install to Astrid</>}
               </button>
-            ) : project.type === 'sdk' ? (
-              /* Standalone (sdk): Add to Desktop, then the repository link
-                 in place of "Open App" — the app tab launches its target in
-                 a frame, and GitHub sends X-Frame-Options: deny, so a framed
+            ) : isStandalone(project) ? (
+              /* Standalone: Add to Desktop, then the repository link in place
+                 of "Open App" — the app tab launches its target in a frame,
+                 and GitHub sends X-Frame-Options: deny, so a framed
                  repository would render as a blank panel. A plain new-tab
                  link avoids that entirely. */
               <>
@@ -446,11 +447,11 @@ export function ProjectPage() {
         <div className="flex gap-6 sm:gap-10 border-t border-neutral-200 dark:border-white/8 mt-6 pt-5">
           {[
             {
-              label: project.type === 'skill' ? 'Installs' : 'Users',
+              label: project.type === PROJECT_TYPES.SKILL ? 'Installs' : 'Users',
               value: metrics?.uniqueUsers ?? project.stats.totalUsers,
               icon: Users,
             },
-            ...(project.type === 'skill'
+            ...(project.type === PROJECT_TYPES.SKILL
               ? []
               : [
                   { label: 'Quests',      value: metrics?.activeQuests     ?? project.stats.activeQuests,     icon: Target },

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -260,8 +260,12 @@ export function ProjectPage() {
     caption: m.caption ?? undefined,
   }));
 
+  // appUrl reaches the wallet's most dangerous sink here: openTab persists it
+  // into DesktopTab.url in localStorage, DesktopLayout turns it into
+  // iframeUrl, and IframeAgent renders <iframe src={activeUrl}> with no
+  // sandbox attribute. A non-https value must never be stored via openTab.
   const handleAddToDesktop = () => {
-    if (!project?.appUrl) return;
+    if (!project?.appUrl || !isHttpsUrl(project.appUrl)) return;
     openTab('custom', { url: project.appUrl, label: project.name });
     navigate(`/agents/custom?url=${encodeURIComponent(project.appUrl)}`);
   };
@@ -436,7 +440,7 @@ export function ProjectPage() {
                 >
                   {installed ? <><Check className="w-4 h-4" /> On Desktop</> : <><Download className="w-4 h-4" /> Add to Desktop</>}
                 </button>
-                {project.appUrl && (
+                {isHttpsUrl(project.appUrl) && (
                   <button onClick={handleAddToDesktop} className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium border border-neutral-200 dark:border-white/8 text-neutral-600 dark:text-white/55 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-300 dark:hover:border-white/15 transition-colors cursor-pointer">
                     Open App <ExternalLink className="w-3.5 h-3.5" />
                   </button>

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -11,7 +11,7 @@ import { DiscordIcon, XIcon } from '../components/icons/SocialIcons';
 import { useDesktopState } from '../hooks/useDesktopState';
 import { useInstalledProjects } from '../hooks/useInstalledProjects';
 import { isHttpsUrl } from '../utils/isHttpsUrl';
-import { isStandalone, PROJECT_TYPES } from '../utils/isStandalone';
+import { isStandalone, supportsQuests, PROJECT_TYPES } from '../utils/isStandalone';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 type MediaItem = { type: string; url: string; caption?: string };
@@ -224,7 +224,11 @@ export function ProjectPage() {
   const { data: project, isLoading } = useProject(slug ?? '', isPreview || undefined);
   const installed = slug ? isInstalled(slug) : false;
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-  const { data: quests } = useProjectQuests(slug ?? '');
+  // Standalone projects don't support quests — skip the fetch once we know
+  // that from the project's own data (before it loads, fetch optimistically
+  // rather than guess; `project` is undefined for one type, not the "no
+  // quests" type).
+  const { data: quests } = useProjectQuests(slug ?? '', !project || supportsQuests(project.type));
   const { data: metrics } = useProjectMetrics(project?._id);
   // Quests are heavy content — collapsed by default, and collapsed per track.
   const [questsOpen, setQuestsOpen] = useState(false);
@@ -451,12 +455,15 @@ export function ProjectPage() {
               value: metrics?.uniqueUsers ?? project.stats.totalUsers,
               icon: Users,
             },
-            ...(project.type === PROJECT_TYPES.SKILL
-              ? []
-              : [
+            // Quest-derived stats — gate on capability (supportsQuests), not on
+            // type: standalone projects never have quests, so these would
+            // always read 0/0 for them.
+            ...(supportsQuests(project.type)
+              ? [
                   { label: 'Quests',      value: metrics?.activeQuests     ?? project.stats.activeQuests,     icon: Target },
                   { label: 'Completions', value: metrics?.totalCompletions ?? project.stats.totalCompletions, icon: Trophy },
-                ]),
+                ]
+              : []),
             ...(metrics && metrics.ratingCount > 0
               ? [{ label: `${metrics.positivePercent}% +`, value: metrics.ratingCount, icon: Star, isCount: true as const }]
               : []),
@@ -498,8 +505,10 @@ export function ProjectPage() {
 
       {/* Quests — collapsed by default; expanded view groups quests by track,
           each track collapsed as well. Only active tracks reach this list
-          (the API filters out quests of DRAFT/ENDED tracks). */}
-      {quests && quests.length > 0 && (
+          (the API filters out quests of DRAFT/ENDED tracks). Gated on
+          supportsQuests: a standalone project's quest list is always empty,
+          but gate on the capability rather than relying on that emptiness. */}
+      {supportsQuests(project.type) && quests && quests.length > 0 && (
         <section className="px-4 sm:px-6 pb-8">
           <div className="max-w-5xl mx-auto">
             <button

--- a/src/services/marketplaceApi.ts
+++ b/src/services/marketplaceApi.ts
@@ -3,7 +3,7 @@ const API_BASE = import.meta.env.VITE_SPHERE_API_URL ?? 'http://localhost:3001';
 // ── Types ─────────────────────────────────────────────────────────────
 export interface ProjectSummary {
   _id: string;
-  type?: 'app' | 'skill';
+  type: 'app' | 'skill' | 'sdk';
   slug: string;
   name: string;
   tagline: string;
@@ -16,6 +16,8 @@ export interface ProjectSummary {
   stats: { totalUsers: number; totalCompletions: number; activeQuests: number };
   appUrl?: string | null;
   websiteUrl?: string | null;
+  repoUrl: string | null;
+  installCommand: string | null;
   pricing?: { model: string; priceUCT: number | null };
 }
 
@@ -87,7 +89,7 @@ async function get<T>(path: string): Promise<T> {
 
 // ── API functions ─────────────────────────────────────────────────────
 export function fetchProjects(params?: {
-  type?: 'app' | 'skill';
+  type?: 'app' | 'skill' | 'sdk';
   category?: string;
   search?: string;
   sort?: string;
@@ -107,7 +109,7 @@ export function fetchProjects(params?: {
   return get(`${qs ? `?${qs}` : ''}`);
 }
 
-export function fetchFeaturedProjects(type?: 'app' | 'skill'): Promise<ProjectSummary[]> {
+export function fetchFeaturedProjects(type?: 'app' | 'skill' | 'sdk'): Promise<ProjectSummary[]> {
   return get(type ? `/featured?type=${type}` : '/featured');
 }
 

--- a/src/services/marketplaceApi.ts
+++ b/src/services/marketplaceApi.ts
@@ -1,9 +1,11 @@
+import type { ProjectType } from '../utils/isStandalone';
+
 const API_BASE = import.meta.env.VITE_SPHERE_API_URL ?? 'http://localhost:3001';
 
 // ── Types ─────────────────────────────────────────────────────────────
 export interface ProjectSummary {
   _id: string;
-  type: 'app' | 'skill' | 'sdk';
+  type: ProjectType;
   slug: string;
   name: string;
   tagline: string;
@@ -89,7 +91,7 @@ async function get<T>(path: string): Promise<T> {
 
 // ── API functions ─────────────────────────────────────────────────────
 export function fetchProjects(params?: {
-  type?: 'app' | 'skill' | 'sdk';
+  type?: ProjectType;
   category?: string;
   search?: string;
   sort?: string;
@@ -109,7 +111,7 @@ export function fetchProjects(params?: {
   return get(`${qs ? `?${qs}` : ''}`);
 }
 
-export function fetchFeaturedProjects(type?: 'app' | 'skill' | 'sdk'): Promise<ProjectSummary[]> {
+export function fetchFeaturedProjects(type?: ProjectType): Promise<ProjectSummary[]> {
   return get(type ? `/featured?type=${type}` : '/featured');
 }
 

--- a/src/services/userApi.ts
+++ b/src/services/userApi.ts
@@ -6,6 +6,7 @@
  * Sphere wallet signs in-process via sphere.signMessage().
  */
 import type { Sphere } from '@unicitylabs/sphere-sdk';
+import type { ProjectType } from '../utils/isStandalone';
 
 const API_BASE = import.meta.env.VITE_SPHERE_API_URL ?? 'http://localhost:3001';
 const JWT_KEY = 'sphere_user_jwt';
@@ -20,7 +21,7 @@ export interface InstalledApp {
   pinned:       boolean;
   project: {
     _id:         string;
-    type:        'app' | 'skill' | 'sdk';
+    type:        ProjectType;
     slug:        string;
     name:        string;
     tagline:     string;

--- a/src/services/userApi.ts
+++ b/src/services/userApi.ts
@@ -20,7 +20,7 @@ export interface InstalledApp {
   pinned:       boolean;
   project: {
     _id:         string;
-    type:        'app' | 'skill';
+    type:        'app' | 'skill' | 'sdk';
     slug:        string;
     name:        string;
     tagline:     string;
@@ -30,6 +30,7 @@ export interface InstalledApp {
     accentColor: string;
     appUrl:      string | null;
     websiteUrl:  string | null;
+    repoUrl:     string | null;
     pricing?:    { model: string; priceUCT: number | null };
   };
 }

--- a/src/utils/isHttpsUrl.ts
+++ b/src/utils/isHttpsUrl.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns true only when `value` is a string that parses as a URL whose
+ * protocol is exactly `https:`.
+ *
+ * Gates any anchor `href` sourced from server data (e.g. a marketplace
+ * project's `repoUrl` / `websiteUrl`) before it is rendered. This app is the
+ * wallet — the same origin that holds the user's keys — so a stored
+ * `javascript:` (or any other non-https) value reaching an `href` would
+ * execute in that origin on click. Server-side validation
+ * (`assertRepoUrl` in sphere-api) is not a substitute for this: the client
+ * must not trust the server completely, since admin/migration/seed paths
+ * can write values that skip the usual validated write path.
+ */
+export function isHttpsUrl(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/isStandalone.ts
+++ b/src/utils/isStandalone.ts
@@ -34,3 +34,24 @@ export type ProjectType = (typeof PROJECT_TYPES)[keyof typeof PROJECT_TYPES];
 export function isStandalone(project: { type: ProjectType }): boolean {
   return project.type === PROJECT_TYPES.STANDALONE;
 }
+
+/**
+ * True when projects of this `type` participate in the quest system — have
+ * quests, quest-derived stats (active quests / completions), etc.
+ *
+ * This is a capability question, not a "where does it run" question: gate
+ * quest-derived UI on `supportsQuests`, never on `isStandalone`/`!isStandalone`
+ * or a direct `type === ...` check, even though today the two happen to
+ * disagree only for `standalone`. The distinction matters because the two
+ * questions can diverge independently in the future (e.g. a fourth type that
+ * launches in-app but still has no quests, or a standalone type that gains
+ * quest support) — code asking "does this have quests" should say so, rather
+ * than encoding that meaning as "is this not standalone".
+ *
+ * `app` and `skill` both support quests; `standalone` does not. Accepts
+ * `null`/`undefined` so call sites don't need an extra guard while a
+ * project's own data is still loading.
+ */
+export function supportsQuests(type: ProjectType | null | undefined): boolean {
+  return type === PROJECT_TYPES.APP || type === PROJECT_TYPES.SKILL;
+}

--- a/src/utils/isStandalone.ts
+++ b/src/utils/isStandalone.ts
@@ -1,0 +1,36 @@
+/**
+ * Canonical project `type` values, matching what sphere-api's marketplace
+ * endpoints return in the `type` field of a project record.
+ *
+ * These constants do NOT protect against drift with the backend: there is no
+ * shared package between this repo and sphere-api (or the other repos that
+ * mirror the same value — sphere-backoffice, sphere-dev-portal). Each repo
+ * holds its own copy of this string. If the API ever changes what it sends,
+ * this file has to be updated by hand to match.
+ */
+export const PROJECT_TYPES = {
+  APP: 'app',
+  SKILL: 'skill',
+  STANDALONE: 'standalone',
+} as const;
+
+export type ProjectType = (typeof PROJECT_TYPES)[keyof typeof PROJECT_TYPES];
+
+/**
+ * True when a project's `type` is `PROJECT_TYPES.STANDALONE` — it has a
+ * public source repository and is cloned/installed and run on the user's own
+ * machine, rather than opened inside Sphere (unlike `app` and `skill`, which
+ * both launch in-app).
+ *
+ * Centralised so the handful of call sites that branch on this (ProjectPage's
+ * action row, the desktop shortcut's launch/context-menu logic, both
+ * marketplace card badges) share one place that knows the meaning of the type
+ * union, instead of repeating the same string comparison — and so a future
+ * fourth type doesn't need to be reasoned about at every call site by hand.
+ *
+ * Takes a minimal shape rather than the full `ProjectSummary` so it also
+ * accepts the narrower inline project shape on `InstalledApp` (userApi.ts).
+ */
+export function isStandalone(project: { type: ProjectType }): boolean {
+  return project.type === PROJECT_TYPES.STANDALONE;
+}

--- a/src/utils/isStandalone.ts
+++ b/src/utils/isStandalone.ts
@@ -30,9 +30,15 @@ export type ProjectType = (typeof PROJECT_TYPES)[keyof typeof PROJECT_TYPES];
  *
  * Takes a minimal shape rather than the full `ProjectSummary` so it also
  * accepts the narrower inline project shape on `InstalledApp` (userApi.ts).
+ *
+ * `type` is nullable even though `ProjectSummary.type` is declared required:
+ * the schema default is `app`, and documents created before the `type` field
+ * existed have none at all, so an absent type reaching this function at
+ * runtime (despite what the TS type claims) must resolve the same way the
+ * rest of the codebase treats it — as `app`, which is never standalone.
  */
-export function isStandalone(project: { type: ProjectType }): boolean {
-  return project.type === PROJECT_TYPES.STANDALONE;
+export function isStandalone(project: { type: ProjectType | null | undefined }): boolean {
+  return (project.type ?? PROJECT_TYPES.APP) === PROJECT_TYPES.STANDALONE;
 }
 
 /**
@@ -41,17 +47,22 @@ export function isStandalone(project: { type: ProjectType }): boolean {
  *
  * This is a capability question, not a "where does it run" question: gate
  * quest-derived UI on `supportsQuests`, never on `isStandalone`/`!isStandalone`
- * or a direct `type === ...` check, even though today the two happen to
- * disagree only for `standalone`. The distinction matters because the two
- * questions can diverge independently in the future (e.g. a fourth type that
- * launches in-app but still has no quests, or a standalone type that gains
- * quest support) — code asking "does this have quests" should say so, rather
- * than encoding that meaning as "is this not standalone".
+ * or a direct `type === ...` check. The distinction matters because the two
+ * questions diverge on `skill`: a skill is a capability invoked by Astrid,
+ * not something that runs a quest campaign, so it does NOT support quests —
+ * even though it isn't standalone either (it launches in-app, same as
+ * `app`). `isStandalone(skill)` is `false` and `supportsQuests(skill)` is
+ * also `false`, but for unrelated reasons; do not assume `!isStandalone` and
+ * `supportsQuests` are interchangeable.
  *
- * `app` and `skill` both support quests; `standalone` does not. Accepts
- * `null`/`undefined` so call sites don't need an extra guard while a
- * project's own data is still loading.
+ * ONLY `app` supports quests. `type` is nullable: the schema default is
+ * `app` and pre-migration documents may have no `type` at all, so an absent
+ * type must fall back to `app` here too — treating it as "not app" would
+ * make untyped (i.e. actually-app) projects silently stop supporting quests,
+ * the same category of bug already corrected once for `skill`. This also
+ * covers a project's own data still being loaded, when a call site hasn't
+ * got a `type` to read yet at all.
  */
 export function supportsQuests(type: ProjectType | null | undefined): boolean {
-  return type === PROJECT_TYPES.APP || type === PROJECT_TYPES.SKILL;
+  return (type ?? PROJECT_TYPES.APP) === PROJECT_TYPES.APP;
 }

--- a/tests/unit/components/desktopLayoutPersistedUrlGate.test.tsx
+++ b/tests/unit/components/desktopLayoutPersistedUrlGate.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * The write side (InstalledProjectIcon, ProjectPage) gates a project's
+ * appUrl/websiteUrl with isHttpsUrl before ever calling openTab. That closes
+ * the write side only: `openTabs` is restored from localStorage by
+ * useDesktopState's loadState(), which is user-writable via devtools
+ * regardless of what our code writes, and a tab persisted BEFORE those
+ * write-side gates existed would otherwise still reach the iframe unchanged
+ * on every load from now on. DesktopLayout's renderTabContent must re-check
+ * `tab.url` with isHttpsUrl before turning it into IframeAgent's `iframeUrl`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useState, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { STORAGE_KEYS } from '../../../src/config/storageKeys';
+import type { AgentConfig } from '../../../src/config/activities';
+
+// jsdom does not implement window.matchMedia; useDesktopState/useUIState read
+// it at module load (defaultState.walletOpen) and on every render, so it must
+// be stubbed before those modules — and DesktopLayout, which imports them —
+// are evaluated. vi.hoisted runs before the imports below.
+vi.hoisted(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+// Everything except useDesktopState/useUIState is stubbed: this test exercises
+// the real renderTabContent gate, not the chrome around it. IframeAgent is
+// replaced with a thin probe that exposes what `src` it would have received.
+vi.mock('../../../src/components/desktop/TabBar', () => ({ TabBar: () => null }));
+vi.mock('../../../src/components/desktop/DesktopShortcuts', () => ({ DesktopShortcuts: () => null }));
+vi.mock('../../../src/components/chat/ChatSection', () => ({ ChatSection: () => null }));
+vi.mock('../../../src/components/chat/dm/DMChatSection', () => ({ DMChatSection: () => null }));
+vi.mock('../../../src/components/chat/group/GroupChatSection', () => ({ GroupChatSection: () => null }));
+vi.mock('../../../src/components/wallet/WalletPanel', () => ({ WalletPanel: () => null }));
+vi.mock('../../../src/components/agents/WalletRequiredBlocker', () => ({
+  WalletRequiredBlocker: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('../../../src/components/activity', () => ({ ActivityTicker: () => null }));
+vi.mock('../../../src/components/layout/Footer', () => ({ Footer: () => null }));
+vi.mock('../../../src/components/agents/IframeAgent', () => ({
+  IframeAgent: ({ agent }: { agent: AgentConfig }) => (
+    <iframe data-testid="mock-iframe" src={agent.iframeUrl} title={agent.name} />
+  ),
+}));
+
+import { DesktopLayout } from '../../../src/components/desktop/DesktopLayout';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const [qc] = useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// Writes a persisted desktop-state exactly like loadState() reads it —
+// simulating a tab that reached localStorage before the write-side gate
+// existed (or one hand-edited via devtools), bypassing openTab entirely.
+function persistTab(url: string) {
+  localStorage.setItem(
+    STORAGE_KEYS.DESKTOP_STATE,
+    JSON.stringify({
+      openTabs: [{ id: 'custom-1', appId: 'custom', label: 'Persisted', url }],
+      activeTabId: 'custom-1',
+    }),
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('DesktopLayout — https gate on a persisted tab.url read from localStorage', () => {
+  it('does not render an iframe for a persisted javascript: url, and shows the custom-URL prompt instead', () => {
+    persistTab('javascript:alert(1)');
+    render(<DesktopLayout />, { wrapper: Wrapper });
+
+    expect(screen.queryByTestId('mock-iframe')).toBeNull();
+    // Same fallback a custom tab with no URL yet already shows — not a new
+    // empty state invented for this gate.
+    expect(screen.getByText('Load Custom URL')).toBeTruthy();
+  });
+
+  it('does not render an iframe for a persisted http:// url, and shows the custom-URL prompt instead', () => {
+    persistTab('http://evil.example.com');
+    render(<DesktopLayout />, { wrapper: Wrapper });
+
+    expect(screen.queryByTestId('mock-iframe')).toBeNull();
+    expect(screen.getByText('Load Custom URL')).toBeTruthy();
+  });
+
+  it('still renders the iframe for a normal persisted https:// url', () => {
+    persistTab('https://app.example.com');
+    render(<DesktopLayout />, { wrapper: Wrapper });
+
+    const iframe = screen.getByTestId('mock-iframe') as HTMLIFrameElement;
+    expect(iframe.getAttribute('src')).toBe('https://app.example.com');
+  });
+});

--- a/tests/unit/components/featuredProjectCardQuestsProp.test.tsx
+++ b/tests/unit/components/featuredProjectCardQuestsProp.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mock
+// referenced inside the factory below must itself be created via vi.hoisted
+// to avoid a TDZ ReferenceError.
+const { onFeaturedProjectCard } = vi.hoisted(() => ({
+  onFeaturedProjectCard: vi.fn(),
+}));
+
+// See projectCardQuestsProp.test.tsx: sphere-ui's FeaturedProjectCard also
+// defaults an absent `quests` to 0 and renders it unconditionally, so the
+// prop itself has to be captured directly rather than read off rendered text.
+vi.mock('@unicitylabs/sphere-ui', () => ({
+  FeaturedProjectCard: (props: Record<string, unknown>) => {
+    onFeaturedProjectCard(props);
+    return null;
+  },
+}));
+
+import { FeaturedProjectCard } from '../../../src/components/marketplace/FeaturedProjectCard';
+import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
+
+const BASE_PROJECT: ProjectSummary = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: PROJECT_TYPES.APP, tagline: 't', logoUrl: '',
+  bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: true,
+  appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
+  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 7 },
+};
+
+function renderCard(over: Partial<ProjectSummary>) {
+  return render(
+    <MemoryRouter>
+      <FeaturedProjectCard project={{ ...BASE_PROJECT, ...over }} />
+    </MemoryRouter>,
+  );
+}
+
+describe('FeaturedProjectCard passes the quest count only when the project type supports quests', () => {
+  it('passes the real quest count for an app project', () => {
+    renderCard({ type: PROJECT_TYPES.APP });
+    expect(onFeaturedProjectCard).toHaveBeenCalledWith(expect.objectContaining({ quests: 7 }));
+  });
+
+  it('omits the quest count for a standalone project', () => {
+    renderCard({ type: PROJECT_TYPES.STANDALONE });
+    expect(onFeaturedProjectCard).toHaveBeenCalledWith(expect.objectContaining({ quests: undefined }));
+  });
+
+  it('omits the quest count for a skill project', () => {
+    renderCard({ type: PROJECT_TYPES.SKILL });
+    expect(onFeaturedProjectCard).toHaveBeenCalledWith(expect.objectContaining({ quests: undefined }));
+  });
+});

--- a/tests/unit/components/featuredProjectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/featuredProjectCardStandaloneBadge.test.tsx
@@ -30,4 +30,9 @@ describe('FeaturedProjectCard standalone badge', () => {
     renderCard({ type: 'app', appUrl: 'https://app.example.com' });
     expect(screen.queryByText('STANDALONE')).toBeNull();
   });
+
+  it('does not show the badge for a skill featured project', () => {
+    renderCard({ type: 'skill' });
+    expect(screen.queryByText('STANDALONE')).toBeNull();
+  });
 });

--- a/tests/unit/components/featuredProjectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/featuredProjectCardStandaloneBadge.test.tsx
@@ -4,9 +4,10 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { FeaturedProjectCard } from '../../../src/components/marketplace/FeaturedProjectCard';
 import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
 
 const BASE_PROJECT: ProjectSummary = {
-  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'app', tagline: 't', logoUrl: '',
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: PROJECT_TYPES.APP, tagline: 't', logoUrl: '',
   bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: true,
   appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
   stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
@@ -21,18 +22,18 @@ function renderCard(over: Partial<ProjectSummary>) {
 }
 
 describe('FeaturedProjectCard standalone badge', () => {
-  it('shows a STANDALONE badge for an sdk featured project', () => {
-    renderCard({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+  it('shows a STANDALONE badge for a standalone featured project', () => {
+    renderCard({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'https://github.com/owner/repo' });
     expect(screen.getByText('STANDALONE')).toBeTruthy();
   });
 
   it('does not show the badge for an app featured project', () => {
-    renderCard({ type: 'app', appUrl: 'https://app.example.com' });
+    renderCard({ type: PROJECT_TYPES.APP, appUrl: 'https://app.example.com' });
     expect(screen.queryByText('STANDALONE')).toBeNull();
   });
 
   it('does not show the badge for a skill featured project', () => {
-    renderCard({ type: 'skill' });
+    renderCard({ type: PROJECT_TYPES.SKILL });
     expect(screen.queryByText('STANDALONE')).toBeNull();
   });
 });

--- a/tests/unit/components/featuredProjectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/featuredProjectCardStandaloneBadge.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { FeaturedProjectCard } from '../../../src/components/marketplace/FeaturedProjectCard';
+import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+
+const BASE_PROJECT: ProjectSummary = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'app', tagline: 't', logoUrl: '',
+  bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: true,
+  appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
+  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
+};
+
+function renderCard(over: Partial<ProjectSummary>) {
+  return render(
+    <MemoryRouter>
+      <FeaturedProjectCard project={{ ...BASE_PROJECT, ...over }} />
+    </MemoryRouter>,
+  );
+}
+
+describe('FeaturedProjectCard standalone badge', () => {
+  it('shows a STANDALONE badge for an sdk featured project', () => {
+    renderCard({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+    expect(screen.getByText('STANDALONE')).toBeTruthy();
+  });
+
+  it('does not show the badge for an app featured project', () => {
+    renderCard({ type: 'app', appUrl: 'https://app.example.com' });
+    expect(screen.queryByText('STANDALONE')).toBeNull();
+  });
+});

--- a/tests/unit/components/installedProjectIconSdk.test.tsx
+++ b/tests/unit/components/installedProjectIconSdk.test.tsx
@@ -143,3 +143,53 @@ describe('InstalledProjectIcon context menu — type branches first', () => {
     expect(screen.queryByRole('button', { name: 'Open in Tab' })).toBeNull();
   });
 });
+
+// appUrl reaches the most dangerous sink in this app: openTab persists it into
+// DesktopTab.url in localStorage, DesktopLayout turns it into iframeUrl, and
+// IframeAgent renders <iframe src={activeUrl}> with no sandbox attribute. A
+// `javascript:` (or any non-https) initial src on an unsandboxed iframe runs
+// with the parent's (wallet's) origin — this is script execution holding the
+// user's keys, not merely a bad link. Both the click launcher and the context
+// menu's "Open in Tab" entry must gate appUrl exactly like repoUrl/websiteUrl
+// already are above.
+describe('InstalledProjectIcon — https gate on the appUrl -> openTab/iframe sink', () => {
+  it('does not open a tab and falls back to the project page for a javascript: appUrl', () => {
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, type: PROJECT_TYPES.APP, appUrl: 'javascript:alert(1)', websiteUrl: null };
+    const { container } = render(<InstalledProjectIcon project={project} />);
+    fireEvent.click(container.querySelector('button')!);
+    expect(openTab).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/apps/agent-guild');
+  });
+
+  it('does not open a tab and falls back to the project page for an http:// appUrl', () => {
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, type: PROJECT_TYPES.APP, appUrl: 'http://app.example.com', websiteUrl: null };
+    const { container } = render(<InstalledProjectIcon project={project} />);
+    fireEvent.click(container.querySelector('button')!);
+    expect(openTab).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/apps/agent-guild');
+  });
+
+  it('renders no Open in Tab entry and never calls openTab for a javascript: appUrl', () => {
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, type: PROJECT_TYPES.APP, appUrl: 'javascript:alert(1)' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open in Tab' })).toBeNull();
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it('renders no Open in Tab entry and never calls openTab for an http:// appUrl', () => {
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, type: PROJECT_TYPES.APP, appUrl: 'http://app.example.com' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open in Tab' })).toBeNull();
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it('still offers Open in Tab and calls openTab for a normal https:// appUrl', () => {
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, type: PROJECT_TYPES.APP, appUrl: 'https://app.example.com' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Open in Tab' }));
+    expect(openTab).toHaveBeenCalledWith('custom', { url: 'https://app.example.com', label: 'Agent Guild' });
+  });
+});

--- a/tests/unit/components/installedProjectIconSdk.test.tsx
+++ b/tests/unit/components/installedProjectIconSdk.test.tsx
@@ -146,8 +146,11 @@ describe('InstalledProjectIcon context menu — type branches first', () => {
 
 // appUrl reaches the most dangerous sink in this app: openTab persists it into
 // DesktopTab.url in localStorage, DesktopLayout turns it into iframeUrl, and
-// IframeAgent renders <iframe src={activeUrl}> with no sandbox attribute. A
-// `javascript:` (or any non-https) initial src on an unsandboxed iframe runs
+// IframeAgent renders <iframe src={activeUrl}>. The frame does carry a
+// sandbox attribute, but it includes allow-scripts + allow-same-origin, which
+// together leave a framed page free to script in its own inherited origin —
+// the sandbox grants no protection against a malicious `src` itself. A
+// `javascript:` (or any non-https) initial src reaching that iframe runs
 // with the parent's (wallet's) origin — this is script execution holding the
 // user's keys, not merely a bad link. Both the click launcher and the context
 // menu's "Open in Tab" entry must gate appUrl exactly like repoUrl/websiteUrl

--- a/tests/unit/components/installedProjectIconSdk.test.tsx
+++ b/tests/unit/components/installedProjectIconSdk.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 // vi.mock factories are hoisted above regular top-level `const`s, so the mocks
 // referenced inside the factories below must themselves be created via
@@ -58,5 +58,87 @@ describe('InstalledProjectIcon for a standalone project', () => {
     const { container } = render(<InstalledProjectIcon project={app} />);
     fireEvent.click(container.querySelector('button')!);
     expect(openTab).toHaveBeenCalledWith('custom', { url: 'https://app.example.com', label: 'Agent Guild' });
+  });
+});
+
+// This app is the wallet — the origin holding the user's keys — so a project
+// field (repoUrl/websiteUrl) reaching window.open is script execution if it
+// is ever anything other than https. window.open gets no JSX sanitisation at
+// all, unlike an <a href>. Server-side validation is not a substitute: admin/
+// migration/seed paths can write values that skip the normal validated write
+// path, so the client must gate again before it ever reaches a nav sink.
+function openContextMenu() {
+  fireEvent.click(screen.getByLabelText('Open context menu'));
+}
+
+describe('InstalledProjectIcon context menu — https gate on window.open sinks', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it('renders no Open repository entry and never calls window.open for a javascript: repoUrl', () => {
+    const project: ProjectSummary = { ...SDK_PROJECT, repoUrl: 'javascript:alert(1)' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open repository' })).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders no Open repository entry and never calls window.open for an http:// repoUrl', () => {
+    const project: ProjectSummary = { ...SDK_PROJECT, repoUrl: 'http://github.com/owner/repo' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open repository' })).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('still opens a real https repository, with noopener,noreferrer', () => {
+    render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    openContextMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Open repository' }));
+    expect(openSpy).toHaveBeenCalledWith('https://github.com/owner/repo', '_blank', 'noopener,noreferrer');
+  });
+
+  it('renders no Open Website entry and never calls window.open for a javascript: websiteUrl', () => {
+    const project: ProjectSummary = { ...SDK_PROJECT, websiteUrl: 'javascript:alert(1)' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open Website' })).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders no Open Website entry and never calls window.open for an http:// websiteUrl', () => {
+    const project: ProjectSummary = { ...SDK_PROJECT, websiteUrl: 'http://aliemul.github.io/agent-guild/' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open Website' })).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('still opens a real https website, with noopener,noreferrer', () => {
+    render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    openContextMenu();
+    fireEvent.click(screen.getByRole('button', { name: 'Open Website' }));
+    expect(openSpy).toHaveBeenCalledWith('https://aliemul.github.io/agent-guild/', '_blank', 'noopener,noreferrer');
+  });
+});
+
+describe('InstalledProjectIcon context menu — type branches first', () => {
+  it('never offers Open in Tab for an sdk project even with a stray appUrl and no repoUrl', () => {
+    // Without repoUrl, the old `type === 'sdk' && repoUrl ? [repo] : appUrl ? [tab] : []`
+    // ternary falls through to the appUrl branch and frames it — even though
+    // launchUrl already forbids framing for sdk unconditionally. Branching on
+    // type first must make the menu agree by construction, not by repoUrl
+    // happening to be set.
+    const project: ProjectSummary = { ...SDK_PROJECT, repoUrl: null, appUrl: 'https://app.example.com' };
+    render(<InstalledProjectIcon project={project} />);
+    openContextMenu();
+    expect(screen.queryByRole('button', { name: 'Open in Tab' })).toBeNull();
   });
 });

--- a/tests/unit/components/installedProjectIconSdk.test.tsx
+++ b/tests/unit/components/installedProjectIconSdk.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mocks
+// referenced inside the factories below must themselves be created via
+// vi.hoisted to avoid a TDZ ReferenceError.
+const { openTab, navigate, ping } = vi.hoisted(() => ({
+  openTab:  vi.fn(),
+  navigate: vi.fn(),
+  ping:     vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useNavigate: () => navigate };
+});
+vi.mock('../../../src/hooks/useDesktopState', () => ({
+  useDesktopState: () => ({ openTab }),
+}));
+vi.mock('../../../src/hooks/useInstalledProjects', () => ({
+  useInstalledProjects: () => ({ uninstall: vi.fn(), ping }),
+}));
+
+import { InstalledProjectIcon } from '../../../src/components/desktop/InstalledProjectIcon';
+
+const SDK_PROJECT = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'sdk',
+  repoUrl: 'https://github.com/owner/repo', appUrl: null,
+  // A website IS set: this is the case the current `appUrl ?? websiteUrl`
+  // fallback would happily frame.
+  websiteUrl: 'https://aliemul.github.io/agent-guild/',
+  logoUrl: null, accentColor: '#FF6F00', category: 'tool', tagline: 't', tags: [],
+  installCommand: null,
+  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0, rating: 0, ratingCount: 0 },
+} as any;
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('InstalledProjectIcon for a standalone project', () => {
+  it('opens the project page rather than an in-app tab', () => {
+    const { container } = render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    fireEvent.click(container.querySelector('button')!);
+    expect(openTab).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/apps/agent-guild');
+  });
+
+  it('never routes a repository through the in-app frame', () => {
+    const { container } = render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    fireEvent.click(container.querySelector('button')!);
+    for (const [arg] of navigate.mock.calls) {
+      expect(String(arg)).not.toContain('/agents/custom');
+    }
+  });
+
+  it('still opens an app project in a tab', () => {
+    const app = { ...SDK_PROJECT, type: 'app', appUrl: 'https://app.example.com', repoUrl: null };
+    const { container } = render(<InstalledProjectIcon project={app} />);
+    fireEvent.click(container.querySelector('button')!);
+    expect(openTab).toHaveBeenCalledWith('custom', { url: 'https://app.example.com', label: 'Agent Guild' });
+  });
+});

--- a/tests/unit/components/installedProjectIconSdk.test.tsx
+++ b/tests/unit/components/installedProjectIconSdk.test.tsx
@@ -22,17 +22,18 @@ vi.mock('../../../src/hooks/useInstalledProjects', () => ({
 }));
 
 import { InstalledProjectIcon } from '../../../src/components/desktop/InstalledProjectIcon';
+import type { ProjectSummary } from '../../../src/services/marketplaceApi';
 
-const SDK_PROJECT = {
+const SDK_PROJECT: ProjectSummary = {
   _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'sdk',
   repoUrl: 'https://github.com/owner/repo', appUrl: null,
   // A website IS set: this is the case the current `appUrl ?? websiteUrl`
   // fallback would happily frame.
   websiteUrl: 'https://aliemul.github.io/agent-guild/',
-  logoUrl: null, accentColor: '#FF6F00', category: 'tool', tagline: 't', tags: [],
-  installCommand: null,
-  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0, rating: 0, ratingCount: 0 },
-} as any;
+  logoUrl: '', accentColor: '#FF6F00', category: 'tool', tagline: 't', tags: [],
+  installCommand: null, featured: false,
+  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
+};
 
 beforeEach(() => { vi.clearAllMocks(); });
 
@@ -53,7 +54,7 @@ describe('InstalledProjectIcon for a standalone project', () => {
   });
 
   it('still opens an app project in a tab', () => {
-    const app = { ...SDK_PROJECT, type: 'app', appUrl: 'https://app.example.com', repoUrl: null };
+    const app: ProjectSummary = { ...SDK_PROJECT, type: 'app', appUrl: 'https://app.example.com', repoUrl: null };
     const { container } = render(<InstalledProjectIcon project={app} />);
     fireEvent.click(container.querySelector('button')!);
     expect(openTab).toHaveBeenCalledWith('custom', { url: 'https://app.example.com', label: 'Agent Guild' });

--- a/tests/unit/components/installedProjectIconSdk.test.tsx
+++ b/tests/unit/components/installedProjectIconSdk.test.tsx
@@ -23,9 +23,10 @@ vi.mock('../../../src/hooks/useInstalledProjects', () => ({
 
 import { InstalledProjectIcon } from '../../../src/components/desktop/InstalledProjectIcon';
 import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
 
-const SDK_PROJECT: ProjectSummary = {
-  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'sdk',
+const STANDALONE_PROJECT: ProjectSummary = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: PROJECT_TYPES.STANDALONE,
   repoUrl: 'https://github.com/owner/repo', appUrl: null,
   // A website IS set: this is the case the current `appUrl ?? websiteUrl`
   // fallback would happily frame.
@@ -39,14 +40,14 @@ beforeEach(() => { vi.clearAllMocks(); });
 
 describe('InstalledProjectIcon for a standalone project', () => {
   it('opens the project page rather than an in-app tab', () => {
-    const { container } = render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    const { container } = render(<InstalledProjectIcon project={STANDALONE_PROJECT} />);
     fireEvent.click(container.querySelector('button')!);
     expect(openTab).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith('/apps/agent-guild');
   });
 
   it('never routes a repository through the in-app frame', () => {
-    const { container } = render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    const { container } = render(<InstalledProjectIcon project={STANDALONE_PROJECT} />);
     fireEvent.click(container.querySelector('button')!);
     for (const [arg] of navigate.mock.calls) {
       expect(String(arg)).not.toContain('/agents/custom');
@@ -54,7 +55,7 @@ describe('InstalledProjectIcon for a standalone project', () => {
   });
 
   it('still opens an app project in a tab', () => {
-    const app: ProjectSummary = { ...SDK_PROJECT, type: 'app', appUrl: 'https://app.example.com', repoUrl: null };
+    const app: ProjectSummary = { ...STANDALONE_PROJECT, type: PROJECT_TYPES.APP, appUrl: 'https://app.example.com', repoUrl: null };
     const { container } = render(<InstalledProjectIcon project={app} />);
     fireEvent.click(container.querySelector('button')!);
     expect(openTab).toHaveBeenCalledWith('custom', { url: 'https://app.example.com', label: 'Agent Guild' });
@@ -83,7 +84,7 @@ describe('InstalledProjectIcon context menu — https gate on window.open sinks'
   });
 
   it('renders no Open repository entry and never calls window.open for a javascript: repoUrl', () => {
-    const project: ProjectSummary = { ...SDK_PROJECT, repoUrl: 'javascript:alert(1)' };
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, repoUrl: 'javascript:alert(1)' };
     render(<InstalledProjectIcon project={project} />);
     openContextMenu();
     expect(screen.queryByRole('button', { name: 'Open repository' })).toBeNull();
@@ -91,7 +92,7 @@ describe('InstalledProjectIcon context menu — https gate on window.open sinks'
   });
 
   it('renders no Open repository entry and never calls window.open for an http:// repoUrl', () => {
-    const project: ProjectSummary = { ...SDK_PROJECT, repoUrl: 'http://github.com/owner/repo' };
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, repoUrl: 'http://github.com/owner/repo' };
     render(<InstalledProjectIcon project={project} />);
     openContextMenu();
     expect(screen.queryByRole('button', { name: 'Open repository' })).toBeNull();
@@ -99,14 +100,14 @@ describe('InstalledProjectIcon context menu — https gate on window.open sinks'
   });
 
   it('still opens a real https repository, with noopener,noreferrer', () => {
-    render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    render(<InstalledProjectIcon project={STANDALONE_PROJECT} />);
     openContextMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Open repository' }));
     expect(openSpy).toHaveBeenCalledWith('https://github.com/owner/repo', '_blank', 'noopener,noreferrer');
   });
 
   it('renders no Open Website entry and never calls window.open for a javascript: websiteUrl', () => {
-    const project: ProjectSummary = { ...SDK_PROJECT, websiteUrl: 'javascript:alert(1)' };
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, websiteUrl: 'javascript:alert(1)' };
     render(<InstalledProjectIcon project={project} />);
     openContextMenu();
     expect(screen.queryByRole('button', { name: 'Open Website' })).toBeNull();
@@ -114,7 +115,7 @@ describe('InstalledProjectIcon context menu — https gate on window.open sinks'
   });
 
   it('renders no Open Website entry and never calls window.open for an http:// websiteUrl', () => {
-    const project: ProjectSummary = { ...SDK_PROJECT, websiteUrl: 'http://aliemul.github.io/agent-guild/' };
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, websiteUrl: 'http://aliemul.github.io/agent-guild/' };
     render(<InstalledProjectIcon project={project} />);
     openContextMenu();
     expect(screen.queryByRole('button', { name: 'Open Website' })).toBeNull();
@@ -122,7 +123,7 @@ describe('InstalledProjectIcon context menu — https gate on window.open sinks'
   });
 
   it('still opens a real https website, with noopener,noreferrer', () => {
-    render(<InstalledProjectIcon project={SDK_PROJECT} />);
+    render(<InstalledProjectIcon project={STANDALONE_PROJECT} />);
     openContextMenu();
     fireEvent.click(screen.getByRole('button', { name: 'Open Website' }));
     expect(openSpy).toHaveBeenCalledWith('https://aliemul.github.io/agent-guild/', '_blank', 'noopener,noreferrer');
@@ -130,13 +131,13 @@ describe('InstalledProjectIcon context menu — https gate on window.open sinks'
 });
 
 describe('InstalledProjectIcon context menu — type branches first', () => {
-  it('never offers Open in Tab for an sdk project even with a stray appUrl and no repoUrl', () => {
-    // Without repoUrl, the old `type === 'sdk' && repoUrl ? [repo] : appUrl ? [tab] : []`
+  it('never offers Open in Tab for a standalone project even with a stray appUrl and no repoUrl', () => {
+    // Without repoUrl, the old `type === 'standalone' && repoUrl ? [repo] : appUrl ? [tab] : []`
     // ternary falls through to the appUrl branch and frames it — even though
-    // launchUrl already forbids framing for sdk unconditionally. Branching on
-    // type first must make the menu agree by construction, not by repoUrl
+    // launchUrl already forbids framing for standalone unconditionally. Branching
+    // on type first must make the menu agree by construction, not by repoUrl
     // happening to be set.
-    const project: ProjectSummary = { ...SDK_PROJECT, repoUrl: null, appUrl: 'https://app.example.com' };
+    const project: ProjectSummary = { ...STANDALONE_PROJECT, repoUrl: null, appUrl: 'https://app.example.com' };
     render(<InstalledProjectIcon project={project} />);
     openContextMenu();
     expect(screen.queryByRole('button', { name: 'Open in Tab' })).toBeNull();

--- a/tests/unit/components/projectCardQuestsProp.test.tsx
+++ b/tests/unit/components/projectCardQuestsProp.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mock
+// referenced inside the factory below must itself be created via vi.hoisted
+// to avoid a TDZ ReferenceError.
+const { onMarketplaceProjectCard } = vi.hoisted(() => ({
+  onMarketplaceProjectCard: vi.fn(),
+}));
+
+// sphere-ui's MarketplaceProjectCard defaults an absent `quests` prop to 0
+// and renders the "Active quests" stat unconditionally either way (no
+// `quests !== undefined &&` guard in its source, only a `= 0` default param)
+// — so the only way to assert what THIS repo's wrapper actually decided to
+// pass is to capture the prop directly, rather than reading the rendered
+// text (which looks identical for `undefined` and `0`).
+vi.mock('@unicitylabs/sphere-ui', () => ({
+  MarketplaceProjectCard: (props: Record<string, unknown>) => {
+    onMarketplaceProjectCard(props);
+    return null;
+  },
+}));
+vi.mock('../../../src/hooks/useInstalledProjects', () => ({
+  useInstalledProjects: () => ({ isInstalled: () => false, toggle: vi.fn() }),
+}));
+
+import { ProjectCard } from '../../../src/components/marketplace/ProjectCard';
+import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
+
+const BASE_PROJECT: ProjectSummary = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: PROJECT_TYPES.APP, tagline: 't', logoUrl: '',
+  bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: false,
+  appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
+  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 7 },
+};
+
+function renderCard(over: Partial<ProjectSummary>) {
+  return render(
+    <MemoryRouter>
+      <ProjectCard project={{ ...BASE_PROJECT, ...over }} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ProjectCard passes the quest count only when the project type supports quests', () => {
+  it('passes the real quest count for an app project', () => {
+    renderCard({ type: PROJECT_TYPES.APP });
+    expect(onMarketplaceProjectCard).toHaveBeenCalledWith(expect.objectContaining({ quests: 7 }));
+  });
+
+  it('omits the quest count for a standalone project', () => {
+    renderCard({ type: PROJECT_TYPES.STANDALONE });
+    expect(onMarketplaceProjectCard).toHaveBeenCalledWith(expect.objectContaining({ quests: undefined }));
+  });
+
+  it('omits the quest count for a skill project', () => {
+    renderCard({ type: PROJECT_TYPES.SKILL });
+    expect(onMarketplaceProjectCard).toHaveBeenCalledWith(expect.objectContaining({ quests: undefined }));
+  });
+});

--- a/tests/unit/components/projectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/projectCardStandaloneBadge.test.tsx
@@ -41,4 +41,9 @@ describe('ProjectCard standalone badge', () => {
     renderCard({ type: 'app', appUrl: 'https://app.example.com' });
     expect(screen.queryByText('STANDALONE')).toBeNull();
   });
+
+  it('does not show the badge for a skill project', () => {
+    renderCard({ type: 'skill' });
+    expect(screen.queryByText('STANDALONE')).toBeNull();
+  });
 });

--- a/tests/unit/components/projectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/projectCardStandaloneBadge.test.tsx
@@ -13,9 +13,10 @@ vi.mock('../../../src/hooks/useInstalledProjects', () => ({
 
 import { ProjectCard } from '../../../src/components/marketplace/ProjectCard';
 import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
 
 const BASE_PROJECT: ProjectSummary = {
-  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'app', tagline: 't', logoUrl: '',
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: PROJECT_TYPES.APP, tagline: 't', logoUrl: '',
   bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: false,
   appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
   stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
@@ -32,18 +33,18 @@ function renderCard(over: Partial<ProjectSummary>) {
 }
 
 describe('ProjectCard standalone badge', () => {
-  it('shows a STANDALONE badge for an sdk project', () => {
-    renderCard({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+  it('shows a STANDALONE badge for a standalone project', () => {
+    renderCard({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'https://github.com/owner/repo' });
     expect(screen.getByText('STANDALONE')).toBeTruthy();
   });
 
   it('does not show the badge for an app project', () => {
-    renderCard({ type: 'app', appUrl: 'https://app.example.com' });
+    renderCard({ type: PROJECT_TYPES.APP, appUrl: 'https://app.example.com' });
     expect(screen.queryByText('STANDALONE')).toBeNull();
   });
 
   it('does not show the badge for a skill project', () => {
-    renderCard({ type: 'skill' });
+    renderCard({ type: PROJECT_TYPES.SKILL });
     expect(screen.queryByText('STANDALONE')).toBeNull();
   });
 });

--- a/tests/unit/components/projectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/projectCardStandaloneBadge.test.tsx
@@ -12,17 +12,18 @@ vi.mock('../../../src/hooks/useInstalledProjects', () => ({
 }));
 
 import { ProjectCard } from '../../../src/components/marketplace/ProjectCard';
+import type { ProjectSummary } from '../../../src/services/marketplaceApi';
 
-const BASE_PROJECT = {
-  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', tagline: 't', logoUrl: null,
+const BASE_PROJECT: ProjectSummary = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', type: 'app', tagline: 't', logoUrl: '',
   bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: false,
   appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
   stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
-} as any;
+};
 
 beforeEach(() => { vi.clearAllMocks(); });
 
-function renderCard(over: Record<string, unknown>) {
+function renderCard(over: Partial<ProjectSummary>) {
   return render(
     <MemoryRouter>
       <ProjectCard project={{ ...BASE_PROJECT, ...over }} />

--- a/tests/unit/components/projectCardStandaloneBadge.test.tsx
+++ b/tests/unit/components/projectCardStandaloneBadge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mock
+// referenced inside the factory below must itself be created via vi.hoisted
+// to avoid a TDZ ReferenceError.
+const { toggle } = vi.hoisted(() => ({ toggle: vi.fn() }));
+
+vi.mock('../../../src/hooks/useInstalledProjects', () => ({
+  useInstalledProjects: () => ({ isInstalled: () => false, toggle }),
+}));
+
+import { ProjectCard } from '../../../src/components/marketplace/ProjectCard';
+
+const BASE_PROJECT = {
+  _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', tagline: 't', logoUrl: null,
+  bannerUrl: null, accentColor: '#FF6F00', category: 'tool', tags: [], featured: false,
+  appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
+  stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
+} as any;
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+function renderCard(over: Record<string, unknown>) {
+  return render(
+    <MemoryRouter>
+      <ProjectCard project={{ ...BASE_PROJECT, ...over }} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ProjectCard standalone badge', () => {
+  it('shows a STANDALONE badge for an sdk project', () => {
+    renderCard({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+    expect(screen.getByText('STANDALONE')).toBeTruthy();
+  });
+
+  it('does not show the badge for an app project', () => {
+    renderCard({ type: 'app', appUrl: 'https://app.example.com' });
+    expect(screen.queryByText('STANDALONE')).toBeNull();
+  });
+});

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
 
 // vi.mock factories are hoisted above regular top-level `const`s, so the mocks
 // referenced inside the factory below must themselves be created via vi.hoisted
@@ -40,7 +41,7 @@ const renderExplore = () => render(<MemoryRouter><ExplorePage /></MemoryRouter>)
 function buildProject(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
   return {
     _id: 'project-1',
-    type: 'app',
+    type: PROJECT_TYPES.APP,
     slug: 'demo-project',
     name: 'Demo Project',
     tagline: 'A demo project for tests',
@@ -72,15 +73,15 @@ beforeEach(() => {
 describe('Explore type tabs', () => {
   it('starts on Apps', () => {
     renderExplore();
-    expect(useProjects).toHaveBeenCalledWith({ type: 'app' });
-    expect(useFeaturedProjects).toHaveBeenCalledWith('app');
+    expect(useProjects).toHaveBeenCalledWith({ type: PROJECT_TYPES.APP });
+    expect(useFeaturedProjects).toHaveBeenCalledWith(PROJECT_TYPES.APP);
   });
 
   it('switches the query to standalone projects', () => {
     renderExplore();
     fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
-    expect(useProjects).toHaveBeenLastCalledWith({ type: 'sdk' });
-    expect(useFeaturedProjects).toHaveBeenLastCalledWith('sdk');
+    expect(useProjects).toHaveBeenLastCalledWith({ type: PROJECT_TYPES.STANDALONE });
+    expect(useFeaturedProjects).toHaveBeenLastCalledWith(PROJECT_TYPES.STANDALONE);
   });
 
   // The category filter and the search box are CLIENT-side state — never
@@ -121,8 +122,8 @@ describe('Explore type tabs', () => {
   // both broke once already (the row was accidentally wired to the active
   // tab's own list instead of the combined one).
   it('computes hero totals from both lists combined, unaffected by the active tab, and never zero while the catalog has content', () => {
-    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'sdk' }) =>
-      params?.type === 'sdk'
+    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'standalone' }) =>
+      params?.type === PROJECT_TYPES.STANDALONE
         ? { data: { projects: [] }, isLoading: false }
         : {
             data: {
@@ -151,8 +152,8 @@ describe('Explore type tabs', () => {
   });
 
   it('uses singular wording for a hero stat only when its value is exactly one', () => {
-    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'sdk' }) =>
-      params?.type === 'sdk'
+    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'standalone' }) =>
+      params?.type === PROJECT_TYPES.STANDALONE
         ? { data: { projects: [] }, isLoading: false }
         : {
             data: {
@@ -180,8 +181,8 @@ describe('Explore type tabs', () => {
   });
 
   it('uses plural wording once a hero stat is more than one (and for zero)', () => {
-    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'sdk' }) =>
-      params?.type === 'sdk'
+    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'standalone' }) =>
+      params?.type === PROJECT_TYPES.STANDALONE
         ? { data: { projects: [] }, isLoading: false }
         : {
             data: {

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -41,4 +41,26 @@ describe('Explore type tabs', () => {
     expect(useProjects).toHaveBeenLastCalledWith({ type: 'sdk' });
     expect(useFeaturedProjects).toHaveBeenLastCalledWith('sdk');
   });
+
+  // The category filter and the search box are CLIENT-side state — never
+  // passed to useProjects/useFeaturedProjects — so the two tests above would
+  // still pass even if the tab handler stopped resetting them. Assert on the
+  // rendered DOM instead of the hooks to actually catch that regression.
+  it('clears the search box and category filter when switching tabs', () => {
+    renderExplore();
+
+    const search = screen.getByPlaceholderText('Search projects...') as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'agent' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Tools' }));
+
+    // Sanity: state was actually set before the tab switch.
+    expect(search.value).toBe('agent');
+    expect(screen.getByRole('button', { name: 'Tools' }).className).toContain('bg-orange-500');
+
+    fireEvent.click(screen.getByRole('button', { name: /Standalone/i }));
+
+    expect(search.value).toBe('');
+    expect(screen.getByRole('button', { name: 'All' }).className).toContain('bg-orange-500');
+    expect(screen.getByRole('button', { name: 'Tools' }).className).not.toContain('bg-orange-500');
+  });
 });

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mocks
+// referenced inside the factory below must themselves be created via vi.hoisted
+// to avoid a TDZ ReferenceError when ExplorePage's import of useMarketplace is
+// resolved.
+const { useProjects, useFeaturedProjects } = vi.hoisted(() => ({
+  useProjects: vi.fn(() => ({ data: { projects: [] }, isLoading: false })),
+  useFeaturedProjects: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock('../../../src/hooks/useMarketplace', () => ({
+  useProjects,
+  useFeaturedProjects,
+  useProjectMetricsBatch: () => ({ data: {} }),
+}));
+vi.mock('../../../src/hooks/useMaintenanceStatus', () => ({
+  useMaintenanceStatus: () => ({ data: { enabled: false } }),
+}));
+
+import { MemoryRouter } from 'react-router-dom';
+import { ExplorePage } from '../../../src/pages/ExplorePage';
+
+// The page links out (project cards, the dev-portal CTA), so a router has to be
+// present even though the mocked queries return no projects.
+const renderExplore = () => render(<MemoryRouter><ExplorePage /></MemoryRouter>);
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('Explore type tabs', () => {
+  it('starts on Apps', () => {
+    renderExplore();
+    expect(useProjects).toHaveBeenCalledWith({ type: 'app' });
+    expect(useFeaturedProjects).toHaveBeenCalledWith('app');
+  });
+
+  it('switches the query to standalone projects', () => {
+    renderExplore();
+    fireEvent.click(screen.getByRole('button', { name: /Standalone/i }));
+    expect(useProjects).toHaveBeenLastCalledWith({ type: 'sdk' });
+    expect(useFeaturedProjects).toHaveBeenLastCalledWith('sdk');
+  });
+});

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import type { ProjectSummary } from '../../../src/services/marketplaceApi';
 
 // vi.mock factories are hoisted above regular top-level `const`s, so the mocks
 // referenced inside the factory below must themselves be created via vi.hoisted
@@ -18,6 +19,13 @@ vi.mock('../../../src/hooks/useMarketplace', () => ({
 vi.mock('../../../src/hooks/useMaintenanceStatus', () => ({
   useMaintenanceStatus: () => ({ data: { enabled: false } }),
 }));
+// ProjectCard reaches into useInstalledProjects -> useSphereContext, which
+// throws outside a SphereProvider. The type-switch header (this file's actual
+// subject) doesn't depend on card internals, so stub the card out rather than
+// wiring a full wallet context just to satisfy a grid of tiles.
+vi.mock('../../../src/components/marketplace/ProjectCard', () => ({
+  ProjectCard: () => null,
+}));
 
 import { MemoryRouter } from 'react-router-dom';
 import { ExplorePage } from '../../../src/pages/ExplorePage';
@@ -26,7 +34,40 @@ import { ExplorePage } from '../../../src/pages/ExplorePage';
 // present even though the mocked queries return no projects.
 const renderExplore = () => render(<MemoryRouter><ExplorePage /></MemoryRouter>);
 
-beforeEach(() => { vi.clearAllMocks(); });
+// A complete ProjectSummary fixture — loose `as any` fixtures were hiding real
+// shape errors (missing required fields) elsewhere, so build the full shape
+// and let callers override just what a given test cares about.
+function buildProject(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
+  return {
+    _id: 'project-1',
+    type: 'app',
+    slug: 'demo-project',
+    name: 'Demo Project',
+    tagline: 'A demo project for tests',
+    logoUrl: 'https://example.com/logo.png',
+    bannerUrl: null,
+    category: 'tool',
+    tags: [],
+    accentColor: '#FF6F00',
+    featured: false,
+    stats: { totalUsers: 0, totalCompletions: 0, activeQuests: 0 },
+    appUrl: null,
+    websiteUrl: null,
+    repoUrl: null,
+    installCommand: null,
+    pricing: undefined,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // clearAllMocks resets call history but not a previously-installed
+  // mockImplementation, so re-pin the default here — tests that need
+  // different data call mockImplementation themselves.
+  useProjects.mockImplementation(() => ({ data: { projects: [] }, isLoading: false }));
+  useFeaturedProjects.mockImplementation(() => ({ data: [] }));
+});
 
 describe('Explore type tabs', () => {
   it('starts on Apps', () => {
@@ -37,7 +78,7 @@ describe('Explore type tabs', () => {
 
   it('switches the query to standalone projects', () => {
     renderExplore();
-    fireEvent.click(screen.getByRole('button', { name: /Standalone/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
     expect(useProjects).toHaveBeenLastCalledWith({ type: 'sdk' });
     expect(useFeaturedProjects).toHaveBeenLastCalledWith('sdk');
   });
@@ -57,10 +98,106 @@ describe('Explore type tabs', () => {
     expect(search.value).toBe('agent');
     expect(screen.getByRole('button', { name: 'Tools' }).className).toContain('bg-orange-500');
 
-    fireEvent.click(screen.getByRole('button', { name: /Standalone/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
 
     expect(search.value).toBe('');
     expect(screen.getByRole('button', { name: 'All' }).className).toContain('bg-orange-500');
     expect(screen.getByRole('button', { name: 'Tools' }).className).not.toContain('bg-orange-500');
+  });
+
+  it('changes the subline copy with the selected type', () => {
+    renderExplore();
+
+    expect(screen.getByText('Open in Sphere')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
+
+    expect(screen.getByText('Run on your own machine')).toBeDefined();
+  });
+
+  // Regression pin: the hero totals describe the WHOLE catalog (apps +
+  // standalone combined). They must read identically no matter which tab is
+  // active, and must never read zero while the combined catalog has content —
+  // both broke once already (the row was accidentally wired to the active
+  // tab's own list instead of the combined one).
+  it('computes hero totals from both lists combined, unaffected by the active tab, and never zero while the catalog has content', () => {
+    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'sdk' }) =>
+      params?.type === 'sdk'
+        ? { data: { projects: [] }, isLoading: false }
+        : {
+            data: {
+              projects: [
+                buildProject({ _id: '1', slug: 'one', category: 'game', stats: { totalUsers: 10, totalCompletions: 0, activeQuests: 0 } }),
+              ],
+            },
+            isLoading: false,
+          },
+    );
+
+    renderExplore();
+
+    const before = screen.getByTestId('hero-stat-projects').textContent;
+    expect(before).toContain('1');
+    expect(screen.getByTestId('hero-stat-users').textContent).toContain('10');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
+
+    // Standalone has zero projects of its own, but the hero row describes the
+    // whole catalog (1 app + 0 standalone = 1), so it must read exactly the
+    // same as before the switch — not zero, not different.
+    expect(screen.getByTestId('hero-stat-projects').textContent).toBe(before);
+    expect(screen.getByTestId('hero-stat-projects').textContent).not.toContain('0');
+    expect(screen.getByTestId('hero-stat-users').textContent).toContain('10');
+  });
+
+  it('uses singular wording for a hero stat only when its value is exactly one', () => {
+    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'sdk' }) =>
+      params?.type === 'sdk'
+        ? { data: { projects: [] }, isLoading: false }
+        : {
+            data: {
+              projects: [
+                buildProject({ _id: '1', slug: 'one', category: 'game', stats: { totalUsers: 1, totalCompletions: 0, activeQuests: 0 } }),
+              ],
+            },
+            isLoading: false,
+          },
+    );
+
+    renderExplore();
+
+    // One project, one user, one category — every stat must be singular.
+    const projectsText = screen.getByTestId('hero-stat-projects').textContent!;
+    const usersText = screen.getByTestId('hero-stat-users').textContent!;
+    const categoriesText = screen.getByTestId('hero-stat-categories').textContent!;
+
+    expect(projectsText).toContain('Total Project');
+    expect(projectsText).not.toContain('Total Projects');
+    expect(usersText).toContain('Total User');
+    expect(usersText).not.toContain('Total Users');
+    expect(categoriesText).toContain('Category');
+    expect(categoriesText).not.toContain('Categories');
+  });
+
+  it('uses plural wording once a hero stat is more than one (and for zero)', () => {
+    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'sdk' }) =>
+      params?.type === 'sdk'
+        ? { data: { projects: [] }, isLoading: false }
+        : {
+            data: {
+              projects: [
+                buildProject({ _id: '1', slug: 'one', category: 'game', stats: { totalUsers: 5, totalCompletions: 0, activeQuests: 0 } }),
+                buildProject({ _id: '2', slug: 'two', category: 'tool', stats: { totalUsers: 5, totalCompletions: 0, activeQuests: 0 } }),
+              ],
+            },
+            isLoading: false,
+          },
+    );
+
+    renderExplore();
+
+    expect(screen.getByTestId('hero-stat-projects').textContent).toContain('Total Projects');
+    expect(screen.getByTestId('hero-stat-users').textContent).toContain('Total Users');
+    expect(screen.getByTestId('hero-stat-categories').textContent).toContain('Categories');
   });
 });

--- a/tests/unit/pages/projectPageQuestsGate.test.tsx
+++ b/tests/unit/pages/projectPageQuestsGate.test.tsx
@@ -30,10 +30,11 @@ vi.mock('../../../src/components/marketplace/ProjectReviewsSection', () => ({
 import { ProjectPage } from '../../../src/pages/ProjectPage';
 import { PROJECT_TYPES, type ProjectType } from '../../../src/utils/isStandalone';
 
-// Non-empty on purpose: the point of this suite is that the section must be
-// gated on the project's TYPE (supportsQuests), not on the query happening to
-// come back empty for standalone. If the gate were `quests.length > 0` alone
-// (today's pre-fix behaviour), this quest would render for every type.
+// Non-empty on purpose: the point of this suite is that visibility is gated
+// on the project's TYPE, not on the query happening to come back empty. If a
+// gate were `quests.length > 0` alone (pre-fix behaviour for the section,
+// still true today for standalone in practice), this quest would render for
+// every type regardless of what it should show.
 const QUEST: ProjectQuest = {
   _id: 'q1', title: 'Say hi', description: 'Say hi in chat', points: 10,
   platform: null, imageUrl: null, tags: [], questType: 'CHECKIN', track: null,
@@ -60,13 +61,24 @@ function renderProjectPage(type: ProjectType) {
 
 beforeEach(() => { vi.clearAllMocks(); });
 
-describe('ProjectPage quests section — gated on supportsQuests, not on emptiness', () => {
+// The Quests SECTION (this list) and the fetch that feeds it are gated on
+// !isStandalone, NOT on supportsQuests — they had no type gate at all before
+// this project-type work, so app/skill must keep showing/fetching quests
+// exactly as before; only standalone (new) is hidden/skipped. See
+// ProjectPage.tsx's comment on the useProjectQuests call for the full
+// reasoning. The Quests/Completions STAT TILES (next describe block) are a
+// different, narrower gate (supportsQuests, app-only) that already excluded
+// skill before this work.
+describe('ProjectPage quests section — gated on !isStandalone (app/skill unchanged, standalone hidden)', () => {
   it('shows the Quests section for an app project when quests exist', () => {
     renderProjectPage(PROJECT_TYPES.APP);
     expect(screen.getByRole('heading', { name: /Quests/i })).toBeTruthy();
   });
 
-  it('shows the Quests section for a skill project when quests exist', () => {
+  // Pin: this is the site that would have silently regressed if the section
+  // were gated on supportsQuests(app-only) instead — skill showed quests
+  // unconditionally before this project-type work, and must keep doing so.
+  it('shows the Quests section for a skill project when quests exist (unchanged from before this work)', () => {
     renderProjectPage(PROJECT_TYPES.SKILL);
     expect(screen.getByRole('heading', { name: /Quests/i })).toBeTruthy();
   });
@@ -75,31 +87,57 @@ describe('ProjectPage quests section — gated on supportsQuests, not on emptine
   // standalone project's page from rendering quest content if the quests
   // query ever returned data (stale cache, a future backend response, etc.) —
   // the mock here always returns a quest regardless of type, so this only
-  // passes if ProjectPage itself gates the section on the type's capability.
+  // passes if ProjectPage itself gates the section on the project's type.
   it('hides the Quests section for a standalone project even though the quests query returns data', () => {
     renderProjectPage(PROJECT_TYPES.STANDALONE);
     expect(screen.queryByRole('heading', { name: /Quests/i })).toBeNull();
   });
-
-  it('hides the Quests/Completions stat tiles for a standalone project', () => {
-    renderProjectPage(PROJECT_TYPES.STANDALONE);
-    expect(screen.queryByText('Completions')).toBeNull();
-  });
-
-  it('shows the Quests/Completions stat tiles for an app project', () => {
-    renderProjectPage(PROJECT_TYPES.APP);
-    expect(screen.getByText('Completions')).toBeTruthy();
-  });
 });
 
-describe('ProjectPage skips the quests fetch once it knows the type has no quests', () => {
+describe('ProjectPage quests fetch — enabled for app/skill (unchanged), disabled for standalone', () => {
+  it('keeps the quests query enabled for an app project', () => {
+    renderProjectPage(PROJECT_TYPES.APP);
+    expect(useProjectQuests).toHaveBeenLastCalledWith('agent-guild', true);
+  });
+
+  // Pin: before this project-type work the fetch was fully unconditional —
+  // a refactor that disabled it for skill (e.g. by reusing the app-only
+  // supportsQuests predicate here) would be exactly the kind of silent
+  // capability/type mix-up this task exists to prevent.
+  it('keeps the quests query enabled for a skill project (unchanged from before this work)', () => {
+    renderProjectPage(PROJECT_TYPES.SKILL);
+    expect(useProjectQuests).toHaveBeenLastCalledWith('agent-guild', true);
+  });
+
   it('disables the quests query for a standalone project', () => {
     renderProjectPage(PROJECT_TYPES.STANDALONE);
     expect(useProjectQuests).toHaveBeenLastCalledWith('agent-guild', false);
   });
+});
 
-  it('keeps the quests query enabled for an app project', () => {
+// The Quests/Completions stat tiles are gated on supportsQuests (app only).
+// This already excluded skill before this project-type work (skill shows
+// "Installs" instead, and never showed these two tiles) — supportsQuests
+// reproduces that exactly, while also fixing standalone, which the old
+// `type === 'skill' ? [] : [...]` check forgot to exclude.
+describe('ProjectPage Quests/Completions stat tiles — gated on supportsQuests (app only)', () => {
+  it('shows the stat tiles for an app project', () => {
     renderProjectPage(PROJECT_TYPES.APP);
-    expect(useProjectQuests).toHaveBeenLastCalledWith('agent-guild', true);
+    expect(screen.getByText('Completions')).toBeTruthy();
+  });
+
+  // Pin: this is the exact regression the owner caught — an earlier version
+  // of supportsQuests (true for app OR skill) made these tiles appear for
+  // skill, where they were hidden before. A skill is a capability invoked by
+  // Astrid, not something that runs a quest campaign, so this must stay
+  // hidden.
+  it('hides the stat tiles for a skill project (matches its behaviour from before this work)', () => {
+    renderProjectPage(PROJECT_TYPES.SKILL);
+    expect(screen.queryByText('Completions')).toBeNull();
+  });
+
+  it('hides the stat tiles for a standalone project', () => {
+    renderProjectPage(PROJECT_TYPES.STANDALONE);
+    expect(screen.queryByText('Completions')).toBeNull();
   });
 });

--- a/tests/unit/pages/projectPageQuestsGate.test.tsx
+++ b/tests/unit/pages/projectPageQuestsGate.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import type { ProjectQuest } from '../../../src/services/marketplaceApi';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mocks
+// referenced inside the factory below must themselves be created via
+// vi.hoisted to avoid a TDZ ReferenceError when ProjectPage's import of
+// useMarketplace is resolved.
+const { useProject, useProjectQuests } = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useProjectQuests: vi.fn(),
+}));
+
+vi.mock('../../../src/hooks/useMarketplace', () => ({
+  useProject:         (...args: unknown[]) => useProject(...args),
+  useProjectQuests:   (...args: unknown[]) => useProjectQuests(...args),
+  useProjectMetrics:  () => ({ data: undefined }),
+}));
+vi.mock('../../../src/hooks/useDesktopState', () => ({
+  useDesktopState: () => ({ openTab: vi.fn() }),
+}));
+vi.mock('../../../src/hooks/useInstalledProjects', () => ({
+  useInstalledProjects: () => ({ isInstalled: () => false, toggle: vi.fn() }),
+}));
+vi.mock('../../../src/components/marketplace/ProjectReviewsSection', () => ({
+  ProjectReviewsSection: () => null,
+}));
+
+import { ProjectPage } from '../../../src/pages/ProjectPage';
+import { PROJECT_TYPES, type ProjectType } from '../../../src/utils/isStandalone';
+
+// Non-empty on purpose: the point of this suite is that the section must be
+// gated on the project's TYPE (supportsQuests), not on the query happening to
+// come back empty for standalone. If the gate were `quests.length > 0` alone
+// (today's pre-fix behaviour), this quest would render for every type.
+const QUEST: ProjectQuest = {
+  _id: 'q1', title: 'Say hi', description: 'Say hi in chat', points: 10,
+  platform: null, imageUrl: null, tags: [], questType: 'CHECKIN', track: null,
+};
+
+function renderProjectPage(type: ProjectType) {
+  useProject.mockReturnValue({
+    data: {
+      _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', tagline: 't', description: 'd',
+      type, appUrl: 'https://app.example.com', websiteUrl: null, repoUrl: null, installCommand: null,
+      logoUrl: null, bannerUrl: null, accentColor: '#FF6F00', category: 'tool',
+      tags: [], media: [], socialLinks: {},
+      stats: { totalUsers: 0, activeQuests: 1, totalCompletions: 3, rating: 0, ratingCount: 0 },
+    },
+    isLoading: false,
+  });
+  useProjectQuests.mockReturnValue({ data: [QUEST] });
+  return render(
+    <MemoryRouter initialEntries={['/apps/agent-guild']}>
+      <Routes><Route path="/apps/:slug" element={<ProjectPage />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('ProjectPage quests section — gated on supportsQuests, not on emptiness', () => {
+  it('shows the Quests section for an app project when quests exist', () => {
+    renderProjectPage(PROJECT_TYPES.APP);
+    expect(screen.getByRole('heading', { name: /Quests/i })).toBeTruthy();
+  });
+
+  it('shows the Quests section for a skill project when quests exist', () => {
+    renderProjectPage(PROJECT_TYPES.SKILL);
+    expect(screen.getByRole('heading', { name: /Quests/i })).toBeTruthy();
+  });
+
+  // The regression this whole task is about: nothing previously stopped a
+  // standalone project's page from rendering quest content if the quests
+  // query ever returned data (stale cache, a future backend response, etc.) —
+  // the mock here always returns a quest regardless of type, so this only
+  // passes if ProjectPage itself gates the section on the type's capability.
+  it('hides the Quests section for a standalone project even though the quests query returns data', () => {
+    renderProjectPage(PROJECT_TYPES.STANDALONE);
+    expect(screen.queryByRole('heading', { name: /Quests/i })).toBeNull();
+  });
+
+  it('hides the Quests/Completions stat tiles for a standalone project', () => {
+    renderProjectPage(PROJECT_TYPES.STANDALONE);
+    expect(screen.queryByText('Completions')).toBeNull();
+  });
+
+  it('shows the Quests/Completions stat tiles for an app project', () => {
+    renderProjectPage(PROJECT_TYPES.APP);
+    expect(screen.getByText('Completions')).toBeTruthy();
+  });
+});
+
+describe('ProjectPage skips the quests fetch once it knows the type has no quests', () => {
+  it('disables the quests query for a standalone project', () => {
+    renderProjectPage(PROJECT_TYPES.STANDALONE);
+    expect(useProjectQuests).toHaveBeenLastCalledWith('agent-guild', false);
+  });
+
+  it('keeps the quests query enabled for an app project', () => {
+    renderProjectPage(PROJECT_TYPES.APP);
+    expect(useProjectQuests).toHaveBeenLastCalledWith('agent-guild', true);
+  });
+});

--- a/tests/unit/pages/projectPageSdkActions.test.tsx
+++ b/tests/unit/pages/projectPageSdkActions.test.tsx
@@ -70,3 +70,41 @@ describe('ProjectPage actions for a standalone project', () => {
     expect(screen.queryByText(/Open repository/i)).toBeNull();
   });
 });
+
+// Both repoUrl and websiteUrl are server-supplied strings rendered straight
+// into an anchor's href on this page, in the wallet's own origin. A stored
+// `javascript:` (or otherwise non-https) value must never reach the DOM as
+// a clickable link — render nothing rather than a dangerous link.
+describe('ProjectPage renders only vetted https:// links', () => {
+  it('does not render Open repository for a javascript: repoUrl', () => {
+    renderProjectPage({ type: 'sdk', repoUrl: 'javascript:alert(1)' });
+    expect(screen.queryByRole('link', { name: /Open repository/i })).toBeNull();
+  });
+
+  it('does not render Open repository for an http:// repoUrl', () => {
+    renderProjectPage({ type: 'sdk', repoUrl: 'http://example.com/owner/repo' });
+    expect(screen.queryByRole('link', { name: /Open repository/i })).toBeNull();
+  });
+
+  it('renders Open repository for a normal https:// repoUrl', () => {
+    renderProjectPage({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+    const link = screen.getByRole('link', { name: /Open repository/i });
+    expect(link.getAttribute('href')).toBe('https://github.com/owner/repo');
+  });
+
+  it('does not render Website for a javascript: websiteUrl', () => {
+    renderProjectPage({ type: 'app', websiteUrl: 'javascript:alert(1)' });
+    expect(screen.queryByRole('link', { name: /Website/i })).toBeNull();
+  });
+
+  it('does not render Website for an http:// websiteUrl', () => {
+    renderProjectPage({ type: 'app', websiteUrl: 'http://example.com' });
+    expect(screen.queryByRole('link', { name: /Website/i })).toBeNull();
+  });
+
+  it('renders Website for a normal https:// websiteUrl', () => {
+    renderProjectPage({ type: 'app', websiteUrl: 'https://example.com' });
+    const link = screen.getByRole('link', { name: /Website/i });
+    expect(link.getAttribute('href')).toBe('https://example.com');
+  });
+});

--- a/tests/unit/pages/projectPageSdkActions.test.tsx
+++ b/tests/unit/pages/projectPageSdkActions.test.tsx
@@ -26,14 +26,15 @@ vi.mock('../../../src/components/marketplace/ProjectReviewsSection', () => ({
 }));
 
 import { ProjectPage } from '../../../src/pages/ProjectPage';
+import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
 
 function renderProjectPage(over: Record<string, unknown>) {
   useProject.mockReturnValue({
     data: {
       _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', tagline: 't', description: 'd',
-      type: 'app', appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
+      type: PROJECT_TYPES.APP, appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
       logoUrl: null, bannerUrl: null, accentColor: '#FF6F00', category: 'tool',
-      // Non-skill types (app/sdk) render a "Completions" stat that reads
+      // Non-skill types (app/standalone) render a "Completions" stat that reads
       // stats.totalCompletions directly (see ProjectPage.tsx) — it must be
       // present in the mock or the page crashes before any assertion runs.
       tags: [], media: [], socialLinks: {}, stats: { totalUsers: 0, activeQuests: 0, totalCompletions: 0, rating: 0, ratingCount: 0 },
@@ -52,20 +53,20 @@ beforeEach(() => { vi.clearAllMocks(); });
 
 describe('ProjectPage actions for a standalone project', () => {
   it('offers the repository instead of launching an app', () => {
-    renderProjectPage({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+    renderProjectPage({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'https://github.com/owner/repo' });
     const link = screen.getByRole('link', { name: /Open repository/i });
     expect(link.getAttribute('href')).toBe('https://github.com/owner/repo');
     expect(screen.queryByText(/Open App/i)).toBeNull();
   });
 
   it('shows the install command as a copyable line', () => {
-    renderProjectPage({ type: 'sdk', repoUrl: 'https://github.com/owner/repo', installCommand: 'npx agent-guild' });
+    renderProjectPage({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'https://github.com/owner/repo', installCommand: 'npx agent-guild' });
     expect(screen.getByText('npx agent-guild')).toBeTruthy();
     expect(screen.getByRole('button', { name: /copy install command/i })).toBeTruthy();
   });
 
   it('leaves an app project alone', () => {
-    renderProjectPage({ type: 'app', appUrl: 'https://app.example.com' });
+    renderProjectPage({ type: PROJECT_TYPES.APP, appUrl: 'https://app.example.com' });
     expect(screen.getByText(/Open App/i)).toBeTruthy();
     expect(screen.queryByText(/Open repository/i)).toBeNull();
   });
@@ -77,33 +78,33 @@ describe('ProjectPage actions for a standalone project', () => {
 // a clickable link — render nothing rather than a dangerous link.
 describe('ProjectPage renders only vetted https:// links', () => {
   it('does not render Open repository for a javascript: repoUrl', () => {
-    renderProjectPage({ type: 'sdk', repoUrl: 'javascript:alert(1)' });
+    renderProjectPage({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'javascript:alert(1)' });
     expect(screen.queryByRole('link', { name: /Open repository/i })).toBeNull();
   });
 
   it('does not render Open repository for an http:// repoUrl', () => {
-    renderProjectPage({ type: 'sdk', repoUrl: 'http://example.com/owner/repo' });
+    renderProjectPage({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'http://example.com/owner/repo' });
     expect(screen.queryByRole('link', { name: /Open repository/i })).toBeNull();
   });
 
   it('renders Open repository for a normal https:// repoUrl', () => {
-    renderProjectPage({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+    renderProjectPage({ type: PROJECT_TYPES.STANDALONE, repoUrl: 'https://github.com/owner/repo' });
     const link = screen.getByRole('link', { name: /Open repository/i });
     expect(link.getAttribute('href')).toBe('https://github.com/owner/repo');
   });
 
   it('does not render Website for a javascript: websiteUrl', () => {
-    renderProjectPage({ type: 'app', websiteUrl: 'javascript:alert(1)' });
+    renderProjectPage({ type: PROJECT_TYPES.APP, websiteUrl: 'javascript:alert(1)' });
     expect(screen.queryByRole('link', { name: /Website/i })).toBeNull();
   });
 
   it('does not render Website for an http:// websiteUrl', () => {
-    renderProjectPage({ type: 'app', websiteUrl: 'http://example.com' });
+    renderProjectPage({ type: PROJECT_TYPES.APP, websiteUrl: 'http://example.com' });
     expect(screen.queryByRole('link', { name: /Website/i })).toBeNull();
   });
 
   it('renders Website for a normal https:// websiteUrl', () => {
-    renderProjectPage({ type: 'app', websiteUrl: 'https://example.com' });
+    renderProjectPage({ type: PROJECT_TYPES.APP, websiteUrl: 'https://example.com' });
     const link = screen.getByRole('link', { name: /Website/i });
     expect(link.getAttribute('href')).toBe('https://example.com');
   });

--- a/tests/unit/pages/projectPageSdkActions.test.tsx
+++ b/tests/unit/pages/projectPageSdkActions.test.tsx
@@ -114,7 +114,10 @@ describe('ProjectPage renders only vetted https:// links', () => {
 // appUrl reaches the most dangerous sink in this app: handleAddToDesktop hands
 // it to openTab, which persists it into DesktopTab.url in localStorage;
 // DesktopLayout turns that into iframeUrl and IframeAgent renders
-// <iframe src={activeUrl}> with no sandbox attribute. A `javascript:` (or any
+// <iframe src={activeUrl}>. The frame does carry a sandbox attribute, but it
+// includes allow-scripts + allow-same-origin, which together leave a framed
+// page free to script in its own inherited origin — the sandbox grants no
+// protection against a malicious `src` itself. A `javascript:` (or any
 // non-https) value reaching that src runs with the wallet's own origin. The
 // "Open App" button must be gated on isHttpsUrl, not just truthiness, and
 // handleAddToDesktop itself must refuse to store an unsafe URL.

--- a/tests/unit/pages/projectPageSdkActions.test.tsx
+++ b/tests/unit/pages/projectPageSdkActions.test.tsx
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 // vi.mock factories are hoisted above regular top-level `const`s, so the mock
 // referenced inside the factory below must itself be created via vi.hoisted
 // to avoid a TDZ ReferenceError when ProjectPage's import of useMarketplace
 // is resolved.
-const { useProject } = vi.hoisted(() => ({
+const { useProject, openTab } = vi.hoisted(() => ({
   useProject: vi.fn(),
+  openTab: vi.fn(),
 }));
 
 vi.mock('../../../src/hooks/useMarketplace', () => ({
@@ -16,7 +17,7 @@ vi.mock('../../../src/hooks/useMarketplace', () => ({
   useProjectMetrics:  () => ({ data: undefined }),
 }));
 vi.mock('../../../src/hooks/useDesktopState', () => ({
-  useDesktopState: () => ({ openTab: vi.fn() }),
+  useDesktopState: () => ({ openTab }),
 }));
 vi.mock('../../../src/hooks/useInstalledProjects', () => ({
   useInstalledProjects: () => ({ isInstalled: () => false, toggle: vi.fn() }),
@@ -107,5 +108,32 @@ describe('ProjectPage renders only vetted https:// links', () => {
     renderProjectPage({ type: PROJECT_TYPES.APP, websiteUrl: 'https://example.com' });
     const link = screen.getByRole('link', { name: /Website/i });
     expect(link.getAttribute('href')).toBe('https://example.com');
+  });
+});
+
+// appUrl reaches the most dangerous sink in this app: handleAddToDesktop hands
+// it to openTab, which persists it into DesktopTab.url in localStorage;
+// DesktopLayout turns that into iframeUrl and IframeAgent renders
+// <iframe src={activeUrl}> with no sandbox attribute. A `javascript:` (or any
+// non-https) value reaching that src runs with the wallet's own origin. The
+// "Open App" button must be gated on isHttpsUrl, not just truthiness, and
+// handleAddToDesktop itself must refuse to store an unsafe URL.
+describe('ProjectPage — https gate on the appUrl -> openTab/iframe sink', () => {
+  it('does not render Open App for a javascript: appUrl', () => {
+    renderProjectPage({ type: PROJECT_TYPES.APP, appUrl: 'javascript:alert(1)' });
+    expect(screen.queryByRole('button', { name: /Open App/i })).toBeNull();
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it('does not render Open App for an http:// appUrl', () => {
+    renderProjectPage({ type: PROJECT_TYPES.APP, appUrl: 'http://app.example.com' });
+    expect(screen.queryByRole('button', { name: /Open App/i })).toBeNull();
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it('still renders Open App and calls openTab for a normal https:// appUrl', () => {
+    renderProjectPage({ type: PROJECT_TYPES.APP, appUrl: 'https://app.example.com' });
+    fireEvent.click(screen.getByRole('button', { name: /Open App/i }));
+    expect(openTab).toHaveBeenCalledWith('custom', { url: 'https://app.example.com', label: 'Agent Guild' });
   });
 });

--- a/tests/unit/pages/projectPageSdkActions.test.tsx
+++ b/tests/unit/pages/projectPageSdkActions.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+// vi.mock factories are hoisted above regular top-level `const`s, so the mock
+// referenced inside the factory below must itself be created via vi.hoisted
+// to avoid a TDZ ReferenceError when ProjectPage's import of useMarketplace
+// is resolved.
+const { useProject } = vi.hoisted(() => ({
+  useProject: vi.fn(),
+}));
+
+vi.mock('../../../src/hooks/useMarketplace', () => ({
+  useProject:         (...args: unknown[]) => useProject(...args),
+  useProjectQuests:   () => ({ data: [] }),
+  useProjectMetrics:  () => ({ data: undefined }),
+}));
+vi.mock('../../../src/hooks/useDesktopState', () => ({
+  useDesktopState: () => ({ openTab: vi.fn() }),
+}));
+vi.mock('../../../src/hooks/useInstalledProjects', () => ({
+  useInstalledProjects: () => ({ isInstalled: () => false, toggle: vi.fn() }),
+}));
+vi.mock('../../../src/components/marketplace/ProjectReviewsSection', () => ({
+  ProjectReviewsSection: () => null,
+}));
+
+import { ProjectPage } from '../../../src/pages/ProjectPage';
+
+function renderProjectPage(over: Record<string, unknown>) {
+  useProject.mockReturnValue({
+    data: {
+      _id: 'p1', slug: 'agent-guild', name: 'Agent Guild', tagline: 't', description: 'd',
+      type: 'app', appUrl: null, websiteUrl: null, repoUrl: null, installCommand: null,
+      logoUrl: null, bannerUrl: null, accentColor: '#FF6F00', category: 'tool',
+      // Non-skill types (app/sdk) render a "Completions" stat that reads
+      // stats.totalCompletions directly (see ProjectPage.tsx) — it must be
+      // present in the mock or the page crashes before any assertion runs.
+      tags: [], media: [], socialLinks: {}, stats: { totalUsers: 0, activeQuests: 0, totalCompletions: 0, rating: 0, ratingCount: 0 },
+      ...over,
+    },
+    isLoading: false,
+  });
+  return render(
+    <MemoryRouter initialEntries={['/apps/agent-guild']}>
+      <Routes><Route path="/apps/:slug" element={<ProjectPage />} /></Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('ProjectPage actions for a standalone project', () => {
+  it('offers the repository instead of launching an app', () => {
+    renderProjectPage({ type: 'sdk', repoUrl: 'https://github.com/owner/repo' });
+    const link = screen.getByRole('link', { name: /Open repository/i });
+    expect(link.getAttribute('href')).toBe('https://github.com/owner/repo');
+    expect(screen.queryByText(/Open App/i)).toBeNull();
+  });
+
+  it('shows the install command as a copyable line', () => {
+    renderProjectPage({ type: 'sdk', repoUrl: 'https://github.com/owner/repo', installCommand: 'npx agent-guild' });
+    expect(screen.getByText('npx agent-guild')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /copy install command/i })).toBeTruthy();
+  });
+
+  it('leaves an app project alone', () => {
+    renderProjectPage({ type: 'app', appUrl: 'https://app.example.com' });
+    expect(screen.getByText(/Open App/i)).toBeTruthy();
+    expect(screen.queryByText(/Open repository/i)).toBeNull();
+  });
+});

--- a/tests/unit/utils/isHttpsUrl.test.ts
+++ b/tests/unit/utils/isHttpsUrl.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isHttpsUrl } from '../../../src/utils/isHttpsUrl';
+
+describe('isHttpsUrl', () => {
+  it('accepts a normal https:// URL', () => {
+    expect(isHttpsUrl('https://github.com/owner/repo')).toBe(true);
+  });
+
+  it('rejects a javascript: URL', () => {
+    expect(isHttpsUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects an http:// URL', () => {
+    expect(isHttpsUrl('http://example.com')).toBe(false);
+  });
+
+  it('rejects unparseable strings and non-string values', () => {
+    expect(isHttpsUrl('not a url')).toBe(false);
+    expect(isHttpsUrl('')).toBe(false);
+    expect(isHttpsUrl(null)).toBe(false);
+    expect(isHttpsUrl(undefined)).toBe(false);
+    expect(isHttpsUrl(42)).toBe(false);
+  });
+});

--- a/tests/unit/utils/isStandalone.test.ts
+++ b/tests/unit/utils/isStandalone.test.ts
@@ -7,22 +7,47 @@ describe('isStandalone', () => {
     expect(isStandalone({ type: PROJECT_TYPES.APP })).toBe(false);
     expect(isStandalone({ type: PROJECT_TYPES.SKILL })).toBe(false);
   });
+
+  // The schema default is `app`, and documents created before the `type`
+  // field existed have none at all — the rest of the codebase reads an
+  // absent type as `app`, so this must too (`app` is never standalone).
+  // Treating an absent type as "not app" here would be harmless by
+  // coincidence (undefined !== 'standalone' either way) but the fallback is
+  // made explicit anyway, matching supportsQuests below and guarding against
+  // this function's comparison ever changing shape later.
+  it('treats an absent type as app (not standalone)', () => {
+    expect(isStandalone({ type: null })).toBe(false);
+    expect(isStandalone({ type: undefined })).toBe(false);
+  });
 });
 
 describe('supportsQuests', () => {
-  it('is true for app and skill', () => {
+  it('is true for app only', () => {
     expect(supportsQuests(PROJECT_TYPES.APP)).toBe(true);
-    expect(supportsQuests(PROJECT_TYPES.SKILL)).toBe(true);
+  });
+
+  // A skill is a capability invoked by Astrid, not something that runs a
+  // quest campaign — it does not support quests, even though (like app) it
+  // launches in-app rather than running standalone. Pinned separately from
+  // isStandalone's own test above: the two predicates must NOT be treated as
+  // interchangeable (isStandalone(skill) is also false, but for an unrelated
+  // reason).
+  it('is false for skill', () => {
+    expect(supportsQuests(PROJECT_TYPES.SKILL)).toBe(false);
   });
 
   it('is false for standalone', () => {
     expect(supportsQuests(PROJECT_TYPES.STANDALONE)).toBe(false);
   });
 
-  // Accepts null/undefined so a call site doesn't need an extra guard while
-  // the project it's asking about is still loading.
-  it('is false for null/undefined (no project loaded yet)', () => {
-    expect(supportsQuests(null)).toBe(false);
-    expect(supportsQuests(undefined)).toBe(false);
+  // The schema default is `app`, and pre-migration documents may have no
+  // `type` field at all — an absent type must resolve to `app` (and
+  // therefore true), never to "not app". Getting this backwards would make
+  // untyped (i.e. actually-app) projects silently stop supporting quests —
+  // the same category of bug already caught once on the `skill` case, just
+  // triggered by missing data instead of a wrong predicate.
+  it('treats an absent type as app (true), not as "not app"', () => {
+    expect(supportsQuests(null)).toBe(true);
+    expect(supportsQuests(undefined)).toBe(true);
   });
 });

--- a/tests/unit/utils/isStandalone.test.ts
+++ b/tests/unit/utils/isStandalone.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { PROJECT_TYPES, isStandalone, supportsQuests } from '../../../src/utils/isStandalone';
+
+describe('isStandalone', () => {
+  it('is true only for a standalone project', () => {
+    expect(isStandalone({ type: PROJECT_TYPES.STANDALONE })).toBe(true);
+    expect(isStandalone({ type: PROJECT_TYPES.APP })).toBe(false);
+    expect(isStandalone({ type: PROJECT_TYPES.SKILL })).toBe(false);
+  });
+});
+
+describe('supportsQuests', () => {
+  it('is true for app and skill', () => {
+    expect(supportsQuests(PROJECT_TYPES.APP)).toBe(true);
+    expect(supportsQuests(PROJECT_TYPES.SKILL)).toBe(true);
+  });
+
+  it('is false for standalone', () => {
+    expect(supportsQuests(PROJECT_TYPES.STANDALONE)).toBe(false);
+  });
+
+  // Accepts null/undefined so a call site doesn't need an extra guard while
+  // the project it's asking about is still loading.
+  it('is false for null/undefined (no project loaded yet)', () => {
+    expect(supportsQuests(null)).toBe(false);
+    expect(supportsQuests(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds the wallet-side surface for the new **Standalone (SDK)** project type — a program built on the Sphere SDK that runs outside Sphere with its own wallet. It is never launched from Sphere; it is cloned or installed, so it carries a public source repository instead of an App URL.

Part of a four-repo change. This branch is **independent** — it can ship before or after the others. Until `sphere-api` ships, no standalone project exists, so nothing here renders.

## What changes

- **Explore** gains an `Apps` / `Standalone` tab. Switching clears the category filter and the search box, since both were filters over the other tab's contents.
- **`STANDALONE` badge** on both card surfaces — the marketplace card and the featured card. Implemented in this repo's own wrappers rather than in `sphere-ui`, deliberately: that library's version is bumped by CI, so touching it would mean a release cycle plus a dependency bump in every consumer.
- **Project page** replaces `Open App` with `Open repository` and shows the install command as a copyable line. `Add to Desktop` is unchanged.
- **Desktop shortcut** for a standalone project opens the project's own page in Explore. It must never open a repository in the in-app tab: that renders in a frame, and GitHub sends `X-Frame-Options: deny`, so the panel would be blank. The context menu offers `Open repository` in a real browser tab instead.

## Security

Two hardening changes came out of review, both in this repo's own threat model — it is the wallet, so a project field reaching a navigation sink is script execution in the origin that holds the user's keys:

- `src/utils/isHttpsUrl.ts` gates every project-supplied URL before it is rendered or opened: the two anchors on the project page and both `window.open` calls in the desktop shortcut's context menu. A value that is not `https` renders no link at all rather than a dead or dangerous one. `javascript:` and `http://` are covered by tests.
- The clipboard call checks the API exists before using it — `navigator.clipboard` is undefined in non-secure contexts.

Not exploitable through any current endpoint: the API validates these fields on every developer write path. The gate exists because the client should not depend on that, and admin endpoints, migrations and the seed script also write projects.

## Verification

663 unit tests pass. `tsc -b && vite build` clean. Lint 0 errors (4 pre-existing warnings in untouched files). Existing `app` and `skill` behaviour is unchanged and covered by regression tests.

## Needs human eyes before merge

The `STANDALONE` badge's placement on both cards was checked by rendering the library's DOM, but no diff can prove it does not overlap the logo or the featured ribbon. Worth a look at Explore with a standalone project present.

## Follow-ups, deliberately not in this branch

- Roughly fourteen other clipboard call sites in this repo share the unguarded-API gap; fixed only at the new call site here.
- For `app` projects the desktop shortcut still opens `appUrl` in the in-app frame without the https gate. Left alone on purpose: framing the app URL *is* the intended behaviour for that type, and gating it could stop a legacy `http://` row from launching. The API validates the field on write.
- Clicking the already-active Explore tab still clears the filters.
