### PR TITLE
chore(deps): bump sphere-ui to 0.1.41 for the discord announcement icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
         "@unicitylabs/sphere-sdk": "0.13.1",
-        "@unicitylabs/sphere-ui": "^0.1.38",
+        "@unicitylabs/sphere-ui": "^0.1.41",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
         "lucide-react": "^0.552.0",
@@ -3010,9 +3010,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.38.tgz",
-      "integrity": "sha512-pComa2oUTZMmDNqe2clDuxfYwlC2GA5M1QuwrZ9HcRbQzmdknJsRs1KzNOh/b7Pj+HvVIkn6UGeBiqvx4DoBow==",
+      "version": "0.1.41",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.41.tgz",
+      "integrity": "sha512-8W7O4HbhAtFCEVdfJEZwVOSW7iba1RYEhMprhnaXylkFfYL4C2eqttjue1PjGmQPbbwUUgj6eUvrt8vPNHz1vA==",
       "dependencies": {
         "framer-motion": "^11.18.2",
         "lucide-react": ">=0.400.0",
@@ -3024,6 +3024,7 @@
       "peerDependencies": {
         "@dnd-kit/core": "^6.0.0",
         "@dnd-kit/sortable": "^8.0.0 || ^10.0.0",
+        "@dnd-kit/utilities": "^3.0.0",
         "@tanstack/react-query": "^5.0.0",
         "@tanstack/react-table": "^8.0.0",
         "react": "^19.0.0",
@@ -3031,6 +3032,21 @@
         "recharts": "^3.0.0"
       },
       "peerDependenciesMeta": {
+        "@dnd-kit/core": {
+          "optional": true
+        },
+        "@dnd-kit/sortable": {
+          "optional": true
+        },
+        "@dnd-kit/utilities": {
+          "optional": true
+        },
+        "@tanstack/react-query": {
+          "optional": true
+        },
+        "@tanstack/react-table": {
+          "optional": true
+        },
         "recharts": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
     "@unicitylabs/sphere-sdk": "0.13.1",
-    "@unicitylabs/sphere-ui": "^0.1.38",
+    "@unicitylabs/sphere-ui": "^0.1.41",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",
     "lucide-react": "^0.552.0",


### PR DESCRIPTION
Picks up the `discord` icon key added in sphere-ui 0.1.41 (sphere-ui #27).

sphere-api now tags every announcement imported from a Discord channel with `icon: 'discord'` (sphere-api #72). Until this bump lands here, such an announcement renders under its type's default glyph — `iconForAnnouncement` falls back rather than showing an empty square, so nothing was broken, it just did not say where it came from.

Dependency bump only, no source changes.

## Verification

- `tsc --noEmit` clean
- `lint`: 0 errors
- test suite passes
- `npm ci --dry-run --legacy-peer-deps=false` passes — the lockfile was regenerated on a machine with `legacy-peer-deps=true` in its global npm config, which has previously produced a lockfile that installs locally and fails CI with `EUSAGE / Missing: … from lock file`. Checked explicitly for this reason.
