### PR TITLE
fix(ui): make copy-to-clipboard survive an insecure context

### DIFF
--- a/src/components/chat/group/GroupItem.tsx
+++ b/src/components/chat/group/GroupItem.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect } from 'react';
 import type { GroupData } from '@unicitylabs/sphere-sdk';
 import { GroupVisibility } from '@unicitylabs/sphere-sdk';
 import { buildGroupInviteLink } from '../../../utils/groupInviteLink';
+import { copyToClipboard } from '../../../utils/copyToClipboard';
 import { showToast } from '../../ui/toast-utils';
 import { getGroupDisplayName, getGroupFormattedLastMessageTime, isPinnedGroup } from '../utils/groupChatHelpers';
 
@@ -134,8 +135,9 @@ export const GroupItem = memo(function GroupItem({
                       const code = await onCreateInvite(group.id);
                       if (code) {
                         const inviteUrl = buildGroupInviteLink({ groupId: group.id, code });
-                        navigator.clipboard.writeText(inviteUrl);
-                        showToast('Invite link copied to clipboard', 'success');
+                        if (await copyToClipboard(inviteUrl)) {
+                          showToast('Invite link copied to clipboard', 'success');
+                        }
                       }
                       setShowMenu(false);
                     }}

--- a/src/components/upgrade/UpgradeSuccess.tsx
+++ b/src/components/upgrade/UpgradeSuccess.tsx
@@ -9,6 +9,7 @@ import { Check, Copy, Sparkles } from 'lucide-react';
 import { Button } from '../wallet/ui';
 import type { PlanInfo } from '../../services/subscriptionApi';
 import { planFeatures } from '../subscription/planFeatures';
+import { copyToClipboard } from '../../utils/copyToClipboard';
 
 const CONFETTI_COLORS = ['#f97316', '#10b981', '#a855f7', '#ec4899', '#3b82f6', '#eab308'];
 
@@ -59,11 +60,12 @@ interface UpgradeSuccessProps {
 
 export function UpgradeSuccess({ plan, apiKey, upgradedMaskedKey, onDone }: UpgradeSuccessProps) {
   const [copied, setCopied] = useState(false);
-  const copyKey = () => {
+  const copyKey = async () => {
     if (!apiKey) return;
-    navigator.clipboard.writeText(apiKey);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    if (await copyToClipboard(apiKey)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
   };
   const features = plan ? planFeatures(plan) : [];
 

--- a/src/components/wallet/L3/modals/LookupModal.tsx
+++ b/src/components/wallet/L3/modals/LookupModal.tsx
@@ -5,6 +5,7 @@ import { ModalHeader } from '../../ui';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
 import { useIdentity } from '../../../../sdk';
 import { getErrorMessage } from '../../../../sdk/errors';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
 interface ResolvedInfo {
   nametag?: string;
@@ -86,11 +87,10 @@ export function LookupModal({ isOpen, onClose }: LookupModalProps) {
   }, [query, sphere]);
 
   const handleCopy = useCallback(async (value: string, field: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
+    if (await copyToClipboard(value)) {
       setCopied(field);
       setTimeout(() => setCopied(false), 1500);
-    } catch { /* ignore */ }
+    }
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/wallet/L3/modals/SeedPhraseModal.tsx
+++ b/src/components/wallet/L3/modals/SeedPhraseModal.tsx
@@ -3,6 +3,7 @@ import { Eye, EyeOff, Copy, Check, ShieldAlert } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, AlertMessage, Button, SecondaryButton } from '../../ui';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
 interface SeedPhraseModalProps {
   isOpen: boolean;
@@ -23,12 +24,11 @@ export function SeedPhraseModal({ isOpen, onClose, seedPhrase }: SeedPhraseModal
   }, [isOpen]);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(seedPhrase.join(' '));
+    if (await copyToClipboard(seedPhrase.join(' '))) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy seed phrase:', err);
+    } else {
+      console.error('Failed to copy seed phrase');
     }
   };
 

--- a/src/components/wallet/L3/modals/SendModal.tsx
+++ b/src/components/wallet/L3/modals/SendModal.tsx
@@ -14,6 +14,7 @@ import { SUBSCRIPTION_ENABLED } from '../../../../config/subscription';
 import { useUpgrade } from '../../../upgrade';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, Button, AlertMessage } from '../../ui';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
 type Step = 'asset' | 'details' | 'confirm' | 'processing' | 'success';
 
@@ -36,11 +37,11 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
   const assets = sdkAssets;
 
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const copyToClipboard = useCallback((text: string, key: string) => {
-    navigator.clipboard.writeText(text).then(() => {
+  const handleCopy = useCallback(async (text: string, key: string) => {
+    if (await copyToClipboard(text)) {
       setCopiedKey(key);
       setTimeout(() => setCopiedKey(null), 2000);
-    }).catch(() => {});
+    }
   }, []);
 
   // State
@@ -361,7 +362,7 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
                     </div>
                     <button
                       type="button"
-                      onClick={() => copyToClipboard(
+                      onClick={() => handleCopy(
                         recipientMode === 'pubkey' ? recipient : `@${recipient}`,
                         'recipient'
                       )}
@@ -384,7 +385,7 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
                       </span>
                       <button
                         type="button"
-                        onClick={() => copyToClipboard(resolvedPubkey, 'address')}
+                        onClick={() => handleCopy(resolvedPubkey, 'address')}
                         className="p-0.5 hover:bg-neutral-200 dark:hover:bg-white/10 rounded transition-colors"
                         title="Copy address"
                       >

--- a/src/components/wallet/L3/modals/SubscriptionModal.tsx
+++ b/src/components/wallet/L3/modals/SubscriptionModal.tsx
@@ -10,6 +10,7 @@ import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
 import { provisionOrRecoverKey } from '../../../../services/subscriptionApi';
 import { validatePastedKey } from '../../../../sdk/subscription/keyCheck';
 import { SPHERE_KEYS } from '../../../../sdk/queryKeys';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
 interface SubscriptionModalProps {
   isOpen: boolean;
@@ -189,10 +190,11 @@ function ApiKeyRow({ apiKey }: { apiKey: string }) {
   const [visible, setVisible] = useState(false);
   const [copied, setCopied] = useState(false);
   const masked = `${apiKey.slice(0, 5)}…${apiKey.slice(-4)}`;
-  const copy = () => {
-    navigator.clipboard.writeText(apiKey);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+  const copy = async () => {
+    if (await copyToClipboard(apiKey)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
   };
   return (
     <div className="rounded-2xl bg-neutral-50 px-4 py-3 dark:bg-white/4">

--- a/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
+++ b/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, EmptyState } from '../../ui';
 import { truncateId, stripDirectScheme } from '../../../../utils/identifiers';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
 const registry = TokenRegistry.getInstance();
 
@@ -19,12 +20,9 @@ function useCopyToClipboard() {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const copy = useCallback(async (text: string, key: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
+    if (await copyToClipboard(text)) {
       setCopiedKey(key);
       setTimeout(() => setCopiedKey(null), 2000);
-    } catch {
-      // Ignore
     }
   }, []);
 

--- a/src/components/wallet/onboarding/components/MnemonicShowScreen.tsx
+++ b/src/components/wallet/onboarding/components/MnemonicShowScreen.tsx
@@ -15,6 +15,7 @@
 import { motion } from "framer-motion";
 import { ShieldAlert, Copy, Check } from "lucide-react";
 import { useState, useCallback } from "react";
+import { copyToClipboard } from "../../../../utils/copyToClipboard";
 
 interface MnemonicShowScreenProps {
   mnemonic: string;
@@ -29,19 +30,7 @@ export function MnemonicShowScreen({
   const words = mnemonic.split(" ");
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(mnemonic);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      const textarea = document.createElement("textarea");
-      textarea.value = mnemonic;
-      textarea.style.position = "fixed";
-      textarea.style.opacity = "0";
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textarea);
+    if (await copyToClipboard(mnemonic)) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }

--- a/src/components/wallet/shared/components/AddressSelector.tsx
+++ b/src/components/wallet/shared/components/AddressSelector.tsx
@@ -7,6 +7,7 @@ import { SPHERE_KEYS } from '../../../../sdk/queryKeys';
 import { useQueryClient } from '@tanstack/react-query';
 import type { TrackedAddress } from '@unicitylabs/sphere-sdk';
 import { truncateId } from '../../../../utils/identifiers';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 import { NewAddressModal } from '../modals/NewAddressModal';
 
 /** Truncate long nametags: show first 6 chars + ... + last 3 chars */
@@ -80,23 +81,21 @@ export function AddressSelector({ compact = true, onNewAddress }: AddressSelecto
   const handleCopyNametag = useCallback(async () => {
     const tagToCopy = nametag;
     if (!tagToCopy) return;
-    try {
-      await navigator.clipboard.writeText(`@${tagToCopy}`);
+    if (await copyToClipboard(`@${tagToCopy}`)) {
       setCopied('nametag');
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy nametag:', err);
+    } else {
+      console.error('Failed to copy nametag');
     }
   }, [nametag]);
 
   const handleCopyPubkey = useCallback(async () => {
     if (!chainPubkey) return;
-    try {
-      await navigator.clipboard.writeText(chainPubkey);
+    if (await copyToClipboard(chainPubkey)) {
       setCopied('address');
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy public key:', err);
+    } else {
+      console.error('Failed to copy public key');
     }
   }, [chainPubkey]);
 

--- a/src/components/wallet/shared/components/TokenRow.tsx
+++ b/src/components/wallet/shared/components/TokenRow.tsx
@@ -3,6 +3,7 @@ import type { Token } from '@unicitylabs/sphere-sdk';
 import { TokenRegistry } from '@unicitylabs/sphere-sdk';
 import { Box, Copy, CheckCircle2, Loader2 } from 'lucide-react';
 import { useState, memo, useEffect } from 'react';
+import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
 interface TokenRowProps {
   token: Token;
@@ -82,11 +83,12 @@ function AnimatedTokenAmount({ amount, coinId, symbol }: {
 export const TokenRow = memo(function TokenRow({ token, delay, isNew = true }: TokenRowProps) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopyId = (e: React.MouseEvent) => {
+  const handleCopyId = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    navigator.clipboard.writeText(token.id);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (await copyToClipboard(token.id)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   const className = "p-3 rounded-xl bg-neutral-50 dark:bg-[rgba(255,255,255,0.03)] hover:bg-neutral-100 dark:hover:bg-[rgba(255,255,255,0.05)] transition-all group";

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { Puzzle, ShieldCheck, Github, Linkedin } from 'lucide-react';
 import { DiscordIcon, XIcon } from '../components/icons/SocialIcons';
+import { copyToClipboard } from '../utils/copyToClipboard';
 
 const openclawFeatures = [
   'Wallet identity — Auto-generated Unicity wallet with mnemonic backup',
@@ -52,10 +53,12 @@ const socialLinks = [
 export function AgentsPage() {
   const [copiedIndex, setCopiedIndex] = useState<string | null>(null);
 
-  const copyToClipboard = (text: string, index: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedIndex(index);
-    setTimeout(() => setCopiedIndex(null), 2000);
+  const handleCopy = async (text: string, index: string) => {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    }
   };
 
   return (
@@ -184,7 +187,7 @@ export function AgentsPage() {
             <div className="flex justify-between items-center px-4 py-2 border-b border-neutral-200 dark:border-white/8">
               <span className="text-xs text-neutral-400 dark:text-white/35 font-mono">terminal</span>
               <button
-                onClick={() => copyToClipboard('openclaw plugins install @unicitylabs/openclaw-unicity\nopenclaw unicity setup\nopenclaw gateway start', 'openclaw-install')}
+                onClick={() => handleCopy('openclaw plugins install @unicitylabs/openclaw-unicity\nopenclaw unicity setup\nopenclaw gateway start', 'openclaw-install')}
                 className="text-xs text-neutral-400 dark:text-white/35 hover:text-neutral-600 dark:hover:text-white/75 transition"
               >
                 {copiedIndex === 'openclaw-install' ? '✓ Copied' : 'Copy'}
@@ -260,7 +263,7 @@ export function AgentsPage() {
             <div className="flex justify-between items-center px-4 py-2 border-b border-neutral-200 dark:border-white/8">
               <span className="text-xs text-neutral-400 dark:text-white/35 font-mono">terminal</span>
               <button
-                onClick={() => copyToClipboard('cargo install astrid-cli\nastrid identity create\nastrid chat', 'astrid-install')}
+                onClick={() => handleCopy('cargo install astrid-cli\nastrid identity create\nastrid chat', 'astrid-install')}
                 className="text-xs text-neutral-400 dark:text-white/35 hover:text-neutral-600 dark:hover:text-white/75 transition"
               >
                 {copiedIndex === 'astrid-install' ? '✓ Copied' : 'Copy'}

--- a/src/pages/DevelopersPage.tsx
+++ b/src/pages/DevelopersPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { Github, Linkedin, Key, Zap, MessageSquare, Store, type LucideIcon } from 'lucide-react';
 import { DiscordIcon, XIcon } from '../components/icons/SocialIcons';
+import { copyToClipboard } from '../utils/copyToClipboard';
 
 type ApiKey = 'init' | 'payments' | 'communication' | 'market';
 
@@ -27,10 +28,12 @@ export function DevelopersPage() {
   const [activeApi, setActiveApi] = useState<ApiKey>('init');
   const [copiedIndex, setCopiedIndex] = useState<string | null>(null);
 
-  const copyToClipboard = (text: string, index: string) => {
-    navigator.clipboard.writeText(text);
-    setCopiedIndex(index);
-    setTimeout(() => setCopiedIndex(null), 2000);
+  const handleCopy = async (text: string, index: string) => {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    }
   };
 
   const apis: Record<ApiKey, ApiInfo> = {
@@ -286,7 +289,7 @@ sphere.communications.onDirectMessage(async (msg) => {
               <div className="flex items-center justify-between mb-3">
                 <span className="text-xs text-neutral-400 dark:text-white/35 font-mono uppercase tracking-wider">The entire integration</span>
                 <button
-                  onClick={() => copyToClipboard(apis[activeApi].code, 'oneliner')}
+                  onClick={() => handleCopy(apis[activeApi].code, 'oneliner')}
                   className="text-xs text-neutral-400 dark:text-white/35 hover:text-neutral-600 dark:hover:text-white/75 transition"
                 >
                   {copiedIndex === 'oneliner' ? '✓ Copied' : 'Copy'}
@@ -302,7 +305,7 @@ sphere.communications.onDirectMessage(async (msg) => {
               <div className="flex items-center justify-between mb-3">
                 <span className="text-xs text-neutral-400 dark:text-white/35 font-mono uppercase tracking-wider">Full example</span>
                 <button
-                  onClick={() => copyToClipboard(apis[activeApi].fullExample, 'full')}
+                  onClick={() => handleCopy(apis[activeApi].fullExample, 'full')}
                   className="text-xs text-neutral-400 dark:text-white/35 hover:text-neutral-600 dark:hover:text-white/75 transition"
                 >
                   {copiedIndex === 'full' ? '✓ Copied' : 'Copy'}
@@ -334,7 +337,7 @@ sphere.communications.onDirectMessage(async (msg) => {
               </div>
               <span className="text-xs text-neutral-500 dark:text-white/35 font-mono">marketplace.ts</span>
               <button
-                onClick={() => copyToClipboard(marketplaceCode, 'marketplace')}
+                onClick={() => handleCopy(marketplaceCode, 'marketplace')}
                 className="text-xs text-neutral-500 dark:text-white/35 hover:text-neutral-700 dark:hover:text-white/75 transition"
               >
                 {copiedIndex === 'marketplace' ? '✓ Copied' : 'Copy'}

--- a/src/pages/DocsPage.tsx
+++ b/src/pages/DocsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { DEV_PORTAL_URL } from '../config/devPortal';
+import { copyToClipboard } from '../utils/copyToClipboard';
 
 type Section =
   | 'getting-started'
@@ -159,10 +160,12 @@ const navigation: NavItem[] = [
 function CodeBlock({ code, filename, language = 'typescript' }: { code: string; filename?: string; language?: string }) {
   const [copied, setCopied] = useState(false);
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(code);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   return (
@@ -170,7 +173,7 @@ function CodeBlock({ code, filename, language = 'typescript' }: { code: string; 
       <div className="flex justify-between items-center px-4 py-2 border-b border-neutral-700">
         <span className="text-xs text-neutral-400 font-mono">{filename || language}</span>
         <button
-          onClick={copyToClipboard}
+          onClick={handleCopy}
           className="text-xs text-neutral-400 hover:text-white transition"
         >
           {copied ? '\u2713 Copied' : 'Copy'}

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -12,6 +12,7 @@ import { useDesktopState } from '../hooks/useDesktopState';
 import { useInstalledProjects } from '../hooks/useInstalledProjects';
 import { isHttpsUrl } from '../utils/isHttpsUrl';
 import { isStandalone, supportsQuests, PROJECT_TYPES } from '../utils/isStandalone';
+import { copyToClipboard } from '../utils/copyToClipboard';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 type MediaItem = { type: string; url: string; caption?: string };
@@ -377,13 +378,12 @@ export function ProjectPage() {
                 <button
                   type="button"
                   aria-label="copy install command"
-                  onClick={() => {
-                    // navigator.clipboard is undefined in non-secure contexts and in
-                    // older browsers; the copy affordance is a convenience, so a
-                    // missing API or a rejected write should fail silently rather
-                    // than throw / surface an unhandled rejection.
-                    if (!navigator.clipboard) return;
-                    navigator.clipboard.writeText(project.installCommand!).catch(() => {});
+                  onClick={async () => {
+                    // The copy affordance is a convenience with no visual feedback
+                    // today — copyToClipboard already never throws (missing API,
+                    // non-secure context, rejected write all resolve to false), so
+                    // failures are silent by design rather than surfaced here.
+                    await copyToClipboard(project.installCommand!);
                   }}
                   className="text-neutral-500 dark:text-white/45 hover:text-neutral-900 dark:hover:text-white transition-colors cursor-pointer"
                 >

--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,0 +1,75 @@
+/**
+ * Copy text to the clipboard without ever throwing.
+ *
+ * `navigator.clipboard` does not exist outside a "secure context" (HTTPS or
+ * localhost) — and Sphere is routinely opened over plain http on a LAN
+ * address during development and demos. Reading the property there throws a
+ * TypeError, which — in a click handler with no try/catch — becomes a dead
+ * button and a console error with zero feedback to the user. Even when the
+ * modern API IS present, `writeText` returns a promise that can reject:
+ * permission denied, or the document not being focused (e.g. the click came
+ * from inside an iframe, or the window lost focus).
+ *
+ * The `document.execCommand('copy')` fallback below is what makes "Copy"
+ * work at all on plain http — do not delete it as dead/legacy code. It
+ * copies via a temporary off-screen `<textarea>`: select the text, ask the
+ * browser to copy the current selection, then clean up. `execCommand` is
+ * deprecated but still implemented everywhere Sphere runs, and there is no
+ * secure-context-free replacement for it.
+ *
+ * Sphere is a wallet: what gets copied here is addresses, mnemonics,
+ * transaction ids and install commands. A copy that silently does nothing
+ * while the UI implies it worked is worse than an ordinary app's clipboard
+ * bug — a user could paste a stale value into a transfer. So this function
+ * never throws; callers get a boolean and decide how to reflect it.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy path — e.g. permission denied, or the
+      // document not being focused (iframe click, backgrounded window).
+    }
+  }
+
+  return legacyCopy(text);
+}
+
+/** `execCommand('copy')` via a temporary off-screen textarea. Never throws. */
+function legacyCopy(text: string): boolean {
+  if (typeof document === 'undefined' || !document.body) return false;
+
+  const previousFocus = document.activeElement as HTMLElement | null;
+  const textarea = document.createElement('textarea');
+  try {
+    textarea.value = text;
+    // Keep it out of the layout and off-screen so nothing visibly flashes.
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.width = '1px';
+    textarea.style.height = '1px';
+    textarea.style.padding = '0';
+    textarea.style.border = 'none';
+    textarea.style.opacity = '0';
+    textarea.setAttribute('readonly', '');
+
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    return document.execCommand('copy') === true;
+  } catch {
+    return false;
+  } finally {
+    if (textarea.parentNode) {
+      textarea.parentNode.removeChild(textarea);
+    }
+    // Restore focus/selection to whatever had it before we hijacked it.
+    if (previousFocus && typeof previousFocus.focus === 'function') {
+      previousFocus.focus();
+    }
+  }
+}

--- a/src/utils/markdown.tsx
+++ b/src/utils/markdown.tsx
@@ -2,15 +2,18 @@ import React, { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { getMentionClickHandler } from './mentionHandler';
 import { getDeepLinkClickHandler, deepLinkToHttps } from './deepLinkHandler';
+import { copyToClipboard } from './copyToClipboard';
 
 // Code block component with copy button
 function CodeBlock({ code, language, keyPrefix }: { code: string; language?: string; keyPrefix: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    const ok = await copyToClipboard(code);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   return (

--- a/tests/unit/utils/copyToClipboard.test.ts
+++ b/tests/unit/utils/copyToClipboard.test.ts
@@ -1,0 +1,121 @@
+/**
+ * copyToClipboard must never throw or reject — see src/utils/copyToClipboard.ts
+ * for why: navigator.clipboard does not exist outside a secure context (Sphere
+ * is routinely opened over plain http on a LAN address), and even when it does
+ * exist, writeText can reject (permission denied, document not focused). The
+ * legacy execCommand('copy') fallback via a temporary textarea is what makes
+ * copy work at all in the no-Clipboard-API case, so every fallback path is
+ * covered here, including that the temporary textarea never survives the call.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { copyToClipboard } from '../../../src/utils/copyToClipboard';
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+function setClipboard(value: unknown) {
+  Object.defineProperty(navigator, 'clipboard', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function textareaCount(): number {
+  return document.querySelectorAll('textarea').length;
+}
+
+// jsdom does not implement document.execCommand at all (the property is
+// absent, not just a no-op), so vi.spyOn — which requires the property to
+// already exist — can't be used here. Define it directly instead.
+const originalExecCommandDescriptor = Object.getOwnPropertyDescriptor(document, 'execCommand');
+
+function setExecCommand(impl: (command: string) => boolean) {
+  Object.defineProperty(document, 'execCommand', {
+    value: vi.fn(impl),
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+  } else {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (originalExecCommandDescriptor) {
+    Object.defineProperty(document, 'execCommand', originalExecCommandDescriptor);
+  } else {
+    // @ts-expect-error test cleanup — restore jsdom's default "not defined" state
+    delete document.execCommand;
+  }
+});
+
+describe('copyToClipboard', () => {
+  it('returns true when the modern Clipboard API succeeds', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+
+    const result = await copyToClipboard('hello');
+
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(textareaCount()).toBe(0);
+  });
+
+  it('falls back to execCommand when navigator.clipboard is unavailable, and returns the fallback result', async () => {
+    setClipboard(undefined);
+    setExecCommand(() => true);
+
+    const result = await copyToClipboard('fallback text');
+
+    expect(result).toBe(true);
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(textareaCount()).toBe(0);
+  });
+
+  it('does not throw when writeText rejects, and falls back (returning false when the fallback also fails)', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('document not focused'));
+    setClipboard({ writeText });
+    setExecCommand(() => false);
+
+    await expect(copyToClipboard('secret')).resolves.toBe(false);
+    expect(textareaCount()).toBe(0);
+  });
+
+  it('returns false when the fallback execCommand reports failure', async () => {
+    setClipboard(undefined);
+    setExecCommand(() => false);
+
+    const result = await copyToClipboard('nope');
+
+    expect(result).toBe(false);
+    expect(textareaCount()).toBe(0);
+  });
+
+  it('cleans up the temporary textarea even when execCommand throws', async () => {
+    setClipboard(undefined);
+    setExecCommand(() => {
+      throw new Error('boom');
+    });
+
+    const result = await copyToClipboard('boom text');
+
+    expect(result).toBe(false);
+    expect(textareaCount()).toBe(0);
+  });
+
+  it('never throws for a rejecting writeText even when the fallback API is entirely missing', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    setClipboard({ writeText });
+    // Simulate an environment with neither modern nor legacy copy support.
+    setExecCommand(() => false);
+
+    await expect(copyToClipboard('x')).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
16 call sites called `navigator.clipboard.writeText` directly. Outside a secure context — Sphere opened over plain http on a LAN address, which is how it is used during development and demos — `navigator.clipboard` is `undefined` and the property access itself throws, so the button is simply dead with an error in the console. Where it does exist, the promise can still reject (permission denied, document not focused), and several sites used `void promise` so a rejection became an unhandled rejection.

This is a wallet: the things being copied are addresses, mnemonics and transaction ids. A copy that silently does nothing while still showing "Copied!" is worse here than in an ordinary app.

Adds `src/utils/copyToClipboard.ts` returning `Promise<boolean>` — modern API first, legacy `execCommand` fallback via an off-screen textarea (that fallback is what makes copy work at all over plain http, and it is commented so nobody removes it as dead code), never throws. All 16 sites now use it, and sites that show a "Copied!" state drive it from the returned boolean, so the confirmation only appears on real success.

Found while doing this: `MnemonicShowScreen` showed "Copied!" even when its inline fallback failed — now gated on actual success.

Not changed, flagged instead: `SeedPhraseModal` and `MnemonicShowScreen` copy recovery phrases but give no visible failure feedback, only `console.error`. Inventing that UI was outside this fix.

705 tests pass (6 new), build clean, lint 0 errors.