### PR TITLE
chore(deps): adopt sphere-ui 0.1.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
         "@unicitylabs/sphere-sdk": "0.13.1",
-        "@unicitylabs/sphere-ui": "^0.1.36",
+        "@unicitylabs/sphere-ui": "^0.1.37",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
         "lucide-react": "^0.552.0",
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.36.tgz",
-      "integrity": "sha512-rziaEOeUej8Cl62wDtfzWZGK1ips4DrhkQU1sLue4/HLz+qDxxliAsLveZwWvhRghxoIqW6w5V/y63xDuLh2Rw==",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.37.tgz",
+      "integrity": "sha512-dPZj7YK1NVZfN0YfWVkCXvVv+/38gEbqaoD9FaFfQTr8yDTT1JronL2xuD/xG4xyp39zxcIdyfQuparWZ3Aj5A==",
       "dependencies": {
         "framer-motion": "^11.18.2",
         "lucide-react": ">=0.400.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
     "@unicitylabs/sphere-sdk": "0.13.1",
-    "@unicitylabs/sphere-ui": "^0.1.36",
+    "@unicitylabs/sphere-ui": "^0.1.37",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",
     "lucide-react": "^0.552.0",


### PR DESCRIPTION
Picks up sphere-ui#23: the `fade-in` animation now ends at `transform: none` instead of `translateY(0)`.

That matters because `fill-mode: both` retains the last keyframe forever, and `translateY(0)` is still a transform — so every `.animate-fade-in` element stayed a containing block for `position: fixed` descendants permanently. Anything `fixed` rendered inside one was positioned against that wrapper rather than the viewport. It surfaced in the dev portal as a dialog whose top was pushed off-screen on short pages; sphere has the same class of wrapper, so this removes the trap here before it bites.

No code changes — dependency and lockfile only. The animation looks identical: `none` interpolates as the identity transform.

705 tests pass, build clean, lint 0 errors. One test (`passwordChangeTimeoutPreservation`) timed out on the first full run under local load and passes in isolation — unrelated to a CSS-only change.