### PR TITLE
fix(csp): allow the market feed's wss origin

### DIFF
--- a/deploy/runtime-config.sh
+++ b/deploy/runtime-config.sh
@@ -194,6 +194,10 @@ if [ -w "$(dirname "$HEADERS_CONF")" ]; then
   CONNECT="$CONNECT wss://nostr-relay.testnet.unicity.network"
   CONNECT="$CONNECT wss://relay.damus.io wss://relay.nostr.band wss://nos.lol"
   CONNECT="$CONNECT https://api.coingecko.com https://market-api.unicity.network"
+  # The market client derives its feed socket by rewriting the API scheme
+  # (SDK: apiUrl.replace(/^http/,'ws') + '/ws/feed'), and CSP treats wss:// as a
+  # DIFFERENT origin than https:// — the https entry above does not cover it.
+  CONNECT="$CONNECT wss://market-api.unicity.network"
   CONNECT="$CONNECT https://unicity-ipfs1.dyndns.org"
   CONNECT="$CONNECT https://o4511695062237184.ingest.de.sentry.io"
 


### PR DESCRIPTION
Prod (report-only) violation:

```
Connecting to 'wss://market-api.unicity.network/ws/feed' violates connect-src …
```

`https://market-api.unicity.network` **is** allowlisted, but CSP treats `wss://` as a different origin, so it never covered the feed socket.

The socket isn't configured anywhere to notice — the SDK's market client derives it from the API base (`apiUrl.replace(/^http/,'ws') + '/ws/feed'`, dist:7903). Adds `wss://market-api.unicity.network` beside its https twin, with the rationale in a comment so the pair stays together.

**Why it matters even though nothing is broken today:** the policy is Report-Only, and flipping it to enforcing is a single env var (`SPHERE_CSP_HEADER_NAME`). Today's log line is tomorrow's silently dead market feed.

Verified: `bash -n` clean. Same pattern is worth a look for any other https origin whose socket the SDK derives — the Nostr relays are already listed as `wss://`, and wallet-api's wake socket rides the origin the SDK derives from `WALLET_API_URL` (the `origin_of` loop emits only the https form; if the wake socket ever reports a violation, that's the same bug and the same fix).