### PR TITLE
fix(connect)!: refuse duplicate send intents + raise the Connect SDK floor to 0.14.1

### DIFF
--- a/src/components/connect/ConnectContext.ts
+++ b/src/components/connect/ConnectContext.ts
@@ -82,6 +82,24 @@ export interface ConnectContextValue {
    * is clickjacking without an iframe (graceful lock §8.4).
    */
   intentInteractive: boolean;
+  /**
+   * (Re)start that settle window.
+   *
+   * THE INVARIANT: the window measures from the moment ACTIONABLE intent UI is
+   * first PRESENTED to the user — never from queue arrival. Any UI that can
+   * authorize or refuse an intent starts the window when it becomes visible.
+   *
+   * Arrival IS presentation for every modal that renders as soon as its intent
+   * reaches the head of the queue, and the provider arms then. UI that is held
+   * back first (the `send` intent's duplicate-payment check, which can take
+   * seconds) must call this when it finally appears — otherwise a check slower
+   * than the window hands the user a live primary button the instant the modal
+   * shows up, which is precisely what the shield exists to prevent.
+   *
+   * Every call restarts the window, so arming once per presentation — never on
+   * every render — is the CALLER's responsibility.
+   */
+  armIntentShield: () => void;
 
   approveConnection: (grantedPermissions: PermissionScope[]) => void;
   denyConnection: () => void;

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getPayments } from '../../sdk/payments';
-import { MessageSquare, PenLine, Coins, Inbox } from 'lucide-react';
+import { MessageSquare, PenLine, Coins, Inbox, AlertTriangle } from 'lucide-react';
 import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
 import { TokenRegistry, formatAmount } from '@unicitylabs/sphere-sdk';
 import { BaseModal, ModalHeader, Button } from '../wallet/ui';
@@ -11,6 +11,8 @@ import { useSendDM } from '../../sdk/hooks/comms/useSendDM';
 import { getErrorMessage } from '../../sdk/errors';
 import { useSphereContext } from '../../sdk';
 import { useSubscriptionKeyGuard } from '../../sdk/hooks/subscription';
+import { useDuplicateSendGuard } from './duplicateSendGuard';
+import { truncateId } from '../../utils/identifiers';
 
 /** Intents this wallet actually implements. Anything else is rejected cleanly. */
 const SUPPORTED_INTENTS = new Set(['send', 'payment_request', 'dm', 'sign_message', 'mint', 'receive']);
@@ -80,6 +82,9 @@ export function ConnectIntentHandler() {
   const [isMinting, setIsMinting] = useState(false);
   const [receiveError, setReceiveError] = useState<string | null>(null);
   const [isReceiving, setIsReceiving] = useState(false);
+  // Money-safety gate for `send` — see duplicateSendGuard.ts for the invariant.
+  const { guard: duplicateSend, approveAnyway: approveDuplicateSend } =
+    useDuplicateSendGuard(pendingIntent);
 
   // Validate/normalize params up front: reject malformed or unsupported intents
   // cleanly (INVALID_PARAMS / METHOD_NOT_FOUND) instead of opening a modal that
@@ -109,6 +114,87 @@ export function ConnectIntentHandler() {
 
   // --- Send Intent: confirm-only (amount fixed, base units, approve/reject) ---
   if (action === 'send') {
+    // THE INVARIANT (see duplicateSendGuard.ts): never execute a send intent
+    // that duplicates a payment already converging. The check runs BEFORE the
+    // send modal exists — a duplicate must never reach a plain "Send" button —
+    // and it fails open on any error/timeout, so it can never strand an intent.
+    //
+    // Nothing renders while it runs (usually one local store read). The §8.4
+    // settle shield still counts from when the intent became the head, so a
+    // slow check eats into that window — which is why THIS modal's safe action
+    // is the one sitting where every other intent modal puts its primary.
+    if (duplicateSend.status === 'checking') return null;
+
+    if (duplicateSend.status === 'duplicate') {
+      const match = duplicateSend.match;
+      const registry = TokenRegistry.getInstance();
+      const def = registry.getDefinition(params.coinId as string);
+      const displayAmount =
+        def?.symbol && def.decimals != null
+          ? formatAmount(String(params.amount), {
+              decimals: def.decimals,
+              symbol: def.symbol,
+              maxFractionDigits: 8,
+            })
+          : String(params.amount);
+      // USER_REJECTED — a human looked at it and said no, and nothing was
+      // spent for THIS intent. Honest, and a code every dApp already knows:
+      // inventing one would be unreadable to the client, and 4201
+      // (INTENT_OUTCOME_UNKNOWN) would falsely claim this intent's own money
+      // may have moved. The transferId in the message is how the dApp
+      // reconciles instead of retrying.
+      const declineMessage =
+        `Declined: a matching payment is still completing (transfer ${match.transferId}). ` +
+        `Do not re-send — reconcile against that transfer.`;
+      const decline = () => rejectIntent(intentId, ERROR_CODES.USER_REJECTED, declineMessage);
+
+      return (
+        <BaseModal isOpen={true} onClose={decline}>
+          <ModalHeader title="Payment already in progress" icon={AlertTriangle} onClose={decline} />
+
+          <div className="px-6 py-5 flex-1 flex flex-col justify-center">
+            <div className="bg-amber-50 dark:bg-amber-500/10 rounded-2xl p-5 mb-5 border border-amber-300 dark:border-amber-500/30">
+              <div className="text-sm text-neutral-700 dark:text-neutral-200">
+                A payment of{' '}
+                <span className="font-semibold text-neutral-900 dark:text-white break-all">
+                  {displayAmount}
+                </span>{' '}
+                to{' '}
+                <span className="font-semibold text-neutral-900 dark:text-white break-all">
+                  {params.to as string}
+                </span>{' '}
+                is still completing (transfer {truncateId(match.transferId)}).
+              </div>
+
+              <div className="mt-3 text-sm font-semibold text-amber-700 dark:text-amber-400">
+                Approving this sends a SECOND payment.
+              </div>
+
+              <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                The payment already in flight finishes on its own — the wallet keeps working on it.
+                {match.legs.total > 0 && (
+                  <> {match.legs.certified} of {match.legs.total} parts are already certified.</>
+                )}
+              </div>
+            </div>
+
+            {/* The destructive action is the SECONDARY button, and the safe one
+                sits where every other intent modal puts its primary — so a
+                reflex click on a modal that appeared under the cursor cannot
+                spend money. */}
+            <div className="flex gap-3">
+              <Button variant="secondary" fullWidth onClick={approveDuplicateSend}>
+                Send anyway
+              </Button>
+              <Button variant="primary" fullWidth onClick={decline}>
+                Don&apos;t send
+              </Button>
+            </div>
+          </div>
+        </BaseModal>
+      );
+    }
+
     return (
       <SendIntentModal
         to={params.to as string}

--- a/src/components/connect/ConnectIntentHandler.tsx
+++ b/src/components/connect/ConnectIntentHandler.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { getPayments } from '../../sdk/payments';
 import { MessageSquare, PenLine, Coins, Inbox, AlertTriangle } from 'lucide-react';
 import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
@@ -71,7 +71,8 @@ function validateIntent(action: string, params: Record<string, unknown>): Intent
 }
 
 export function ConnectIntentHandler() {
-  const { pendingIntent, resolveIntent, rejectIntent, registerAutoIntent } = useConnectContext();
+  const { pendingIntent, resolveIntent, rejectIntent, registerAutoIntent, armIntentShield } =
+    useConnectContext();
   const { sphere } = useSphereContext();
   const { ready: subscriptionKeyReady } = useSubscriptionKeyGuard();
   const { sendDM, isLoading: isSendingDM } = useSendDM();
@@ -97,6 +98,36 @@ export function ConnectIntentHandler() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingIntent]);
 
+  // THE INVARIANT (ConnectContext.armIntentShield): the §8.4 settle window
+  // measures from the moment actionable UI is PRESENTED. Every modal below
+  // renders the instant its intent reaches the head of the queue, so the
+  // provider's arrival arm is already the presentation arm for them — EXCEPT
+  // `send`, which is held behind the duplicate-payment check (up to
+  // DUPLICATE_CHECK_TIMEOUT_MS, i.e. far past the window). Both of that check's
+  // outcomes are actionable: the send confirmation, and the duplicate warning
+  // whose "Send anyway" spends a second time. So both arm on appearance, and
+  // the transition from the warning to the confirmation arms again — that is a
+  // fresh primary button under a cursor that just clicked one.
+  const shieldPresentation =
+    pendingIntent !== null &&
+    pendingIntent.action === 'send' &&
+    duplicateSend.status !== 'checking' &&
+    validateIntent(pendingIntent.action, pendingIntent.params) === null
+      ? `${pendingIntent.id}:${duplicateSend.status}`
+      : null;
+
+  // Arm ONCE per presentation: this component re-renders for reasons unrelated
+  // to what is on screen (DM error, mint progress, a parent sync), and re-arming
+  // on every render would hold the shield up indefinitely. A LAYOUT effect, so
+  // the shield is up in the SAME paint the modal first appears in — useEffect
+  // runs after paint, and that frame is real.
+  const armedForRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    if (shieldPresentation === null || armedForRef.current === shieldPresentation) return;
+    armedForRef.current = shieldPresentation;
+    armIntentShield();
+  }, [shieldPresentation, armIntentShield]);
+
   if (!pendingIntent) return null;
 
   // Captured HERE, so every callback below settles the intent this render belongs to. The
@@ -120,9 +151,10 @@ export function ConnectIntentHandler() {
     // and it fails open on any error/timeout, so it can never strand an intent.
     //
     // Nothing renders while it runs (usually one local store read). The §8.4
-    // settle shield still counts from when the intent became the head, so a
-    // slow check eats into that window — which is why THIS modal's safe action
-    // is the one sitting where every other intent modal puts its primary.
+    // settle shield is re-armed when the check's UI finally appears (see
+    // shieldPresentation above), so a slow check no longer spends the window
+    // behind a blank screen — and THIS modal's safe action is additionally the
+    // one sitting where every other intent modal puts its primary.
     if (duplicateSend.status === 'checking') return null;
 
     if (duplicateSend.status === 'duplicate') {

--- a/src/components/connect/ConnectProvider.tsx
+++ b/src/components/connect/ConnectProvider.tsx
@@ -18,6 +18,7 @@ import { ConnectIntentHandler } from './ConnectIntentHandler';
 import { registerConnectHost, unregisterConnectHost } from '../../sdk/connectHostRegistry';
 import { useSphereContext } from '../../sdk/hooks/core/useSphere';
 import { LockedRequestBadge, type LockedRequestCounts } from './LockedRequestBadge';
+import { INTENT_SETTLE_MS } from './settleWindow';
 
 /**
  * Recommended refusal text for WALLET_LOCKED, matching what the host sends. It
@@ -25,14 +26,6 @@ import { LockedRequestBadge, type LockedRequestCounts } from './LockedRequestBad
  * 4009 code. Nothing may depend on this string being byte-identical anywhere.
  */
 const WALLET_LOCKED_MESSAGE = 'Wallet is locked';
-
-/**
- * Clicks are swallowed for this long after the intent modal's contents change.
- * Every intent modal shares button geometry, so a swap under a stationary cursor
- * is clickjacking without an iframe — and a FIFO queue makes the moment
- * predictable (graceful lock §8.4).
- */
-const INTENT_SETTLE_MS = 500;
 
 interface ConnectProviderProps {
   children: ReactNode;

--- a/src/components/connect/ConnectProvider.tsx
+++ b/src/components/connect/ConnectProvider.tsx
@@ -150,6 +150,18 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
 
   const [intentInteractive, setIntentInteractive] = useState(false);
 
+  // THE INVARIANT: the settle window measures from the moment ACTIONABLE intent
+  // UI is first PRESENTED to the user — never from queue arrival. For every
+  // modal that renders as soon as its intent reaches the head those are the same
+  // instant, and arrival arms the window below. UI that is held back first — the
+  // `send` intent's duplicate-payment check, up to DUPLICATE_CHECK_TIMEOUT_MS —
+  // re-arms via armIntentShield() when it actually appears; otherwise a check
+  // slower than INTENT_SETTLE_MS handed the user a live Send button the instant
+  // the modal rendered, with the whole window already spent behind a blank
+  // screen.
+  const [shieldArm, setShieldArm] = useState(0);
+  const armIntentShield = useCallback(() => setShieldArm((n) => n + 1), []);
+
   useEffect(() => {
     if (!pendingIntent) {
       setIntentInteractive(false);
@@ -160,9 +172,10 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
     return () => clearTimeout(timer);
     // Keyed on the intent IDENTITY, not the object: the queue head object is
     // re-read on every sync, and depending on the object would restart the
-    // window forever.
+    // window forever. `shieldArm` is the explicit re-arm — it only ever changes
+    // when a caller says new actionable UI just appeared.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingIntent?.id]);
+  }, [pendingIntent?.id, shieldArm]);
 
   const releaseHost = useCallback(
     (host: ConnectHost) => {
@@ -275,6 +288,7 @@ export function ConnectProvider({ children }: ConnectProviderProps) {
     pendingApproval,
     pendingIntent,
     intentInteractive,
+    armIntentShield,
     approveConnection,
     denyConnection,
     resolveIntent,

--- a/src/components/connect/SendIntentModal.tsx
+++ b/src/components/connect/SendIntentModal.tsx
@@ -8,6 +8,7 @@ import { QuotaBlockedError } from '../../sdk/quotaGate';
 import { useUpgrade } from '../upgrade';
 import { showToast } from '../ui/toast-utils';
 import { IntentConfirmModal } from './IntentConfirmModal';
+import { sendIntentRecipient } from './duplicateSendGuard';
 
 interface SendIntentModalProps {
   /** Recipient: Unicity ID (@tag) or DIRECT:// address, as supplied by the dApp. */
@@ -58,7 +59,9 @@ export function SendIntentModal({ to, amount, coinId, memo, onResolve, onReject,
   const handleSend = async () => {
     setBusy(true);
     try {
-      const recipient = to.startsWith('DIRECT://') ? to : to.replace(/^@/, '');
+      // Shared with the duplicate-send guard, so the identifier this modal
+      // spends against is the identifier the guard resolved and matched.
+      const recipient = sendIntentRecipient(to);
       const result = await transfer({ coinId, amount, recipient, ...(memo ? { memo } : {}) });
       // #433: a deliveryPending result means the spend certified on-chain but the
       // recipient-side delivery is journaled for retry (§3.1). The dApp learns it

--- a/src/components/connect/duplicateSendGuard.ts
+++ b/src/components/connect/duplicateSendGuard.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { coinIdsMatch } from '@unicitylabs/sphere-sdk';
+import type { Sphere } from '@unicitylabs/sphere-sdk';
+import type { PendingTransfer } from '@unicitylabs/sphere-sdk/payments-v2';
+import { getPayments } from '../../sdk/payments';
+import { useSphereContext } from '../../sdk/hooks/core/useSphere';
+import { isChainPubkey } from '../../utils/identifiers';
+import type { PendingIntent } from './ConnectContext';
+
+/**
+ * THE INVARIANT: the wallet never executes a Connect `send` intent that
+ * duplicates a payment already converging.
+ *
+ * Why the WALLET has to own this — a dApp cannot be trusted to behave, and
+ * every layer under this one is blind to it:
+ *
+ *  - A keep-open send outcome (#631/#665: the spend may already be certified
+ *    on-chain, and the SDK converges that SAME transferId in-session) is
+ *    reported to the dApp as `{success:true, status:'pending',
+ *    deliveryPending:true}` — synthesized in useTransfer, handed on by
+ *    ConnectIntentHandler. A dApp that reads `status:'pending'` as "not
+ *    finished yet" and re-issues the intent is not misbehaving unreasonably;
+ *    it is reading a word that means "still converging" as "did not happen".
+ *  - Nothing below dedupes it. `ConnectHost.handleIntentRequest` and the
+ *    InFlightRegistry dedupe by REQUEST id, so a fresh request is fresh work;
+ *    the ConnectProvider queue is FIFO, not a deduper; and the SDK's
+ *    reservation ledger only stops the SAME token being spent twice — a new
+ *    transferId simply plans against the remaining free balance.
+ *  - Audit probe: seed 100 + 100, send 100 → keep-open; re-send 100 →
+ *    delivered. Recipient mailbox: 2 entries. SENT history: two transferIds.
+ *    200 delivered for a 100 request.
+ *  - It is version-independent (a 0.14.1+ dApp retrying does exactly this), so
+ *    the Connect SDK floor in config/connect.ts does NOT mitigate it.
+ *
+ * "Converging" is exactly `payments.pendingTransfers()` (sphere-sdk 0.14.2):
+ * the SDK derives that list ON READ from the intent backstop + delivery
+ * journal + shortfalls, so it survives a reload and needs no wallet-side
+ * bookkeeping of its own — nothing here is cached, and a re-issue after a
+ * refresh or a crash is caught exactly like one in the same session.
+ *
+ * The read happens when the intent ARRIVES, which is enough for the vector it
+ * closes: the SDK writes the backstop row at plan time, i.e. BEFORE the dApp
+ * receives any answer at all, so a re-issue can never outrun the row it must
+ * see. A row appearing later (another host's send going keep-open while this
+ * confirmation sits on screen) is outside the check.
+ *
+ * The guard NEVER auto-executes and NEVER silently rejects: a match raises a
+ * blocking confirmation naming the in-flight transfer (ConnectIntentHandler),
+ * because the user may genuinely want to pay the same person the same amount
+ * twice.
+ */
+
+/**
+ * Bounded wait for the check. It is one derived-store read plus at most one
+ * recipient resolution, but both can ride the network — and a guard that hangs
+ * would strand the dApp's intent behind a modal that never appears. On expiry
+ * the check FAILS OPEN (the send modal renders as before): the guard is a
+ * safety net over a rare outcome, never a gate that can freeze a payment.
+ */
+export const DUPLICATE_CHECK_TIMEOUT_MS = 4_000;
+
+/**
+ * The exact recipient string the send path spends against — SendIntentModal
+ * hands this to the SDK, and the guard resolves this, so both sides can never
+ * disagree about who is being paid.
+ */
+export function sendIntentRecipient(to: string): string {
+  return to.startsWith('DIRECT://') ? to : to.replace(/^@/, '');
+}
+
+/** Exact decimal-string compare in base units — BigInt on both sides, never a float. */
+function sameAmount(rowAmount: string, want: bigint): boolean {
+  const raw = rowAmount.trim();
+  if (raw === '') return false; // journal-only rows carry no amount
+  try {
+    return BigInt(raw) === want;
+  } catch {
+    return false;
+  }
+}
+
+export interface DuplicateSendTarget {
+  /** Recipient chain pubkey, already resolved (case-insensitive on compare). */
+  recipientPubkey: string;
+  coinId: string;
+  /** Base units, decimal string. */
+  amount: string;
+}
+
+/**
+ * The first converging transfer that pays the same recipient the same amount of
+ * the same coin, or null.
+ *
+ * Normalization: pubkey case-insensitive (the SDK lowercases a literal pubkey
+ * recipient but a binding-resolved one keeps its published case); coinId via
+ * the SDK's own `coinIdsMatch` (registry-canonical, so `UCT` and its 64-hex id
+ * are one coin); amount by BigInt equality.
+ *
+ * A journal-only row (delivery owed, payload gone) carries an empty coinId and
+ * amount and therefore never matches — it cannot be compared honestly, and
+ * blocking on recipient alone would refuse unrelated payments. A shortfall row
+ * (#690) carries the REMAINING amount, so re-issuing the original full amount
+ * against one does not match either: that is a partial settlement, a different
+ * problem from the duplicate this guard exists for.
+ */
+export function findDuplicatePending(
+  rows: readonly PendingTransfer[],
+  target: DuplicateSendTarget,
+): PendingTransfer | null {
+  const wantPubkey = target.recipientPubkey.trim().toLowerCase();
+  if (wantPubkey === '') return null;
+  let wantAmount: bigint;
+  try {
+    wantAmount = BigInt(target.amount.trim());
+  } catch {
+    return null;
+  }
+  return (
+    rows.find(
+      (row) =>
+        row.recipient.trim().toLowerCase() === wantPubkey &&
+        row.coinId !== '' &&
+        coinIdsMatch(row.coinId, target.coinId) &&
+        sameAmount(row.amount, wantAmount),
+    ) ?? null
+  );
+}
+
+/**
+ * Resolve an intent recipient to a chain pubkey the same way the send path
+ * does: the SDK's `resolveRecipientInfo` takes a literal chain pubkey as the
+ * answer and sends everything else through the peer resolver (`sphere.resolve`,
+ * the one SendModal and LookupModal use). Returns null when it cannot be
+ * resolved — the send itself would then fail INVALID_RECIPIENT anyway.
+ */
+async function resolveRecipientPubkey(sphere: Sphere | null, to: string): Promise<string | null> {
+  const identifier = sendIntentRecipient(to);
+  if (isChainPubkey(identifier)) return identifier;
+  const peer = await sphere?.resolve(identifier);
+  return peer?.chainPubkey ? peer.chainPubkey : null;
+}
+
+export type DuplicateSendGuard =
+  | { status: 'checking'; match: null }
+  | { status: 'clear'; match: null }
+  | { status: 'duplicate'; match: PendingTransfer };
+
+const CLEAR: DuplicateSendGuard = { status: 'clear', match: null };
+const CHECKING: DuplicateSendGuard = { status: 'checking', match: null };
+
+export interface UseDuplicateSendGuardReturn {
+  guard: DuplicateSendGuard;
+  /** The user looked at the warning and chose to pay twice anyway. */
+  approveAnyway: () => void;
+}
+
+/**
+ * Runs the invariant above for the `send` intent at the head of the queue.
+ * Non-send intents (and no intent at all) are always 'clear'.
+ */
+export function useDuplicateSendGuard(intent: PendingIntent | null): UseDuplicateSendGuardReturn {
+  const { sphere } = useSphereContext();
+  // Stamped with the intent it answers. A verdict is NEVER read for another
+  // intent: a send whose check has not settled reads 'checking' from the render
+  // itself, so the send modal cannot flash on screen in the frame before the
+  // effect starts (useEffect runs after paint — that frame is real).
+  const [checked, setChecked] = useState<{ intentId: number; guard: DuplicateSendGuard } | null>(null);
+  // Generation counter: the head advances (and StrictMode re-runs effects)
+  // while a check is in flight — only the newest run may write state.
+  const runRef = useRef(0);
+
+  const isSend = intent !== null && intent.action === 'send';
+  // Two identical back-to-back send intents — the double-pay case itself —
+  // differ ONLY by id, so the id has to be a dependency.
+  const intentId = intent?.id ?? null;
+  const to = isSend ? String(intent.params.to ?? '') : '';
+  const coinId = isSend ? String(intent.params.coinId ?? '') : '';
+  const amount = isSend ? String(intent.params.amount ?? '') : '';
+
+  useEffect(() => {
+    const run = ++runRef.current;
+    if (!isSend || intentId === null) return;
+
+    let done = false;
+    // `timer` is initialized before anything can call settle() — the timeout
+    // callback and the async pass below both run after this statement.
+    const settle = (next: DuplicateSendGuard) => {
+      if (done || runRef.current !== run) return;
+      done = true;
+      clearTimeout(timer);
+      setChecked({ intentId, guard: next });
+    };
+    const timer = setTimeout(() => settle(CLEAR), DUPLICATE_CHECK_TIMEOUT_MS);
+
+    void (async () => {
+      try {
+        const payments = getPayments(sphere);
+        if (!payments) return settle(CLEAR);
+        const rows = await payments.pendingTransfers();
+        // Nothing is converging: the overwhelmingly common case, and it costs
+        // no recipient resolution at all.
+        if (rows.length === 0) return settle(CLEAR);
+        const recipientPubkey = await resolveRecipientPubkey(sphere, to);
+        if (recipientPubkey === null) return settle(CLEAR);
+        const match = findDuplicatePending(rows, { recipientPubkey, coinId, amount });
+        settle(match === null ? CLEAR : { status: 'duplicate', match });
+      } catch {
+        // Fail open — see DUPLICATE_CHECK_TIMEOUT_MS.
+        settle(CLEAR);
+      }
+    })();
+
+    return () => clearTimeout(timer);
+  }, [sphere, isSend, intentId, to, coinId, amount]);
+
+  // Stamped with the intent the user was actually looking at, so an override
+  // can never leak to a later payment.
+  const approveAnyway = useCallback(() => {
+    if (intentId !== null) setChecked({ intentId, guard: CLEAR });
+  }, [intentId]);
+
+  const guard: DuplicateSendGuard = !isSend
+    ? CLEAR
+    : checked !== null && checked.intentId === intentId
+      ? checked.guard
+      : CHECKING;
+
+  return { guard, approveAnyway };
+}

--- a/src/components/connect/settleWindow.ts
+++ b/src/components/connect/settleWindow.ts
@@ -1,0 +1,13 @@
+/**
+ * Clicks are swallowed for this long after actionable, money-spending UI is
+ * first PRESENTED to the user. Every intent modal shares button geometry, so a
+ * swap under a stationary cursor is clickjacking without an iframe — and a
+ * FIFO queue makes the moment predictable (graceful lock §8.4).
+ *
+ * It lives alone in this leaf module because it is NOT Connect-only: the
+ * wallet's own SendModal arms the same window over its confirm step and its
+ * duplicate-payment warning (a user who double-taps their own Send button pays
+ * exactly as twice as a dApp that re-issues an intent). One constant, so the
+ * two surfaces can never drift into teaching different reflexes.
+ */
+export const INTENT_SETTLE_MS = 500;

--- a/src/components/wallet/L3/modals/SendModal.tsx
+++ b/src/components/wallet/L3/modals/SendModal.tsx
@@ -1,9 +1,12 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { getPayments } from '../../../../sdk/payments';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowRight, Loader2, User, CheckCircle, Coins, Hash, Copy, Check, Clock, Sparkles, RefreshCw } from 'lucide-react';
+import { ArrowRight, Loader2, User, CheckCircle, Coins, Hash, Copy, Check, Clock, Sparkles, RefreshCw, AlertTriangle } from 'lucide-react';
 import type { Asset, TransferResult } from '@unicitylabs/sphere-sdk';
+import type { PendingTransfer } from '@unicitylabs/sphere-sdk/payments-v2';
 import { parseTokenAmount, safeParseTokenAmount } from '@unicitylabs/sphere-sdk';
+import { findDuplicatePending, DUPLICATE_CHECK_TIMEOUT_MS } from '../../../connect/duplicateSendGuard';
+import { INTENT_SETTLE_MS } from '../../../connect/settleWindow';
 import { useAssets, useTransfer, formatAmount } from '../../../../sdk';
 import { getErrorMessage, isKeepOpenPendingResult } from '../../../../sdk/errors';
 import { useSphereContext } from '../../../../sdk/hooks/core/useSphere';
@@ -17,11 +20,29 @@ import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, Button, AlertMessage } from '../../ui';
 import { copyToClipboard } from '../../../../utils/copyToClipboard';
 
-type Step = 'asset' | 'details' | 'confirm' | 'processing' | 'success';
+type Step = 'asset' | 'details' | 'confirm' | 'duplicate' | 'processing' | 'success';
 
 interface SendModalProps {
   isOpen: boolean;
   onClose: (result?: { success: boolean }) => void;
+}
+
+/**
+ * The chain pubkey this send will actually be locked to, derived from what the
+ * modal already resolved — never a second resolution path. `null` means there
+ * is nothing to compare (a pasted DIRECT:// address, or a Unicity ID the peer
+ * lookup could not answer), and the duplicate check then fails open.
+ */
+function sendTargetPubkey(
+  mode: 'nametag' | 'pubkey',
+  recipient: string,
+  resolvedPubkey: string | null,
+): string | null {
+  if (mode === 'pubkey') {
+    const value = recipient.trim();
+    return isChainPubkey(value) ? value : null;
+  }
+  return resolvedPubkey;
 }
 
 export function SendModal({ isOpen, onClose }: SendModalProps) {
@@ -76,6 +97,87 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
     legs: { certified: number; total: number } | null;
   } | null>(null);
   const [isResuming, setIsResuming] = useState(false);
+
+  // THE INVARIANT (stated once in connect/duplicateSendGuard.ts): the wallet
+  // does not start a send that duplicates a payment already converging, and no
+  // control that can authorize one is live the instant it appears.
+  //
+  // The wallet's OWN send is the same hole the Connect path closed: a keep-open
+  // outcome ("Network is busy") leaves the SDK converging that transfer, but the
+  // reservation ledger only stops the SAME token being spent twice — a fresh
+  // attempt simply plans a NEW transferId against the remaining balance and the
+  // recipient is paid twice. A user who closes the busy screen and sends again,
+  // or double-taps Confirm, does exactly that.
+  //
+  // `findDuplicatePending` is the single matcher for both surfaces (imported,
+  // never re-implemented) and `INTENT_SETTLE_MS` the single settle window.
+  const [duplicateMatch, setDuplicateMatch] = useState<PendingTransfer | null>(null);
+  const [duplicateApproved, setDuplicateApproved] = useState(false);
+  const [isCheckingDuplicate, setIsCheckingDuplicate] = useState(false);
+  const sendAttemptRef = useRef(false);
+
+  /**
+   * The converging transfer this attempt would duplicate, or null.
+   *
+   * FAILS OPEN on every unhappy path — no payments facade, an unresolvable
+   * recipient, a throwing or slow `pendingTransfers()` (bounded by
+   * DUPLICATE_CHECK_TIMEOUT_MS, the Connect guard's own budget). A safety net
+   * over a rare outcome must never become a gate that blocks a legitimate send.
+   */
+  const findConvergingDuplicate = useCallback(
+    async (
+      recipientPubkey: string | null,
+      coinId: string,
+      amount: string,
+    ): Promise<PendingTransfer | null> => {
+      if (!recipientPubkey) return null;
+      const payments = getPayments(sphere);
+      if (!payments) return null;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const rows = await Promise.race([
+          payments.pendingTransfers(),
+          new Promise<null>((resolve) => {
+            timer = setTimeout(() => resolve(null), DUPLICATE_CHECK_TIMEOUT_MS);
+          }),
+        ]);
+        if (rows === null || rows.length === 0) return null;
+        return findDuplicatePending(rows, { recipientPubkey, coinId, amount });
+      } catch {
+        return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+    [sphere],
+  );
+
+  // The §8.4 settle window, local equivalent of the ConnectProvider shield
+  // (there is no provider here) and measured with the SAME constant.
+  //
+  // It is armed by a callback ref on every control that can authorize a spend,
+  // so the window starts when the control MOUNTS — not when the step state
+  // flips. Those differ: AnimatePresence mode="wait" holds the next step back
+  // until the previous one has finished exiting, and a window started at the
+  // state change would already be half spent behind an animation. Every arm is
+  // a real presentation: entering confirm, the duplicate warning, and the
+  // warning→proceed transition that puts a fresh Send button under a cursor
+  // that just clicked "Send anyway".
+  //
+  // Ref callbacks and the LAYOUT effect below both run in the commit phase, so
+  // the disabled state is in the control's FIRST paint — a useEffect runs after
+  // paint, and that frame is real and clickable.
+  const [actionsLive, setActionsLive] = useState(false);
+  const [shieldArm, setShieldArm] = useState(0);
+  const armSettleShield = useCallback((node: HTMLButtonElement | null) => {
+    if (node !== null) setShieldArm((n) => n + 1);
+  }, []);
+  useLayoutEffect(() => {
+    setActionsLive(false);
+    if (shieldArm === 0) return;
+    const timer = setTimeout(() => setActionsLive(true), INTENT_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [shieldArm]);
 
   // Clear the keep-open copy when the SDK's convergence lands: transfer:updated
   // for the SAME transferId with a done status flips the screen to plain
@@ -137,6 +239,8 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
     setQuotaBlocked(null);
     setDeliveryPending(false);
     setKeepOpen(null);
+    setDuplicateMatch(null);
+    setDuplicateApproved(false);
   };
 
   const handleClose = () => {
@@ -147,6 +251,9 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
   const getBackHandler = () => {
     if (step === 'details') return () => setStep('asset');
     if (step === 'confirm') return () => setStep('details');
+    // Backing out of the duplicate warning lands on the edit step — a safe
+    // place, and never one that can send.
+    if (step === 'duplicate') return () => { setDuplicateMatch(null); setStep('details'); };
     return handleClose;
   };
 
@@ -155,6 +262,7 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
       case 'asset': return 'Select Asset';
       case 'details': return 'Send';
       case 'confirm': return 'Confirm Transfer';
+      case 'duplicate': return 'Payment already in progress';
       case 'processing': return 'Processing...';
       case 'success': return 'Sent!';
     }
@@ -173,8 +281,15 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
     // Re-entering confirm via details is a fresh attempt — a quota block from
     // a previous send must not survive it (same lifecycle as recipientError).
     setQuotaBlocked(null);
+    // ...and neither may an override the user granted for an earlier
+    // recipient/amount: this attempt is checked on its own merits.
+    setDuplicateMatch(null);
+    setDuplicateApproved(false);
 
     try {
+      let finalRecipient: string;
+      let resolved: string | null = null;
+
       if (recipientMode === 'pubkey') {
         const value = recipient.trim();
         // Pasted DIRECT:// addresses stay accepted for compatibility — the SDK resolves them.
@@ -182,25 +297,38 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
           setRecipientError('Enter a valid public key (66 hex characters starting with 02 or 03)');
           return;
         }
-        setRecipient(value);
-        setResolvedPubkey(null);
-        setStep('confirm');
+        finalRecipient = value;
       } else {
         const cleanTag = recipient.replace('@', '').replace('@unicity', '').trim();
+        finalRecipient = cleanTag;
 
         if (sphere?.resolve) {
           const peerInfo = await sphere.resolve(`@${cleanTag}`);
-          if (peerInfo) {
-            setRecipient(cleanTag);
-            setResolvedPubkey(peerInfo.chainPubkey || null);
-            setStep('confirm');
-          } else {
+          if (!peerInfo) {
             setRecipientError(`User @${cleanTag} not found`);
+            return;
           }
-        } else {
-          setRecipient(cleanTag);
-          setStep('confirm');
+          resolved = peerInfo.chainPubkey || null;
         }
+      }
+
+      setRecipient(finalRecipient);
+      setResolvedPubkey(resolved);
+
+      // Learn about a converging duplicate HERE, before the confirm screen —
+      // the same resolution that feeds the confirm summary feeds the check, so
+      // the two can never disagree about who is being paid. handleSend checks
+      // again: this screen can sit open while another send goes keep-open.
+      const match = await findConvergingDuplicate(
+        sendTargetPubkey(recipientMode, finalRecipient, resolved),
+        selectedAsset.coinId,
+        targetAmount.toString(),
+      );
+      if (match) {
+        setDuplicateMatch(match);
+        setStep('duplicate');
+      } else {
+        setStep('confirm');
       }
     } catch (err) {
       setRecipientError(getErrorMessage(err));
@@ -212,14 +340,44 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
   // STEP 3: Execute transfer via SDK
   const handleSend = async () => {
     if (!selectedAsset || !amountInput || !recipient) return;
+    // Re-entrancy floor UNDER the disabled button: `isTransferring` and
+    // `isCheckingDuplicate` are React state, so they only stop a second click
+    // once a re-render has flushed. The ref flips synchronously — two clicks
+    // dispatched in one task (a queued double-tap, a programmatic re-dispatch)
+    // can never open two attempts. Cleared in `finally`, so no path can leave
+    // the button permanently dead.
+    if (isTransferring || isCheckingDuplicate || sendAttemptRef.current) return;
+    sendAttemptRef.current = true;
 
-    setStep('processing');
     setRecipientError(null);
     setQuotaBlocked(null);
     setKeepOpen(null);
 
     try {
       const amount = parseTokenAmount(amountInput, selectedAsset.decimals).toString();
+
+      // Last gate before money moves. Only an explicit "Send anyway" gets past
+      // a match — the user may genuinely want to pay the same person twice.
+      if (!duplicateApproved) {
+        setIsCheckingDuplicate(true);
+        let match: PendingTransfer | null;
+        try {
+          match = await findConvergingDuplicate(
+            sendTargetPubkey(recipientMode, recipient, resolvedPubkey),
+            selectedAsset.coinId,
+            amount,
+          );
+        } finally {
+          setIsCheckingDuplicate(false);
+        }
+        if (match) {
+          setDuplicateMatch(match);
+          setStep('duplicate');
+          return;
+        }
+      }
+
+      setStep('processing');
       const result = await transfer({
         coinId: selectedAsset.coinId,
         amount,
@@ -256,6 +414,8 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
         setRecipientError(getErrorMessage(e));
       }
       setStep('confirm');
+    } finally {
+      sendAttemptRef.current = false;
     }
   };
 
@@ -533,11 +693,66 @@ export function SendModal({ isOpen, onClose }: SendModalProps) {
                   Cancel
                 </button>
                 <button
+                  ref={armSettleShield}
                   onClick={handleSend}
-                  disabled={isTransferring || subsNotReady}
+                  disabled={isTransferring || subsNotReady || isCheckingDuplicate || !actionsLive}
                   className="flex-1 py-4 bg-orange-500 hover:bg-orange-600 dark:bg-brand-orange dark:hover:bg-brand-orange-dark text-white font-bold font-mono rounded-full transition-colors disabled:opacity-50"
                 >
                   Send
+                </button>
+              </div>
+            </motion.div>
+          )}
+
+          {/* 3b. DUPLICATE WARNING — a payment matching this one is still
+              converging. Same wording and same button shape as the Connect
+              duplicate modal (ConnectIntentHandler), so both surfaces teach the
+              user the same thing: the destructive action is the SECONDARY
+              button, and the safe one sits where the primary always is. */}
+          {step === 'duplicate' && duplicateMatch && selectedAsset && (
+            <motion.div key="dup" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              <div className="bg-amber-50 dark:bg-amber-500/10 rounded-2xl p-5 mb-5 border border-amber-300 dark:border-amber-500/30">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
+                  <div className="text-sm text-neutral-700 dark:text-neutral-200">
+                    A payment of{' '}
+                    <span className="font-semibold text-neutral-900 dark:text-white break-all">
+                      {amountInput} {selectedAsset.symbol}
+                    </span>{' '}
+                    to{' '}
+                    <span className="font-semibold text-neutral-900 dark:text-white break-all" title={recipient}>
+                      {recipientMode === 'pubkey' ? truncateId(stripDirectScheme(recipient)) : `@${recipient}`}
+                    </span>{' '}
+                    is still completing (transfer {truncateId(duplicateMatch.transferId)}).
+                  </div>
+                </div>
+
+                <div className="mt-3 text-sm font-semibold text-amber-700 dark:text-amber-400">
+                  Sending again pays TWICE.
+                </div>
+
+                <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                  The payment already in flight finishes on its own — the wallet keeps working on it.
+                  {duplicateMatch.legs.total > 0 && (
+                    <> {duplicateMatch.legs.certified} of {duplicateMatch.legs.total} parts are already certified.</>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  ref={armSettleShield}
+                  onClick={() => { setDuplicateApproved(true); setDuplicateMatch(null); setStep('confirm'); }}
+                  disabled={!actionsLive}
+                  className="flex-1 py-4 bg-neutral-100 dark:bg-white/6 hover:bg-neutral-200 dark:hover:bg-white/10 text-neutral-700 dark:text-white/65 font-semibold font-mono rounded-full transition-colors disabled:opacity-50"
+                >
+                  Send anyway
+                </button>
+                <button
+                  onClick={() => { setDuplicateMatch(null); setStep('details'); }}
+                  className="flex-1 py-4 bg-orange-500 hover:bg-orange-600 dark:bg-brand-orange dark:hover:bg-brand-orange-dark text-white font-bold font-mono rounded-full transition-colors"
+                >
+                  Don&apos;t send
                 </button>
               </div>
             </motion.div>

--- a/src/config/connect.ts
+++ b/src/config/connect.ts
@@ -6,19 +6,25 @@
  * Minimum `@unicitylabs/sphere-sdk` version a connecting dApp must be built
  * against for this wallet to accept its Sphere Connect handshake.
  *
- * The wallet is on the 0.12.x line; apps built against < 0.12 speak an
- * incompatible Connect / token contract, so their handshake is refused by the
- * SDK's compatibility gate (`checkCompatibility` → `protocol_incompatible`),
- * surfaced to the user via `onConnectionRejected` (and silently dropped for
- * background auto-connect attempts).
+ * The wallet is on the 0.14.x line (post-P11-flip: payments-v2 is the only
+ * money path). Apps below 0.14.1 still CONNECT correctly — the host's
+ * wire-compat adapter serves the old query and event names — but they read a
+ * surface that has moved underneath them: `Asset.unconfirmed*` is pinned to
+ * zero, `Token.status` lost values they filter on, `payment_request:settling`
+ * and `:response` never fire, and history `tokenIds[].id` carries a coinId.
+ * Those are silent wrong answers, which is worse than a refusal that names
+ * the required version.
  *
- * The floor is the earliest 0.12.0 PRE-RELEASE (`-0`), not `0.12.0`, because
- * semver orders prereleases below the release. The wallet ships stable
- * `0.12.0`, but dApps mid-migration (and dev builds) may still be on a
- * `0.12.0-dev.x` prerelease; a plain `0.12.0` floor would reject those
- * (`compareSemver('0.12.0-dev.1', '0.12.0') === -1`). `0.12.0-0` admits any
- * 0.12.0 prerelease and up while still rejecting every 0.11.x and below.
+ * `-0` admits any 0.14.1 PRERELEASE (semver orders prereleases below the
+ * release), so dev builds mid-migration are not refused.
  *
- * Bump this in lockstep with the wallet's major.minor line.
+ * Keep in lockstep with the SDK's own `DEFAULT_MIN_CLIENT_SDK_VERSION`
+ * (sphere-sdk connect/protocol.ts) — this constant OVERRIDES that default,
+ * so a stale value here silently disables the SDK floor entirely (it did:
+ * this sat at 0.12.0-0 through the 0.13 and 0.14 lines).
+ *
+ * NOT a double-pay control: re-issuing a `send` intent after a keep-open
+ * outcome is version-independent. That is guarded in ConnectIntentHandler
+ * against `payments.pendingTransfers()`.
  */
-export const CONNECT_MIN_SDK_VERSION = '0.12.0-0';
+export const CONNECT_MIN_SDK_VERSION = '0.14.1-0';

--- a/tests/unit/components/connectIntentShieldPresentation.test.tsx
+++ b/tests/unit/components/connectIntentShieldPresentation.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * THE INVARIANT (ConnectContext.armIntentShield): the §8.4 settle window
+ * measures from the moment ACTIONABLE intent UI is first PRESENTED to the user
+ * — never from queue arrival.
+ *
+ * The bug it closes: the shield used to be armed by the intent ARRIVING at the
+ * head of the queue. The duplicate-send guard can hold the send modal back for
+ * up to DUPLICATE_CHECK_TIMEOUT_MS (a pendingTransfers() read plus a recipient
+ * resolution, both able to ride the network). A check slower than the 500 ms
+ * window therefore spent the whole window behind a BLANK screen, and the modal
+ * appeared with a live "Send" button under the cursor — exactly the
+ * accidental-click / clickjack case the shield exists for.
+ *
+ * This drives the real ConnectProvider + real ConnectIntentHandler together,
+ * because the defect only exists in the seam between them.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import type { ConnectHost, DAppMetadata } from '@unicitylabs/sphere-sdk/connect';
+import type { PendingTransfer } from '@unicitylabs/sphere-sdk/payments-v2';
+
+const COIN = 'c'.repeat(64);
+const BOB_PUBKEY = `02${'a'.repeat(64)}`;
+
+const ASSET = {
+  coinId: COIN,
+  symbol: 'UCT',
+  name: 'Unicity',
+  decimals: 0,
+  totalAmount: '1000',
+  confirmedAmount: '1000',
+  unconfirmedAmount: '0',
+  tokenCount: 1,
+  iconUrl: null,
+  priceUsd: null,
+};
+
+const transferMock = vi.fn();
+const pendingTransfersMock = vi.fn(async (): Promise<PendingTransfer[]> => []);
+const fakeSphere = {
+  resolve: vi.fn(async () => ({ chainPubkey: BOB_PUBKEY })),
+  payments: { pendingTransfers: pendingTransfersMock },
+};
+
+vi.mock('../../../src/sdk', () => ({
+  useSphereContext: () => ({ sphere: fakeSphere }),
+  useAssets: () => ({ assets: [ASSET] }),
+  useTransfer: () => ({
+    transfer: transferMock,
+    isLoading: false,
+    error: null,
+    lastResult: null,
+    reset: vi.fn(),
+  }),
+}));
+// ConnectProvider needs `isLocked`; the duplicate guard needs `sphere`.
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ sphere: fakeSphere, isLocked: false, unlock: vi.fn(async () => {}) }),
+}));
+vi.mock('../../../src/sdk/hooks/subscription', () => ({
+  useSubscriptionKeyGuard: () => ({ ready: true, assertReady: vi.fn() }),
+}));
+vi.mock('../../../src/sdk/hooks/comms/useSendDM', () => ({
+  useSendDM: () => ({ sendDM: vi.fn(), isLoading: false }),
+}));
+vi.mock('../../../src/components/upgrade', () => ({
+  useUpgrade: () => ({ openUpgrade: vi.fn() }),
+}));
+vi.mock('../../../src/components/connect/ConnectionApprovalModal', () => ({
+  ConnectionApprovalModal: () => null,
+}));
+
+import { ConnectProvider } from '../../../src/components/connect/ConnectProvider';
+import {
+  useConnectContext,
+  type ConnectContextValue,
+} from '../../../src/components/connect/ConnectContext';
+import { clearConnectHosts } from '../../../src/sdk/connectHostRegistry';
+
+/** Copy unique to SendIntentModal — its presence means the send confirmation is on screen. */
+const SEND_MODAL_COPY = 'This dApp is asking to send tokens from your wallet.';
+const SETTLE_MS = 500;
+/** How long the guard check takes here — deliberately past the settle window. */
+const SLOW_CHECK_MS = 1200;
+
+const host = { id: 'A' } as unknown as ConnectHost;
+
+let ctx: ConnectContextValue | null = null;
+function Probe() {
+  ctx = useConnectContext();
+  return <div data-testid="interactive">{String(ctx.intentInteractive)}</div>;
+}
+
+function shielded(): boolean {
+  return screen.queryByTestId('intent-settle-shield') !== null;
+}
+
+function sendIntent() {
+  act(() => {
+    void ctx!.requestIntent(host, 'https://dapp.example', 'send', {
+      to: '@bob',
+      amount: '100',
+      coinId: COIN,
+    });
+  });
+}
+
+/** A pendingTransfers() read that answers only after `ms` of (fake) time. */
+function slowCheck(rows: PendingTransfer[], ms: number) {
+  pendingTransfersMock.mockImplementation(
+    () => new Promise<PendingTransfer[]>((resolve) => setTimeout(() => resolve(rows), ms)),
+  );
+}
+
+function pendingRow(): PendingTransfer {
+  return {
+    transferId: 'tf_9d2c4e7a1b3f',
+    kind: 'open',
+    recipient: BOB_PUBKEY,
+    coinId: COIN,
+    amount: '100',
+    legs: { certified: 1, total: 2 },
+    deliveryPending: true,
+    createdAt: 1,
+  };
+}
+
+beforeEach(() => {
+  ctx = null;
+  clearConnectHosts();
+  transferMock.mockReset();
+  transferMock.mockResolvedValue({ id: 'tid', status: 'confirmed', tokens: [], tokenTransfers: [] });
+  pendingTransfersMock.mockReset();
+  pendingTransfersMock.mockResolvedValue([]);
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  clearConnectHosts();
+});
+
+describe('settle shield arms when the intent UI is PRESENTED, not when it arrives', () => {
+  it('a 1200 ms duplicate check still yields a shielded Send for the full window after the modal appears', async () => {
+    slowCheck([], SLOW_CHECK_MS);
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+    act(() => ctx!.attachHost(host, 'https://a.example'));
+
+    sendIntent();
+
+    // The arrival window burns while the check runs behind a blank screen —
+    // nothing actionable is on screen, so it protects nothing.
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS); });
+    expect(screen.queryByText(SEND_MODAL_COPY)).toBeNull();
+
+    // The check answers: the Send button appears NOW, and the window restarts NOW.
+    await act(async () => { vi.advanceTimersByTime(SLOW_CHECK_MS - SETTLE_MS); });
+    expect(screen.getByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(shielded()).toBe(true);
+    expect(screen.getByTestId('interactive').textContent).toBe('false');
+
+    // Still shielded a tick before the window closes...
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS - 1); });
+    expect(shielded()).toBe(true);
+
+    // ...and released only after a full INTENT_SETTLE_MS of the modal being visible.
+    await act(async () => { vi.advanceTimersByTime(1); });
+    expect(shielded()).toBe(false);
+    expect(screen.getByTestId('interactive').textContent).toBe('true');
+  });
+
+  it('shields the duplicate warning from ITS appearance — "Send anyway" spends a second time', async () => {
+    slowCheck([pendingRow()], SLOW_CHECK_MS);
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+    act(() => ctx!.attachHost(host, 'https://a.example'));
+
+    sendIntent();
+    await act(async () => { vi.advanceTimersByTime(SLOW_CHECK_MS); });
+
+    expect(screen.getByText('Payment already in progress')).toBeTruthy();
+    expect(shielded()).toBe(true);
+
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS); });
+    expect(shielded()).toBe(false);
+
+    // Choosing "Send anyway" swaps in a fresh primary button under the cursor
+    // that just clicked — that is a new presentation, so it re-arms.
+    await act(async () => { fireEvent.click(screen.getByText('Send anyway')); });
+    expect(screen.getByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(shielded()).toBe(true);
+    expect(transferMock).not.toHaveBeenCalled();
+
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS); });
+    expect(shielded()).toBe(false);
+  });
+
+  it('an immediately presented intent keeps the arrival-armed window (no regression, no double window)', async () => {
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+    act(() => ctx!.attachHost(host, 'https://a.example'));
+
+    act(() => {
+      void ctx!.requestIntent(host, 'https://a.example', 'sign_message', { message: 'hi' });
+    });
+
+    expect(screen.getByText('Sign Message')).toBeTruthy();
+    expect(shielded()).toBe(true);
+
+    // Exactly one window, measured from arrival — the handler must not add a
+    // second one for UI that was never delayed.
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS); });
+    expect(shielded()).toBe(false);
+    expect(screen.getByTestId('interactive').textContent).toBe('true');
+  });
+
+  it('does not re-arm on a re-render that changes nothing about what is presented', async () => {
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+    act(() => ctx!.attachHost(host, 'https://a.example'));
+
+    sendIntent();
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(screen.getByText(SEND_MODAL_COPY)).toBeTruthy();
+
+    // Half the window in, force unrelated re-renders of the whole tree (a
+    // connection approval queuing behind the intent re-renders the provider and
+    // every child). If arming were per-render the window would never close.
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS / 2); });
+    act(() => {
+      void ctx!.requestApproval(host, { name: 'dapp' } as DAppMetadata, [], 'https://a.example');
+      void ctx!.requestApproval(host, { name: 'dapp' } as DAppMetadata, [], 'https://a.example');
+    });
+    expect(shielded()).toBe(true);
+
+    // The window still closes on its ORIGINAL schedule.
+    await act(async () => { vi.advanceTimersByTime(SETTLE_MS / 2); });
+    expect(shielded()).toBe(false);
+  });
+});

--- a/tests/unit/components/connectSendIntentDuplicateGuard.test.tsx
+++ b/tests/unit/components/connectSendIntentDuplicateGuard.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * THE INVARIANT: the wallet never executes a Connect `send` intent that
+ * duplicates a payment already converging (`payments.pendingTransfers()`).
+ *
+ * The bug it closes: a keep-open send outcome is reported to the dApp as
+ * `{success:true, status:'pending', deliveryPending:true}`. A dApp reading
+ * `status:'pending'` as "not finished" and re-issuing the intent used to get a
+ * SECOND SPEND — nothing below ConnectIntentHandler dedupes it (the host and
+ * the InFlightRegistry dedupe by REQUEST id; the SDK's reservation ledger only
+ * stops the SAME token being re-spent, so a new transferId simply plans against
+ * the remaining free balance). Probe: seed 100+100, send 100 → keep-open,
+ * re-send 100 → delivered; 200 delivered for a 100 request.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import type { ConnectHost } from '@unicitylabs/sphere-sdk/connect';
+import { ERROR_CODES } from '@unicitylabs/sphere-sdk/connect';
+import type { PendingTransfer } from '@unicitylabs/sphere-sdk/payments-v2';
+
+const COIN = 'c'.repeat(64);
+const BOB_PUBKEY = `02${'a'.repeat(64)}`;
+const CAROL_PUBKEY = `03${'b'.repeat(64)}`;
+
+const ASSET = {
+  coinId: COIN,
+  symbol: 'UCT',
+  name: 'Unicity',
+  decimals: 0,
+  totalAmount: '1000',
+  confirmedAmount: '1000',
+  unconfirmedAmount: '0',
+  tokenCount: 1,
+  iconUrl: null,
+  priceUsd: null,
+};
+
+const transferMock = vi.fn();
+const resolveMock = vi.fn(async () => ({ chainPubkey: BOB_PUBKEY }));
+const pendingTransfersMock = vi.fn(async (): Promise<PendingTransfer[]> => []);
+
+const fakeSphere = {
+  resolve: resolveMock,
+  payments: { pendingTransfers: pendingTransfersMock },
+};
+
+// ConnectIntentHandler reads useSphereContext from the barrel; the guard reads
+// it from the deep module — both must see the same fake wallet.
+vi.mock('../../../src/sdk', async () => {
+  const { formatAmount } = await vi.importActual<typeof import('../../../src/sdk/utils/format')>(
+    '../../../src/sdk/utils/format',
+  );
+  return {
+    formatAmount,
+    useSphereContext: () => ({ sphere: fakeSphere }),
+    useAssets: () => ({ assets: [ASSET] }),
+    useTransfer: () => ({
+      transfer: transferMock,
+      isLoading: false,
+      error: null,
+      lastResult: null,
+      reset: vi.fn(),
+    }),
+  };
+});
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ sphere: fakeSphere }),
+}));
+vi.mock('../../../src/sdk/hooks/subscription', () => ({
+  useSubscriptionKeyGuard: () => ({ ready: true, assertReady: vi.fn() }),
+}));
+vi.mock('../../../src/sdk/hooks/comms/useSendDM', () => ({
+  useSendDM: () => ({ sendDM: vi.fn(), isLoading: false }),
+}));
+vi.mock('../../../src/components/upgrade', () => ({
+  useUpgrade: () => ({ openUpgrade: vi.fn() }),
+}));
+
+const resolveIntent = vi.fn();
+const rejectIntent = vi.fn();
+let pendingIntent: {
+  id: number;
+  host: ConnectHost;
+  origin: string;
+  action: string;
+  params: Record<string, unknown>;
+  resolve: (result: unknown) => void;
+} | null = null;
+
+vi.mock('../../../src/components/connect/ConnectContext', () => ({
+  useConnectContext: () => ({
+    pendingIntent,
+    resolveIntent,
+    rejectIntent,
+    registerAutoIntent: vi.fn(),
+  }),
+}));
+
+import { ConnectIntentHandler } from '../../../src/components/connect/ConnectIntentHandler';
+import { DUPLICATE_CHECK_TIMEOUT_MS } from '../../../src/components/connect/duplicateSendGuard';
+
+function sendIntent(params: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    host: {} as ConnectHost,
+    origin: 'https://dapp.example',
+    action: 'send',
+    params: { to: '@bob', amount: '100', coinId: COIN, ...params },
+    resolve: vi.fn(),
+  };
+}
+
+function pendingRow(over: Partial<PendingTransfer> = {}): PendingTransfer {
+  return {
+    transferId: 'tf_9d2c4e7a1b3f',
+    kind: 'open',
+    recipient: BOB_PUBKEY,
+    coinId: COIN,
+    amount: '100',
+    legs: { certified: 1, total: 2 },
+    deliveryPending: true,
+    createdAt: 1,
+    ...over,
+  };
+}
+
+/** Copy unique to SendIntentModal — its presence means the send path was reached. */
+const SEND_MODAL_COPY = 'This dApp is asking to send tokens from your wallet.';
+
+beforeEach(() => {
+  transferMock.mockReset();
+  transferMock.mockResolvedValue({
+    id: 'tid-new',
+    status: 'confirmed',
+    tokens: [],
+    tokenTransfers: [],
+  });
+  resolveMock.mockClear();
+  resolveMock.mockResolvedValue({ chainPubkey: BOB_PUBKEY });
+  pendingTransfersMock.mockReset();
+  pendingTransfersMock.mockResolvedValue([]);
+  resolveIntent.mockClear();
+  rejectIntent.mockClear();
+  pendingIntent = sendIntent();
+});
+
+describe('Connect send intent — duplicate-payment guard', () => {
+  it('blocks a send intent that duplicates a converging transfer: warning shown, send path never reached', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+
+    render(<ConnectIntentHandler />);
+
+    expect(await screen.findByText('Payment already in progress')).toBeTruthy();
+    // Names the amount, the recipient and the in-flight transfer — a warning
+    // that does not identify what is already converging is not actionable.
+    const line = screen.getByText(/is still completing/).textContent ?? '';
+    expect(line).toContain('100');
+    expect(line).toContain('@bob');
+    expect(line).toContain('tf_9d2...1b3f');
+    expect(screen.getByText('Approving this sends a SECOND payment.')).toBeTruthy();
+
+    // The plain "Send" confirmation must never have rendered...
+    expect(screen.queryByText(SEND_MODAL_COPY)).toBeNull();
+    // ...and no money moved, in either direction.
+    expect(transferMock).not.toHaveBeenCalled();
+    expect(resolveIntent).not.toHaveBeenCalled();
+    expect(rejectIntent).not.toHaveBeenCalled();
+  });
+
+  it('declining resolves the intent with USER_REJECTED naming the transfer, and never spends', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+
+    render(<ConnectIntentHandler />);
+    fireEvent.click(await screen.findByText("Don't send"));
+
+    expect(rejectIntent).toHaveBeenCalledTimes(1);
+    const [id, code, message] = rejectIntent.mock.calls[0]!;
+    expect(id).toBe(7);
+    expect(code).toBe(ERROR_CODES.USER_REJECTED);
+    expect(message).toContain('tf_9d2c4e7a1b3f');
+    expect(message).toMatch(/still completing/i);
+    expect(transferMock).not.toHaveBeenCalled();
+  });
+
+  it('approving explicitly DOES send — the user may genuinely want to pay twice', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+
+    render(<ConnectIntentHandler />);
+    fireEvent.click(await screen.findByText('Send anyway'));
+
+    // Only now does the normal confirm modal appear.
+    expect(await screen.findByText(SEND_MODAL_COPY)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(transferMock).toHaveBeenCalledTimes(1));
+    expect(transferMock).toHaveBeenCalledWith({ coinId: COIN, amount: '100', recipient: 'bob' });
+    await waitFor(() => expect(resolveIntent).toHaveBeenCalledTimes(1));
+    expect(resolveIntent.mock.calls[0]![1]).toMatchObject({ success: true });
+    expect(rejectIntent).not.toHaveBeenCalled();
+  });
+
+  it('matches a converging transfer whose recipient pubkey differs only in case', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow({ recipient: BOB_PUBKEY.toUpperCase() })]);
+
+    render(<ConnectIntentHandler />);
+
+    expect(await screen.findByText('Payment already in progress')).toBeTruthy();
+    expect(screen.queryByText(SEND_MODAL_COPY)).toBeNull();
+  });
+
+  it('passes through when nothing is converging — and costs no recipient resolution', async () => {
+    pendingTransfersMock.mockResolvedValue([]);
+
+    render(<ConnectIntentHandler />);
+
+    expect(await screen.findByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(screen.queryByText('Payment already in progress')).toBeNull();
+    expect(resolveMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a different amount', { row: { amount: '101' }, intent: {} }],
+    ['a different recipient', { row: { recipient: CAROL_PUBKEY }, intent: {} }],
+    ['a different coin', { row: { coinId: 'd'.repeat(64) }, intent: {} }],
+    ['a different requested amount', { row: {}, intent: { amount: '99' } }],
+  ])('passes an intent through untouched when the pending transfer has %s', async (_label, spec) => {
+    pendingTransfersMock.mockResolvedValue([pendingRow(spec.row as Partial<PendingTransfer>)]);
+    pendingIntent = sendIntent(spec.intent);
+
+    render(<ConnectIntentHandler />);
+
+    expect(await screen.findByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(screen.queryByText('Payment already in progress')).toBeNull();
+    expect(rejectIntent).not.toHaveBeenCalled();
+  });
+
+  it('fails open: a pendingTransfers() outage never strands the intent', async () => {
+    pendingTransfersMock.mockRejectedValue(new Error('offline'));
+
+    render(<ConnectIntentHandler />);
+
+    expect(await screen.findByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(rejectIntent).not.toHaveBeenCalled();
+  });
+
+  it('fails open on a check that never answers — a guard may never freeze a payment', async () => {
+    vi.useFakeTimers();
+    try {
+      pendingTransfersMock.mockReturnValue(new Promise<PendingTransfer[]>(() => {}));
+
+      render(<ConnectIntentHandler />);
+      // Nothing is on screen while the check is in flight: the send modal must
+      // never render behind the guard's back.
+      expect(screen.queryByText(SEND_MODAL_COPY)).toBeNull();
+
+      await act(async () => {
+        vi.advanceTimersByTime(DUPLICATE_CHECK_TIMEOUT_MS);
+      });
+
+      expect(screen.getByText(SEND_MODAL_COPY)).toBeTruthy();
+      expect(rejectIntent).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/components/connectSendIntentDuplicateGuard.test.tsx
+++ b/tests/unit/components/connectSendIntentDuplicateGuard.test.tsx
@@ -77,6 +77,13 @@ vi.mock('../../../src/components/upgrade', () => ({
 
 const resolveIntent = vi.fn();
 const rejectIntent = vi.fn();
+/**
+ * ConnectProvider's settle-window arm. The handler must call it exactly once
+ * per PRESENTATION — the send confirmation and the duplicate warning each count
+ * as one, and a plain re-render counts as none. The window itself is verified
+ * end to end in connectIntentShieldPresentation.test.tsx.
+ */
+const armIntentShield = vi.fn();
 let pendingIntent: {
   id: number;
   host: ConnectHost;
@@ -92,6 +99,7 @@ vi.mock('../../../src/components/connect/ConnectContext', () => ({
     resolveIntent,
     rejectIntent,
     registerAutoIntent: vi.fn(),
+    armIntentShield,
   }),
 }));
 
@@ -140,6 +148,7 @@ beforeEach(() => {
   pendingTransfersMock.mockResolvedValue([]);
   resolveIntent.mockClear();
   rejectIntent.mockClear();
+  armIntentShield.mockClear();
   pendingIntent = sendIntent();
 });
 
@@ -261,5 +270,66 @@ describe('Connect send intent — duplicate-payment guard', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+/**
+ * The guard delays the modal, so the §8.4 settle window can no longer be
+ * measured from the intent's ARRIVAL — it is armed when the UI is PRESENTED.
+ * Here: WHO arms and HOW OFTEN. That the armed window actually shields the
+ * button is proven end to end in connectIntentShieldPresentation.test.tsx.
+ */
+describe('Connect send intent — settle shield arms per presentation', () => {
+  it('arms when the send confirmation appears after a check that outlives the window', async () => {
+    vi.useFakeTimers();
+    try {
+      // Answers only at 1200 ms — well past the 500 ms window the intent's
+      // arrival started.
+      pendingTransfersMock.mockReturnValue(
+        new Promise<PendingTransfer[]>((resolve) => setTimeout(() => resolve([]), 1200)),
+      );
+
+      render(<ConnectIntentHandler />);
+      // Nothing actionable is on screen yet, so nothing to shield.
+      expect(armIntentShield).not.toHaveBeenCalled();
+
+      await act(async () => { vi.advanceTimersByTime(1200); });
+
+      expect(screen.getByText(SEND_MODAL_COPY)).toBeTruthy();
+      expect(armIntentShield).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('arms for the duplicate warning too, and again for the confirmation behind "Send anyway"', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+
+    render(<ConnectIntentHandler />);
+
+    // "Send anyway" is destructive — it deserves the window as much as "Send".
+    expect(await screen.findByText('Payment already in progress')).toBeTruthy();
+    expect(armIntentShield).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Send anyway'));
+
+    // A fresh primary button just appeared under the cursor that clicked the
+    // secondary one — a new presentation, a new window.
+    expect(await screen.findByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(armIntentShield).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-arm on re-renders that present nothing new', async () => {
+    const { rerender } = render(<ConnectIntentHandler />);
+
+    expect(await screen.findByText(SEND_MODAL_COPY)).toBeTruthy();
+    expect(armIntentShield).toHaveBeenCalledTimes(1);
+
+    rerender(<ConnectIntentHandler />);
+    rerender(<ConnectIntentHandler />);
+
+    // Re-arming per render would hold the shield up for as long as the modal is
+    // open, which is not a settle window — it is a broken modal.
+    expect(armIntentShield).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/components/intentSettleGuard.test.tsx
+++ b/tests/unit/components/intentSettleGuard.test.tsx
@@ -76,6 +76,57 @@ describe('intent settle-time guard', () => {
     expect(screen.getByTestId('interactive').textContent).toBe('false');
   });
 
+  it('re-arms on demand, even after the arrival window has already elapsed', () => {
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+    act(() => ctx!.attachHost(host, 'https://a.example'));
+
+    act(() => { void ctx!.requestIntent(host, 'https://a.example', 'send', {}); });
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(screen.getByTestId('interactive').textContent).toBe('true');
+
+    // Same intent, but its actionable UI is only being PRESENTED now (a
+    // duplicate-send check that finally answered). The window measures from
+    // here — arrival shielded a blank screen.
+    act(() => ctx!.armIntentShield());
+
+    expect(screen.getByTestId('intent-settle-shield')).toBeDefined();
+    expect(screen.getByTestId('interactive').textContent).toBe('false');
+
+    act(() => { vi.advanceTimersByTime(499); });
+    expect(screen.getByTestId('interactive').textContent).toBe('false');
+    act(() => { vi.advanceTimersByTime(1); });
+    expect(screen.getByTestId('interactive').textContent).toBe('true');
+  });
+
+  it('an arm mid-window restarts it in full instead of inheriting the remainder', () => {
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+    act(() => ctx!.attachHost(host, 'https://a.example'));
+
+    act(() => { void ctx!.requestIntent(host, 'https://a.example', 'send', {}); });
+    act(() => { vi.advanceTimersByTime(400); });
+
+    act(() => ctx!.armIntentShield());
+
+    // The arrival timer must have been cleared: if it survived, 100 ms more
+    // would release the button 400 ms early.
+    act(() => { vi.advanceTimersByTime(100); });
+    expect(screen.getByTestId('interactive').textContent).toBe('false');
+
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(screen.getByTestId('interactive').textContent).toBe('true');
+  });
+
+  it('arming with nothing on screen shields nothing', () => {
+    render(<ConnectProvider><Probe /></ConnectProvider>);
+
+    act(() => ctx!.armIntentShield());
+
+    // No intent, no actionable UI — and therefore no full-screen click eater
+    // over a wallet the user is using normally.
+    expect(screen.queryByTestId('intent-settle-shield')).toBeNull();
+    expect(screen.getByTestId('interactive').textContent).toBe('false');
+  });
+
   it('renders no shield when there is no intent on screen', () => {
     render(<ConnectProvider><Probe /></ConnectProvider>);
     expect(screen.queryByTestId('intent-settle-shield')).toBeNull();

--- a/tests/unit/components/sendModalDuplicateGuard.test.tsx
+++ b/tests/unit/components/sendModalDuplicateGuard.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * THE INVARIANT (stated in src/components/connect/duplicateSendGuard.ts): the
+ * wallet does not start a send that duplicates a payment already converging,
+ * and no control that can authorize one is live the instant it appears.
+ *
+ * The Connect path was closed first (ConnectIntentHandler + the presentation-
+ * armed settle shield). This is the wallet's OWN send modal, the other half of
+ * the same hole: a keep-open outcome ("Network is busy") leaves the SDK
+ * converging that transfer, while the reservation ledger only stops the SAME
+ * token being spent twice — a second attempt plans a NEW transferId against the
+ * remaining balance and the recipient is paid TWICE (audit probe: 100 sent,
+ * keep-open, re-sent 100 → recipient got 200). A user who closes the busy
+ * screen and sends again, or double-taps Send, does exactly that.
+ *
+ * Matching is `findDuplicatePending` — the same matcher the Connect guard uses,
+ * imported, never re-implemented — and the settle window is the same
+ * INTENT_SETTLE_MS.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import type { PendingTransfer } from '@unicitylabs/sphere-sdk/payments-v2';
+import { INTENT_SETTLE_MS } from '../../../src/components/connect/settleWindow';
+
+/**
+ * Animations are stubbed out so the only thing FAKE TIME drives here is the
+ * settle window itself. framer-motion's frame loop captures the timer
+ * environment it first sees, and re-installing fake timers per test leaves it
+ * driving nothing — with the real library, step transitions stall from the
+ * fourth test on. Nothing under test depends on the animation: the shield is
+ * armed by the control's MOUNT, which is exactly what this stub preserves.
+ */
+vi.mock('framer-motion', async () => {
+  const React = await import('react');
+  const cache = new Map<string, React.ElementType>();
+  const MOTION_ONLY = new Set([
+    'initial', 'animate', 'exit', 'transition', 'variants', 'layout', 'layoutId', 'drag',
+    'whileHover', 'whileTap', 'whileFocus', 'whileDrag', 'whileInView', 'onAnimationComplete',
+  ]);
+  const strip = (props: Record<string, unknown>) =>
+    Object.fromEntries(Object.entries(props).filter(([key]) => !MOTION_ONLY.has(key)));
+  const motion = new Proxy({} as Record<string, React.ElementType>, {
+    get(_target, tag) {
+      if (typeof tag !== 'string') return undefined;
+      if (!cache.has(tag)) {
+        // Cached per tag: a fresh component identity on every property read
+        // would remount the whole subtree each render (and re-arm the shield
+        // forever).
+        const Component = ({ children, ...props }: Record<string, unknown> & { children?: React.ReactNode }) =>
+          React.createElement(tag, strip(props), children);
+        Component.displayName = `motion.${tag}`;
+        cache.set(tag, Component);
+      }
+      return cache.get(tag);
+    },
+  });
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+const COIN = 'c'.repeat(64);
+const OTHER_COIN = 'd'.repeat(64);
+const BOB_PUBKEY = `02${'a'.repeat(64)}`;
+const CAROL_PUBKEY = `03${'b'.repeat(64)}`;
+
+const ASSET = {
+  coinId: COIN,
+  symbol: 'UCT',
+  name: 'Unicity',
+  decimals: 0,
+  totalAmount: '1000',
+  confirmedAmount: '1000',
+  unconfirmedAmount: '0',
+  tokenCount: 1,
+  iconUrl: null,
+  priceUsd: null,
+};
+
+const transferMock = vi.fn();
+const pendingTransfersMock = vi.fn(async (): Promise<PendingTransfer[]> => []);
+const resolveMock = vi.fn(async () => ({ chainPubkey: BOB_PUBKEY }));
+
+vi.mock('../../../src/sdk', async () => {
+  const { formatAmount } = await vi.importActual<typeof import('../../../src/sdk/utils/format')>(
+    '../../../src/sdk/utils/format',
+  );
+  return {
+    formatAmount,
+    useAssets: () => ({ assets: [ASSET] }),
+    useTransfer: () => ({
+      transfer: transferMock,
+      isLoading: false,
+      error: null,
+      lastResult: null,
+      reset: vi.fn(),
+    }),
+  };
+});
+
+const fakeSphere = {
+  on: vi.fn(),
+  off: vi.fn(),
+  resolve: resolveMock,
+  payments: { pendingTransfers: pendingTransfersMock, resumeNow: vi.fn(), send: vi.fn() },
+};
+
+vi.mock('../../../src/sdk/hooks/core/useSphere', () => ({
+  useSphereContext: () => ({ sphere: fakeSphere, subscriptionKeyStatus: 'ready' }),
+}));
+vi.mock('../../../src/sdk/hooks/subscription', () => ({
+  useUtilization: () => ({ data: undefined }),
+}));
+vi.mock('../../../src/components/upgrade', () => ({
+  useUpgrade: () => ({ openUpgrade: vi.fn() }),
+}));
+
+import { SendModal } from '../../../src/components/wallet/L3/modals/SendModal';
+
+function pendingRow(overrides: Partial<PendingTransfer> = {}): PendingTransfer {
+  return {
+    transferId: 'tf_9d2c4e7a1b3f',
+    kind: 'open',
+    recipient: BOB_PUBKEY,
+    coinId: COIN,
+    amount: '10',
+    legs: { certified: 1, total: 2 },
+    deliveryPending: true,
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * Step transitions ride framer-motion's AnimatePresence, so time has to move
+ * for the next screen to mount. Advancing in small slices keeps the settle
+ * window (armed when the control mounts) essentially untouched — at most one
+ * slice of it is consumed before the assertions below run.
+ */
+const SLICE_MS = 20;
+async function advanceUntil(present: () => boolean, maxMs = 3_000) {
+  let elapsed = 0;
+  while (!present() && elapsed < maxMs) {
+    await act(async () => {
+      vi.advanceTimersByTime(SLICE_MS);
+      await Promise.resolve();
+    });
+    elapsed += SLICE_MS;
+  }
+  if (!present()) throw new Error('UI never appeared');
+}
+
+const sendButton = () => screen.queryByRole('button', { name: 'Send' }) as HTMLButtonElement | null;
+const sendAnywayButton = () =>
+  screen.queryByRole('button', { name: 'Send anyway' }) as HTMLButtonElement | null;
+
+/** asset → details → Review. Lands on the confirm step, or the duplicate warning. */
+async function review({ recipient = 'bob', amount = '10' } = {}) {
+  render(<SendModal isOpen onClose={vi.fn()} />);
+  fireEvent.click(screen.getByText('UCT'));
+  await advanceUntil(() => screen.queryByPlaceholderText("Recipient's Unicity ID") !== null);
+  fireEvent.change(screen.getByPlaceholderText("Recipient's Unicity ID"), {
+    target: { value: recipient },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Amount'), { target: { value: amount } });
+  await act(async () => {
+    fireEvent.click(screen.getByText('Review'));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Wait out the settle window, then press Send on the confirm step. */
+async function pressSend() {
+  await advanceUntil(() => sendButton() !== null);
+  await act(async () => {
+    vi.advanceTimersByTime(INTENT_SETTLE_MS);
+  });
+  await act(async () => {
+    fireEvent.click(sendButton()!);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  transferMock.mockReset();
+  transferMock.mockResolvedValue({ id: 'tid', status: 'completed', tokens: [], tokenTransfers: [] });
+  pendingTransfersMock.mockReset();
+  pendingTransfersMock.mockResolvedValue([]);
+  resolveMock.mockReset();
+  resolveMock.mockResolvedValue({ chainPubkey: BOB_PUBKEY });
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SendModal — settle shield (no control is live the instant it appears)', () => {
+  it('the confirm-step Send button is inert when it first appears and for the settle window after', async () => {
+    await review();
+    await advanceUntil(() => sendButton() !== null);
+
+    // First paint of the button: dead.
+    expect(sendButton()!.disabled).toBe(true);
+
+    // Still dead most of the way through the window (a slice of it may have
+    // been consumed getting here — the margin, not the window, is approximate).
+    await act(async () => {
+      vi.advanceTimersByTime(INTENT_SETTLE_MS - SLICE_MS * 5);
+    });
+    expect(sendButton()!.disabled).toBe(true);
+
+    // A double-tap landing in that window spends nothing.
+    fireEvent.click(sendButton()!);
+    expect(transferMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(SLICE_MS * 5);
+    });
+    expect(sendButton()!.disabled).toBe(false);
+  });
+
+  it('two clicks dispatched in one task open exactly one attempt', async () => {
+    await review();
+    await advanceUntil(() => sendButton() !== null);
+    await act(async () => {
+      vi.advanceTimersByTime(INTENT_SETTLE_MS);
+    });
+
+    // Past the settle window the button is live — but a double-tap that lands
+    // before React can flush the disabled state must still spend once. The
+    // synchronous re-entrancy ref, not a re-render, is what makes that true.
+    await act(async () => {
+      const button = sendButton()!;
+      fireEvent.click(button);
+      fireEvent.click(button);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(transferMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms on the warning→proceed transition — "Send anyway" hands over a dead Send button', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+    await review();
+    await advanceUntil(() => sendAnywayButton() !== null);
+
+    // The destructive control is itself shielded on appearance.
+    expect(sendAnywayButton()!.disabled).toBe(true);
+    await act(async () => {
+      vi.advanceTimersByTime(INTENT_SETTLE_MS);
+    });
+    expect(sendAnywayButton()!.disabled).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(sendAnywayButton()!);
+      await Promise.resolve();
+    });
+    await advanceUntil(() => sendButton() !== null);
+
+    // A fresh primary button under the cursor that just clicked one: dead again.
+    expect(sendButton()!.disabled).toBe(true);
+    fireEvent.click(sendButton()!);
+    expect(transferMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(INTENT_SETTLE_MS);
+    });
+    expect(sendButton()!.disabled).toBe(false);
+  });
+});
+
+describe('SendModal — duplicate payment guard', () => {
+  it('a converging transfer for the same recipient/coin/amount blocks the send and names it', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+    await review();
+    await advanceUntil(() => screen.queryByText('Sending again pays TWICE.') !== null);
+
+    expect(screen.getByText(/is still completing \(transfer/)).toBeTruthy();
+    expect(screen.getByText(/1 of 2 parts are already certified/)).toBeTruthy();
+    // Nothing was executed, and the confirm screen is not what the user is
+    // looking at — the warning replaced it.
+    expect(transferMock).not.toHaveBeenCalled();
+    expect(sendButton()).toBeNull();
+  });
+
+  it('declining returns to the edit step and sends nothing', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+    await review();
+    await advanceUntil(() => screen.queryByText("Don't send") !== null);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Don't send"));
+      await Promise.resolve();
+    });
+    await advanceUntil(() => screen.queryByPlaceholderText('Amount') !== null);
+
+    expect(transferMock).not.toHaveBeenCalled();
+    expect(screen.queryByText('Sending again pays TWICE.')).toBeNull();
+  });
+
+  it('explicit approval sends exactly once', async () => {
+    pendingTransfersMock.mockResolvedValue([pendingRow()]);
+    await review();
+    await advanceUntil(() => sendAnywayButton() !== null);
+    await act(async () => {
+      vi.advanceTimersByTime(INTENT_SETTLE_MS);
+    });
+    await act(async () => {
+      fireEvent.click(sendAnywayButton()!);
+      await Promise.resolve();
+    });
+
+    await pressSend();
+
+    // The override is honoured — a user may genuinely want to pay twice — and
+    // the still-matching row does NOT re-raise the warning behind their back.
+    expect(transferMock).toHaveBeenCalledTimes(1);
+    expect(transferMock.mock.calls[0][0]).toMatchObject({ amount: '10', coinId: COIN });
+  });
+
+  it('a row that matches only at SEND time (another send went keep-open meanwhile) still blocks', async () => {
+    pendingTransfersMock.mockResolvedValueOnce([]); // clear when the confirm step opens
+    pendingTransfersMock.mockResolvedValue([pendingRow()]); // converging by the time Send is pressed
+
+    await review();
+    await pressSend();
+
+    expect(transferMock).not.toHaveBeenCalled();
+    await advanceUntil(() => screen.queryByText('Sending again pays TWICE.') !== null);
+  });
+
+  it.each([
+    ['a different amount', pendingRow({ amount: '11' })],
+    ['a different recipient', pendingRow({ recipient: CAROL_PUBKEY })],
+    ['a different coin', pendingRow({ coinId: OTHER_COIN })],
+    ['a journal-only row with no amount', pendingRow({ amount: '', coinId: '' })],
+  ])('%s is not a duplicate — the send proceeds', async (_label, row) => {
+    pendingTransfersMock.mockResolvedValue([row]);
+    await review();
+    await pressSend();
+
+    expect(transferMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Sending again pays TWICE.')).toBeNull();
+  });
+
+  it('no converging transfers: the send proceeds on the single resolution the modal already did', async () => {
+    await review();
+    await pressSend();
+
+    expect(transferMock).toHaveBeenCalledTimes(1);
+    // The guard reuses the confirm step's resolution — it never opens a second
+    // recipient lookup of its own.
+    expect(resolveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open: pendingTransfers() throwing never blocks a legitimate send', async () => {
+    pendingTransfersMock.mockRejectedValue(new Error('storage unavailable'));
+    await review();
+    await pressSend();
+
+    expect(transferMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Sending again pays TWICE.')).toBeNull();
+  });
+});

--- a/tests/unit/components/sendModalKeepOpen.test.tsx
+++ b/tests/unit/components/sendModalKeepOpen.test.tsx
@@ -96,7 +96,12 @@ async function driveSend() {
   // Wait for the CONFIRM step (its summary card) — the details step's header
   // title is also 'Send', so the button must be located only once we're there.
   await screen.findByText('You are sending');
-  fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+  // The confirm-step Send button is inert for INTENT_SETTLE_MS after it first
+  // paints (the duplicate-payment / double-tap shield) — a real user waits that
+  // window out, and so does this driver.
+  const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+  await waitFor(() => expect(send.disabled).toBe(false));
+  fireEvent.click(send);
 }
 
 beforeEach(() => {


### PR DESCRIPTION
Two changes, one of them a money fix. They are unrelated in mechanism and the floor is explicitly **not** a mitigation for the bug — see below.

## 1. The verified double-pay path (the fix)

When a Connect `send` intent ends in a **keep-open** outcome (#631/#665 — the spend may already be certified on-chain and the SDK converges that SAME `transferId` in-session), the wallet answers the dApp:

```jsonc
{ "success": true, "status": "pending", "deliveryPending": true }
```

synthesized in `useTransfer.ts` (PENDING_COMMIT branch) and passed through by `ConnectIntentHandler.tsx`. A dApp that reads `status:'pending'` as "not finished" and **re-issues the intent gets a SECOND SPEND**. Nothing dedupes it at any layer:

| Layer | Why it does not catch it |
|---|---|
| `ConnectHost.handleIntentRequest` / `InFlightRegistry` | dedupe by **request id** — a re-issue is a new request |
| `ConnectProvider` intent queue | FIFO ordering, not a deduper |
| `SendIntentModal` / `PaymentsFacade.sendWithPolicy` | no notion of "already converging" |
| SDK reservation ledger | only stops the **same token** being spent twice; a new `transferId` plans against the remaining free balance |

**Audit probe (empirically reproduced):** seed `100 + 100`, send `100` → keep-open; re-send `100` → delivered. Recipient mailbox: **2 entries**. SENT history: **two transferIds**. **200 delivered for a 100 request.**

### The invariant

> The wallet never executes a send intent that duplicates a payment already converging.

"Converging" is exactly `payments.pendingTransfers()` (sphere-sdk 0.14.2) — derived **on read** from the intent backstop + delivery journal + shortfalls, so the protection holds across a reload and needs no wallet-side bookkeeping. No new SDK surface.

### What it does

- **`src/components/connect/duplicateSendGuard.ts`** (new) — when a `send` intent arrives, read `pendingTransfers()` and match on **(recipient chain pubkey, coinId, amount)**.
  - pubkey compared case-insensitively; `coinId` via the SDK's registry-canonical `coinIdsMatch`; `amount` by **BigInt** equality (exact decimal strings, never a float).
  - An **empty list short-circuits** before any recipient resolution — the common path costs one local read and no round-trip.
  - Resolution reuses `sphere.resolve` on the *same identifier the modal spends against* (`sendIntentRecipient`, now shared with `SendIntentModal` so the two can never disagree), mirroring the SDK's own rule that a literal chain pubkey **is** the answer.
  - **Fails open** on any error and on a 4 s timeout: a guard may never freeze a payment.
- **`ConnectIntentHandler.tsx`** — on a match, a blocking confirmation renders **instead of** `SendIntentModal`: *"A payment of X to Y is still completing (transfer …abcd). Approving this sends a SECOND payment."* Never auto-executes, never silently rejects — the user may genuinely want to pay twice.
  - **"Send anyway" is the secondary button**; the safe action sits where every other intent modal puts its primary, so a reflex click on a modal that appeared under the cursor cannot spend money.
  - Declining answers **`USER_REJECTED` (4003)** with the `transferId` in the message — an existing code the dApp already knows (inventing one would be unreadable; `INTENT_OUTCOME_UNKNOWN` (4201) would falsely claim *this* intent's money may have moved) — so the dApp reconciles against that transfer instead of retrying.

### Not covered (deliberate)

The wallet's **own** `SendModal` is not guarded. Doing so needs a new confirm-step state plus pubkey derivation for its raw-pubkey mode — more than the few lines this was scoped to, and a redesign of the primary send flow. It is human-driven, already shows the honest keep-open copy, and its only retry affordance is `resumeNow()` (never `send()`).

A shortfall row carries the **remaining** amount, so re-issuing the original full amount against a partial settlement does not match — that is #690's problem, not this one. Both bounds are documented in the guard.

## 2. Connect SDK floor 0.12.0-0 → 0.14.1-0 (hygiene, not the fix)

`CONNECT_MIN_SDK_VERSION` sat at `0.12.0-0` through the 0.13 and 0.14 lines, and it **overrides** the SDK's own `DEFAULT_MIN_CLIENT_SDK_VERSION` — a stale value here silently disables the floor entirely. Sub-0.14.1 apps still connect and then read a surface that moved underneath them (`Asset.unconfirmed*` pinned to zero, dropped `Token.status` values, `payment_request:settling`/`:response` never firing, history `tokenIds[].id` carrying a coinId): silent wrong answers, worse than a refusal that names the required version.

**This does not mitigate the double-pay path.** A fully up-to-date 0.14.1+ dApp retrying on `status:'pending'` double-pays exactly the same way — which is why the guard is version-independent and lives in the wallet.

## Tests

11 new in `tests/unit/components/connectSendIntentDuplicateGuard.test.tsx`:

- matching intent → warning shown, send path **never reached** (no `transfer()`, no resolve/reject)
- declining → `USER_REJECTED` naming the transfer, **never spends**
- approving explicitly → **does** send (`transfer()` once, intent resolved `success:true`)
- case-different recipient pubkey still matches
- different amount / recipient / coin / requested amount → passes through untouched
- empty `pendingTransfers()` → passes through **and costs no recipient resolution**
- `pendingTransfers()` outage and a check that never answers → fail open

**Mutation-verified:** neutering `findDuplicatePending` (return null) and bypassing the handler's duplicate branch each turn **4 tests red**, including the primary; pinning the timeout out of reach turns the fail-open test red.

**Gates:** `npm run build` ✅ · `npm run typecheck:tests` ✅ · `npm run test:run` **751 passed** (740 + 11) ✅ · `npm run lint` **0 errors** (3 pre-existing warnings) ✅
