### PR TITLE
fix(explore): page the whole catalog, filter on the server, and let users order it

### DIFF
--- a/src/components/common/DragScrollRow.tsx
+++ b/src/components/common/DragScrollRow.tsx
@@ -1,0 +1,164 @@
+import { useState, useRef, useCallback, useEffect, type ReactNode } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface DragScrollRowProps {
+  /**
+   * Row items. Each should carry `shrink-0 snap-start` so it keeps its width
+   * and the track settles on a card edge rather than mid-card.
+   */
+  children: ReactNode;
+  /**
+   * Names the row in the scroll buttons' accessible labels, e.g. passing
+   * "featured projects" yields "Scroll featured projects right".
+   */
+  label: string;
+  /** Extra classes for the scroll track — hosts differ in vertical padding. */
+  trackClassName?: string;
+}
+
+/** Width of the fade at an edge that has more content past it. */
+const FADE = '3rem';
+
+/**
+ * A horizontally scrolling row that reads as one.
+ *
+ * The bare pattern — `overflow-x-auto` plus `scrollbar-hide` — renders a row
+ * of tiles with no scrollbar, no arrows and no half-visible card, which looks
+ * exactly like a grid that happens to fit. Nothing tells a viewer that more
+ * items are one drag to the right, so they never drag, and everything past
+ * the fold is effectively invisible.
+ *
+ * Three affordances fix that: arrows in whichever direction has more to show,
+ * a fade at those same edges, and scroll snapping.
+ *
+ * The fade is a CSS mask, not a gradient painted in the background colour.
+ * A coloured overlay has to know what it sits on, which is wrong the moment
+ * the same row appears on a second surface — the desktop's background is not
+ * Explore's. A mask fades the content's own alpha and is right on any
+ * background.
+ */
+export function DragScrollRow({ children, label, trackClassName = '' }: DragScrollRowProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const startX = useRef(0);
+  const scrollLeftRef = useRef(0);
+  const moved = useRef(false);
+
+  const [overflow, setOverflow] = useState({ left: false, right: false });
+
+  const stopDrag = useCallback(() => {
+    isDragging.current = false;
+    if (scrollRef.current) scrollRef.current.style.cursor = 'grab';
+    // Reset after a tick so onClickCapture can still block the current click.
+    setTimeout(() => { moved.current = false; }, 0);
+  }, []);
+
+  // Global mouseup prevents a stuck drag when the pointer leaves the window.
+  useEffect(() => {
+    window.addEventListener('mouseup', stopDrag);
+    return () => window.removeEventListener('mouseup', stopDrag);
+  }, [stopDrag]);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    isDragging.current = true;
+    moved.current = false;
+    startX.current = e.pageX;
+    scrollLeftRef.current = scrollRef.current?.scrollLeft ?? 0;
+    if (scrollRef.current) scrollRef.current.style.cursor = 'grabbing';
+  }, []);
+
+  const onMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging.current || !scrollRef.current) return;
+    e.preventDefault();
+    const walk = (e.pageX - startX.current) * 1.2;
+    scrollRef.current.scrollLeft = scrollLeftRef.current - walk;
+    if (Math.abs(walk) > 5) moved.current = true;
+  }, []);
+
+  const syncOverflow = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // 1px slack: fractional scroll widths otherwise leave the right arrow
+    // showing forever at the end of the track.
+    setOverflow({
+      left:  el.scrollLeft > 1,
+      right: el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    syncOverflow();
+    const el = scrollRef.current;
+    if (!el) return;
+    // Observes the track AND its content: the row also becomes scrollable
+    // when items finish loading, which never resizes the track itself. A
+    // window listener would miss both that and the sidebar opening.
+    const observer = new ResizeObserver(syncOverflow);
+    observer.observe(el);
+    for (const child of Array.from(el.children)) observer.observe(child);
+    return () => observer.disconnect();
+  }, [syncOverflow, children]);
+
+  /**
+   * One "page" of scroll is the visible width less a sliver, so a partially
+   * seen card stays partially seen instead of jumping out of view.
+   */
+  const scrollByPage = useCallback((direction: 1 | -1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * Math.max(240, el.clientWidth - 96), behavior: 'smooth' });
+  }, []);
+
+  const maskImage = overflow.left || overflow.right
+    ? `linear-gradient(to right, transparent 0, #000 ${overflow.left ? FADE : '0px'}, #000 calc(100% - ${overflow.right ? FADE : '0px'}), transparent 100%)`
+    : undefined;
+
+  const arrowClass =
+    'absolute top-1/2 -translate-y-1/2 z-20 grid place-items-center w-9 h-9 rounded-full ' +
+    'bg-white/90 dark:bg-white/12 backdrop-blur border border-neutral-200 dark:border-white/15 ' +
+    'text-neutral-700 dark:text-white shadow-lg hover:bg-white dark:hover:bg-white/20 ' +
+    'transition-colors cursor-pointer';
+
+  return (
+    <div className="relative">
+      {/* Real buttons, not decoration: drag-to-scroll is invisible to keyboard
+          users and to anyone on a trackpad who never thinks to try it. Each is
+          rendered only while there is something in that direction. */}
+      {overflow.left && (
+        <button
+          type="button"
+          aria-label={`Scroll ${label} left`}
+          onClick={() => scrollByPage(-1)}
+          className={`${arrowClass} left-1`}
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+      )}
+      {overflow.right && (
+        <button
+          type="button"
+          aria-label={`Scroll ${label} right`}
+          onClick={() => scrollByPage(1)}
+          className={`${arrowClass} right-1`}
+        >
+          <ChevronRight className="w-5 h-5" />
+        </button>
+      )}
+
+      <div
+        ref={scrollRef}
+        onScroll={syncOverflow}
+        onDragStart={e => e.preventDefault()}
+        onMouseDown={e => { e.preventDefault(); onMouseDown(e); }}
+        onMouseMove={onMouseMove}
+        onMouseUp={stopDrag}
+        onMouseLeave={stopDrag}
+        onClickCapture={e => { if (moved.current) { e.preventDefault(); e.stopPropagation(); } }}
+        className={`flex gap-4 overflow-x-auto scrollbar-hide select-none snap-x ${trackClassName}`}
+        style={{ cursor: 'grab', userSelect: 'none', WebkitMaskImage: maskImage, maskImage }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/desktop/DesktopShortcuts.tsx
+++ b/src/components/desktop/DesktopShortcuts.tsx
@@ -1,5 +1,4 @@
 import { useNavigate, Link } from 'react-router-dom';
-import { useRef, useCallback, useEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import {
   DndContext,
@@ -21,6 +20,7 @@ import { useDesktopState } from '../../hooks/useDesktopState';
 import { useDmUnreadCount } from '../chat/hooks/useDmUnreadCount';
 import { useGroupUnreadCount } from '../chat/hooks/useGroupUnreadCount';
 import { useFeaturedProjects, useProjectsBySlugs, useProjectMetricsBatch } from '../../hooks/useMarketplace';
+import { DragScrollRow } from '../common/DragScrollRow';
 import { useDesktopOrder, type DesktopOrderItem } from '../../hooks/useDesktopOrder';
 import type { ProjectSummary } from '../../services/marketplaceApi';
 import { DesktopIcon } from './DesktopIcon';
@@ -86,42 +86,6 @@ function SortableDesktopItem({ item, projectsBySlug, openAppIds, getBadge, onAge
       buttonRef={setActivatorNodeRef}
       buttonProps={{ ...attributes, ...listeners }}
     />
-  );
-}
-
-// Drag-scrollable container (same pattern as MediaGallery)
-function DragScroll({ children }: { children: React.ReactNode }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const dragging = useRef(false);
-  const startX = useRef(0);
-  const sl = useRef(0);
-  const moved = useRef(false);
-
-  const stop = useCallback(() => {
-    dragging.current = false;
-    if (ref.current) ref.current.style.cursor = 'grab';
-    setTimeout(() => { moved.current = false; }, 0);
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('mouseup', stop);
-    return () => window.removeEventListener('mouseup', stop);
-  }, [stop]);
-
-  return (
-    <div
-      ref={ref}
-      onDragStart={e => e.preventDefault()}
-      onMouseDown={e => { e.preventDefault(); dragging.current = true; moved.current = false; startX.current = e.pageX; sl.current = ref.current?.scrollLeft ?? 0; if (ref.current) ref.current.style.cursor = 'grabbing'; }}
-      onMouseMove={e => { if (!dragging.current || !ref.current) return; e.preventDefault(); const w = (e.pageX - startX.current) * 1.2; ref.current.scrollLeft = sl.current - w; if (Math.abs(w) > 5) moved.current = true; }}
-      onMouseUp={stop}
-      onMouseLeave={stop}
-      onClickCapture={e => { if (moved.current) { e.preventDefault(); e.stopPropagation(); } }}
-      className="flex gap-4 overflow-x-auto scrollbar-hide pb-2 select-none"
-      style={{ cursor: 'grab', userSelect: 'none' }}
-    >
-      {children}
-    </div>
   );
 }
 
@@ -195,13 +159,13 @@ export function DesktopShortcuts() {
                 View all <ArrowRight className="w-3 h-3" />
               </Link>
             </div>
-            <DragScroll>
+            <DragScrollRow label="featured projects" trackClassName="pb-2">
               {featuredProjects.map((project) => (
-                <div key={project.slug} className="shrink-0">
+                <div key={project.slug} className="shrink-0 snap-start">
                   <FeaturedProjectCard project={project} metrics={metricsByProject[project._id]} />
                 </div>
               ))}
-            </DragScroll>
+            </DragScrollRow>
           </section>
         )}
 

--- a/src/components/desktop/DesktopShortcuts.tsx
+++ b/src/components/desktop/DesktopShortcuts.tsx
@@ -20,7 +20,7 @@ import { DEV_PORTAL_URL } from '../../config/devPortal';
 import { useDesktopState } from '../../hooks/useDesktopState';
 import { useDmUnreadCount } from '../chat/hooks/useDmUnreadCount';
 import { useGroupUnreadCount } from '../chat/hooks/useGroupUnreadCount';
-import { useFeaturedProjects, useProjects, useProjectMetricsBatch } from '../../hooks/useMarketplace';
+import { useFeaturedProjects, useProjectsBySlugs, useProjectMetricsBatch } from '../../hooks/useMarketplace';
 import { useDesktopOrder, type DesktopOrderItem } from '../../hooks/useDesktopOrder';
 import type { ProjectSummary } from '../../services/marketplaceApi';
 import { DesktopIcon } from './DesktopIcon';
@@ -131,14 +131,26 @@ export function DesktopShortcuts() {
   const dmUnreadCount = useDmUnreadCount();
   const groupUnreadCount = useGroupUnreadCount();
   const { data: featuredProjects } = useFeaturedProjects();
-  const { data: projectsData } = useProjects();
-  const allProjects = projectsData?.projects;
   const { orderedIds, orderedItems, reorder } = useDesktopOrder();
 
-  // Batch live metrics for every project rendered on the desktop (featured + apps list)
+  // Resolve installed apps by SLUG, one lookup per installed app.
+  //
+  // This used to read the marketplace's project list — which returns a single
+  // page — and drop any icon whose project was not on it. The effect was
+  // silent and looked like data loss: an app the user had installed simply
+  // stopped appearing on their desktop once the catalog grew past one page,
+  // with no error and nothing to click. A desktop icon is a lookup by a slug
+  // the user already chose, not a listing, so it must not depend on where
+  // that project happens to fall in a paginated catalog.
+  const installedSlugs = orderedItems
+    .filter((item) => item.kind === 'app')
+    .map((item) => item.refId);
+  const projectsBySlug = useProjectsBySlugs(installedSlugs);
+
+  // Batch live metrics for every project rendered on the desktop (featured + installed)
   const allProjectIds = [...new Set([
     ...(featuredProjects ?? []).map((p) => p._id),
-    ...(allProjects ?? []).map((p) => p._id),
+    ...[...projectsBySlug.values()].map((p) => p._id),
   ])];
   const { data: metricsByProject = {} } = useProjectMetricsBatch(allProjectIds);
 
@@ -146,9 +158,6 @@ export function DesktopShortcuts() {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
   );
-
-  const projectsBySlug = new Map<string, ProjectSummary>();
-  for (const p of allProjects ?? []) projectsBySlug.set(p.slug, p);
 
   const openAppIds = new Set(openTabs.map((t) => t.appId));
 

--- a/src/components/marketplace/CategoryFilter.tsx
+++ b/src/components/marketplace/CategoryFilter.tsx
@@ -1,37 +1,65 @@
+export interface CategoryOption {
+  category: string;
+  count:    number;
+}
+
 interface CategoryFilterProps {
-  categories: string[];
+  categories: CategoryOption[];
   active: string | null;
   onChange: (category: string | null) => void;
+  /** Total across the categories shown, for the "All" pill. Omitted → no count. */
+  totalCount?: number;
 }
 
 const categoryLabels: Record<string, string> = {
   game: 'Games', defi: 'DeFi', social: 'Social', tool: 'Tools', nft: 'NFT', other: 'Other',
+  utility: 'Utility', trading: 'Trading',
 };
 
-export function CategoryFilter({ categories, active, onChange }: CategoryFilterProps) {
+/**
+ * A category with no label of its own still gets a readable chip. The list
+ * is data-driven now (the API reports which categories actually have
+ * published projects), so a category nobody remembered to add here must not
+ * render as raw lowercase.
+ */
+function labelFor(category: string): string {
+  return categoryLabels[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+}
+
+const pillClass = (isActive: boolean) =>
+  `shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
+    isActive
+      ? 'bg-orange-500 dark:bg-brand-orange text-white shadow-md shadow-orange-500/20'
+      : 'bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/8 text-neutral-500 dark:text-white/45 hover:text-neutral-700 dark:hover:text-white hover:border-neutral-300 dark:hover:border-white/15'
+  }`;
+
+/**
+ * Counts render inside an aria-hidden span so each button's accessible name
+ * stays the bare label — screen readers announce "Tools", not "Tools 5".
+ */
+function Count({ value }: { value?: number }) {
+  if (value === undefined || value <= 0) return null;
+  return <span aria-hidden className="ml-1.5 opacity-60 tabular-nums">{value}</span>;
+}
+
+export function CategoryFilter({ categories, active, onChange, totalCount }: CategoryFilterProps) {
   return (
     <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
-      <button
-        onClick={() => onChange(null)}
-        className={`shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
-          active === null
-            ? 'bg-orange-500 dark:bg-brand-orange text-white shadow-md shadow-orange-500/20'
-            : 'bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/8 text-neutral-500 dark:text-white/45 hover:text-neutral-700 dark:hover:text-white hover:border-neutral-300 dark:hover:border-white/15'
-        }`}
-      >
+      <button onClick={() => onChange(null)} className={pillClass(active === null)}>
         All
+        <Count value={totalCount} />
       </button>
-      {categories.map((cat) => (
+      {/* A row without a category cannot be filtered on, so it gets no chip —
+          `category` is required by the schema today, but a chip that renders
+          as "Null" and filters to nothing is not the way to find that out. */}
+      {categories.filter(c => !!c.category).map(({ category, count }) => (
         <button
-          key={cat}
-          onClick={() => onChange(active === cat ? null : cat)}
-          className={`shrink-0 px-4 py-2 rounded-xl text-sm font-medium transition-all ${
-            active === cat
-              ? 'bg-orange-500 dark:bg-brand-orange text-white shadow-md shadow-orange-500/20'
-              : 'bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/8 text-neutral-500 dark:text-white/45 hover:text-neutral-700 dark:hover:text-white hover:border-neutral-300 dark:hover:border-white/15'
-          }`}
+          key={category}
+          onClick={() => onChange(active === category ? null : category)}
+          className={pillClass(active === category)}
         >
-          {categoryLabels[cat] ?? cat}
+          {labelFor(category)}
+          <Count value={count} />
         </button>
       ))}
     </div>

--- a/src/components/marketplace/SortControl.tsx
+++ b/src/components/marketplace/SortControl.tsx
@@ -1,0 +1,56 @@
+export const SORT_OPTIONS = [
+  { value: 'relevant', label: 'Relevant' },
+  { value: 'new',      label: 'New' },
+  { value: 'top',      label: 'Top' },
+] as const;
+
+export type SortValue = (typeof SORT_OPTIONS)[number]['value'];
+
+interface SortControlProps {
+  value: SortValue;
+  onChange: (value: SortValue) => void;
+}
+
+/**
+ * How the catalog is ordered.
+ *
+ * A segmented control rather than pills, deliberately: the category chips
+ * directly below are pills, and they are a FILTER — several could sensibly be
+ * on at once, and turning one on changes how many projects exist. Sort is
+ * exactly one choice and changes no counts. Giving the two different shapes
+ * is what keeps "Top" from reading as another category.
+ *
+ * Smaller than the Apps/Standalone tabs above it for the same reason in
+ * reverse: those partition the catalog into two different things, this only
+ * reorders what is already on screen, and matching their size would claim
+ * equal importance.
+ */
+export function SortControl({ value, onChange }: SortControlProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Sort projects"
+      className="inline-flex items-center gap-0.5 rounded-full border border-neutral-200 dark:border-white/10 bg-neutral-50 dark:bg-white/4 p-0.5"
+    >
+      {SORT_OPTIONS.map(option => {
+        const isActive = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            onClick={() => onChange(option.value)}
+            className={
+              isActive
+                ? 'rounded-full px-3.5 py-1.5 text-xs font-semibold text-white bg-orange-500 dark:bg-brand-orange shadow-sm cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-orange-500/60'
+                : 'rounded-full px-3.5 py-1.5 text-xs font-semibold text-neutral-500 dark:text-white/50 hover:text-neutral-900 dark:hover:text-white cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-orange-500/60 transition-colors'
+            }
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Trailing debounce for a value that drives a network request.
+ *
+ * Explore's search box filters server-side, so every keystroke would
+ * otherwise be its own request to /api/marketplace. Debouncing collapses a
+ * burst of typing into the one term the user actually stopped on.
+ *
+ * Clearing is applied IMMEDIATELY rather than after the delay: emptying the
+ * search box (or a tab switch that resets it) should bring the full list
+ * back at once, and delaying it would fire one extra request for a term the
+ * user has already deleted.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    if (!value) {
+      setDebounced(value);
+      return;
+    }
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery, useQueries } from '@tanstack/react-query';
 import {
   fetchProjects,
   fetchFeaturedProjects,
@@ -10,6 +10,10 @@ import {
   fetchProjectRatings,
   fetchRatingReplies,
   fetchCategories,
+  fetchMarketplaceStats,
+  type PaginatedProjects,
+  type ProjectDetail,
+  type ProjectMetrics,
 } from '../services/marketplaceApi';
 import { useMarketplaceEnabled } from './useMaintenanceStatus';
 import type { ProjectType } from '../utils/isStandalone';
@@ -20,11 +24,73 @@ import type { ProjectType } from '../utils/isStandalone';
 // the browser never logs the (expected) 503s as red console errors. The wallet core
 // is unaffected — it talks to the chain/SDK, not sphere-api.
 
-export function useProjects(params?: { type?: ProjectType; category?: string; search?: string; sort?: string; page?: number; limit?: number }) {
+/**
+ * Explore's page size.
+ *
+ * Deliberately above the server's 20 default so today's catalog arrives in a
+ * single request, and well under both the server's own 50 cap and the metrics
+ * endpoint's 100-id batch limit. It also divides evenly into every column
+ * count the Explore grid produces (1/2/3/4/6 under auto-fill minmax(280px)),
+ * so a full page never leaves a ragged last row.
+ */
+export const EXPLORE_PAGE_SIZE = 24;
+
+export interface ProjectsQueryParams {
+  type?:     ProjectType;
+  category?: string | null;
+  search?:   string;
+  sort?:     string;
+}
+
+/**
+ * Paged project list — the whole catalog, one page at a time.
+ *
+ * Filtering (`search`, `category`) is part of the query key and therefore
+ * happens on the SERVER. It used to be done in the browser over whatever the
+ * single unpaginated request had returned, which meant a project past the
+ * first page could not be found by typing its name at all.
+ *
+ * `placeholderData` keeps the previous page visible while a new search term
+ * settles, so typing dims the grid instead of replacing it with skeletons and
+ * flashing "No projects found" between keystrokes. It deliberately refuses to
+ * carry data across a TYPE change: an app card rendered under the Standalone
+ * tab carries no badge to say otherwise, so a stale frame there would be a
+ * lie rather than a rough edge.
+ */
+export function useInfiniteProjects(params: ProjectsQueryParams) {
+  const marketplaceEnabled = useMarketplaceEnabled();
+  const category = params.category ?? undefined;
+  const search   = params.search?.trim() || undefined;
+  const key = { type: params.type, category, search, sort: params.sort, limit: EXPLORE_PAGE_SIZE };
+
+  return useInfiniteQuery({
+    queryKey: ['marketplace', 'projects', 'infinite', key] as const,
+    queryFn: ({ pageParam }) => fetchProjects({
+      type: params.type, category, search, sort: params.sort,
+      page: pageParam, limit: EXPLORE_PAGE_SIZE,
+    }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage: PaginatedProjects) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+    placeholderData: (previous, previousQuery) => {
+      const previousKey = previousQuery?.queryKey[3] as typeof key | undefined;
+      return previousKey?.type === params.type ? previous : undefined;
+    },
+    enabled: marketplaceEnabled,
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Catalog-wide totals for the Explore hero, counted server-side. The hero row
+ * describes the whole catalog, so it cannot be derived from a page of results
+ * — that is precisely what made it report the page size instead of the total.
+ */
+export function useMarketplaceStats() {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
-    queryKey: ['marketplace', 'projects', params],
-    queryFn: () => fetchProjects(params),
+    queryKey: ['marketplace', 'stats'],
+    queryFn: fetchMarketplaceStats,
     enabled: marketplaceEnabled,
     staleTime: 5 * 60_000,
   });
@@ -74,11 +140,15 @@ export function useProjectAchievements(slug: string) {
   });
 }
 
-export function useCategories() {
+/**
+ * Category chips with their counts. Scoped to a project type when given, so
+ * the chips shown under a tab can only offer filters that tab can satisfy.
+ */
+export function useCategories(type?: ProjectType) {
   const marketplaceEnabled = useMarketplaceEnabled();
   return useQuery({
-    queryKey: ['marketplace', 'categories'],
-    queryFn: fetchCategories,
+    queryKey: ['marketplace', 'categories', type],
+    queryFn: () => fetchCategories(type),
     enabled: marketplaceEnabled,
     staleTime: 10 * 60_000,
   });
@@ -102,6 +172,70 @@ export function useProjectMetricsBatch(projectIds: string[]) {
     enabled: marketplaceEnabled && projectIds.length > 0,
     staleTime: 60_000,
   });
+}
+
+/**
+ * Metrics for a list that grows page by page.
+ *
+ * One query per GROUP of ids rather than one query over the accumulated list:
+ * a group's ids never change once loaded, so its metrics stay cached and
+ * loading page N costs exactly one metrics request instead of re-fetching
+ * every project seen so far.
+ *
+ * Pass groups whose membership is stable — Explore passes one group per
+ * loaded page plus one for the featured carousel.
+ */
+export function useProjectMetricsByGroups(groups: string[][]) {
+  const marketplaceEnabled = useMarketplaceEnabled();
+  const nonEmpty = groups.filter(g => g.length > 0);
+
+  const results = useQueries({
+    queries: nonEmpty.map(ids => ({
+      queryKey: ['metrics', 'projects', ids.slice().sort().join(',')],
+      queryFn:  () => fetchProjectMetricsBatch(ids),
+      enabled:  marketplaceEnabled,
+      staleTime: 60_000,
+    })),
+  });
+
+  // Merged outside `combine` so the merge is not re-run by react-query on
+  // every render of every consumer; the join key below is what makes the
+  // memo in the calling component cheap.
+  const merged: Record<string, ProjectMetrics> = {};
+  for (const r of results) if (r.data) Object.assign(merged, r.data);
+  return merged;
+}
+
+/**
+ * Resolve a known set of slugs to full projects.
+ *
+ * The desktop needs the project behind each INSTALLED slug, which is a
+ * lookup, not a listing — reading it off the marketplace's first page meant
+ * an app outside that page resolved to nothing and its icon silently
+ * vanished from the user's desktop. Each slug is its own query, sharing the
+ * exact cache entry `useProject` uses, so opening a project page warms this
+ * and vice versa.
+ */
+export function useProjectsBySlugs(slugs: string[]) {
+  const marketplaceEnabled = useMarketplaceEnabled();
+
+  const results = useQueries({
+    queries: slugs.map(slug => ({
+      // Same key shape as useProject(slug) — a shared cache entry, not a copy.
+      queryKey: ['marketplace', 'project', slug, { preview: undefined }],
+      queryFn:  () => fetchProject(slug),
+      enabled:  marketplaceEnabled && !!slug,
+      staleTime: 5 * 60_000,
+      // A slug can point at a project that was unpublished or removed. That
+      // is an expected 404, not a transient failure, so don't retry it — the
+      // caller simply renders nothing for it, exactly as before.
+      retry: false,
+    })),
+  });
+
+  const bySlug = new Map<string, ProjectDetail>();
+  results.forEach((r, i) => { if (r.data) bySlug.set(slugs[i], r.data); });
+  return bySlug;
 }
 
 export function useProjectRatings(slug: string | undefined, page = 1, sort: 'helpful' | 'recent' = 'helpful') {

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { Search, ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Search, ArrowRight } from 'lucide-react';
 import {
   useInfiniteProjects,
   useFeaturedProjects,
@@ -12,6 +12,7 @@ import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCard';
 import { ProjectCard } from '../components/marketplace/ProjectCard';
 import { CategoryFilter } from '../components/marketplace/CategoryFilter';
+import { DragScrollRow } from '../components/common/DragScrollRow';
 import { MaintenanceScreen } from '../components/MaintenanceScreen';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 import { DEV_PORTAL_URL } from '../config/devPortal';
@@ -27,141 +28,20 @@ import type { ProjectSummary, ProjectMetrics } from '../services/marketplaceApi'
  */
 const SEARCH_DEBOUNCE_MS = 300;
 
-// ─── Drag-scrollable Featured Carousel ────────────────────────────────────────
+// ─── Featured Carousel ────────────────────────────────────────────────────────
 
 function FeaturedCarousel({ items, metricsByProject }: {
   items: ProjectSummary[];
   metricsByProject: Record<string, ProjectMetrics>;
 }) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isDragging = useRef(false);
-  const startX = useRef(0);
-  const scrollLeftRef = useRef(0);
-  const moved = useRef(false);
-
-  const stopDrag = useCallback(() => {
-    isDragging.current = false;
-    if (scrollRef.current) scrollRef.current.style.cursor = 'grab';
-    // Reset moved flag after a tick so onClickCapture can still block the current click
-    setTimeout(() => { moved.current = false; }, 0);
-  }, []);
-
-  // Global mouseup to prevent stuck drag when mouse leaves window
-  useEffect(() => {
-    window.addEventListener('mouseup', stopDrag);
-    return () => window.removeEventListener('mouseup', stopDrag);
-  }, [stopDrag]);
-
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
-    isDragging.current = true;
-    moved.current = false;
-    startX.current = e.pageX;
-    scrollLeftRef.current = scrollRef.current?.scrollLeft ?? 0;
-    if (scrollRef.current) scrollRef.current.style.cursor = 'grabbing';
-  }, []);
-
-  const onMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!isDragging.current || !scrollRef.current) return;
-    e.preventDefault();
-    const walk = (e.pageX - startX.current) * 1.2;
-    scrollRef.current.scrollLeft = scrollLeftRef.current - walk;
-    if (Math.abs(walk) > 5) moved.current = true;
-  }, []);
-
-  // Whether there is more carousel in either direction. Drives the arrows and
-  // the edge fades — with `scrollbar-hide` and no peeking card, a full-width
-  // row of tiles reads as a finished grid, and a viewer has no way to learn
-  // that two thirds of the featured projects are one drag to the right.
-  const [overflow, setOverflow] = useState({ left: false, right: false });
-
-  const syncOverflow = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    // 1px slack: fractional scroll widths otherwise leave the right arrow
-    // showing forever at the end of the track.
-    setOverflow({
-      left:  el.scrollLeft > 1,
-      right: el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
-    });
-  }, []);
-
-  useEffect(() => {
-    syncOverflow();
-    const el = scrollRef.current;
-    if (!el) return;
-    // ResizeObserver rather than a window listener: the carousel also changes
-    // width when the sidebar opens, which never resizes the window.
-    const observer = new ResizeObserver(syncOverflow);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [syncOverflow, items]);
-
-  /** One "page" of scroll = the visible width, less a sliver so a partially
-   *  seen card stays partially seen rather than jumping out of view. */
-  const scrollByPage = useCallback((direction: 1 | -1) => {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollBy({ left: direction * Math.max(240, el.clientWidth - 96), behavior: 'smooth' });
-  }, []);
-
   return (
-    <div className="relative">
-      {/* Edge fades — the cheapest honest signal that content continues past
-          the edge. Non-interactive so they never eat a click on a card. */}
-      <div
-        aria-hidden
-        className={`pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-linear-to-r from-neutral-100 dark:from-[#060606] to-transparent transition-opacity duration-200 ${overflow.left ? 'opacity-100' : 'opacity-0'}`}
-      />
-      <div
-        aria-hidden
-        className={`pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-linear-to-l from-neutral-100 dark:from-[#060606] to-transparent transition-opacity duration-200 ${overflow.right ? 'opacity-100' : 'opacity-0'}`}
-      />
-
-      {/* Arrows are real buttons, not decoration: drag-to-scroll is invisible
-          to keyboard users and to anyone on a trackpad who never thinks to
-          try. Hidden entirely when there is nothing to scroll to. */}
-      {overflow.left && (
-        <button
-          type="button"
-          aria-label="Scroll featured projects left"
-          onClick={() => scrollByPage(-1)}
-          className="absolute left-1 top-1/2 -translate-y-1/2 z-20 grid place-items-center w-9 h-9 rounded-full bg-white/90 dark:bg-white/12 backdrop-blur border border-neutral-200 dark:border-white/15 text-neutral-700 dark:text-white shadow-lg hover:bg-white dark:hover:bg-white/20 transition-colors cursor-pointer"
-        >
-          <ChevronLeft className="w-5 h-5" />
-        </button>
-      )}
-      {overflow.right && (
-        <button
-          type="button"
-          aria-label="Scroll featured projects right"
-          onClick={() => scrollByPage(1)}
-          className="absolute right-1 top-1/2 -translate-y-1/2 z-20 grid place-items-center w-9 h-9 rounded-full bg-white/90 dark:bg-white/12 backdrop-blur border border-neutral-200 dark:border-white/15 text-neutral-700 dark:text-white shadow-lg hover:bg-white dark:hover:bg-white/20 transition-colors cursor-pointer"
-        >
-          <ChevronRight className="w-5 h-5" />
-        </button>
-      )}
-
-      <div
-        ref={scrollRef}
-        onScroll={syncOverflow}
-        onDragStart={e => e.preventDefault()}
-        onMouseDown={e => { e.preventDefault(); onMouseDown(e); }}
-        onMouseMove={onMouseMove}
-        onMouseUp={stopDrag}
-        onMouseLeave={stopDrag}
-        onClickCapture={(e) => { if (moved.current) { e.preventDefault(); e.stopPropagation(); } }}
-        // `snap-x` so a drag settles on a card edge instead of mid-card, which
-        // is the other half of reading as a carousel rather than a cut-off row.
-        className="flex gap-4 overflow-x-auto scrollbar-hide py-3 select-none snap-x snap-mandatory"
-        style={{ cursor: 'grab' }}
-      >
-        {items.map((project) => (
-          <div key={project.slug} className="shrink-0 snap-start">
-            <FeaturedProjectCard project={project} metrics={metricsByProject[project._id]} />
-          </div>
-        ))}
-      </div>
-    </div>
+    <DragScrollRow label="featured projects" trackClassName="py-3">
+      {items.map((project) => (
+        <div key={project.slug} className="shrink-0 snap-start">
+          <FeaturedProjectCard project={project} metrics={metricsByProject[project._id]} />
+        </div>
+      ))}
+    </DragScrollRow>
   );
 }
 

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,7 +1,14 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Search, ArrowRight } from 'lucide-react';
-import { useProjects, useFeaturedProjects, useProjectMetricsBatch } from '../hooks/useMarketplace';
+import {
+  useInfiniteProjects,
+  useFeaturedProjects,
+  useProjectMetricsByGroups,
+  useMarketplaceStats,
+  useCategories,
+} from '../hooks/useMarketplace';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCard';
 import { ProjectCard } from '../components/marketplace/ProjectCard';
 import { CategoryFilter } from '../components/marketplace/CategoryFilter';
@@ -9,10 +16,16 @@ import { MaintenanceScreen } from '../components/MaintenanceScreen';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 import { DEV_PORTAL_URL } from '../config/devPortal';
 import { PROJECT_TYPES } from '../utils/isStandalone';
+import type { ProjectSummary } from '../services/marketplaceApi';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const APP_CATEGORIES = ['game', 'defi', 'social', 'tool'];
+/**
+ * How long typing settles before it becomes a request. Search runs on the
+ * server now (it has to — the browser only ever holds the pages it loaded),
+ * so every keystroke would otherwise be its own round trip.
+ */
+const SEARCH_DEBOUNCE_MS = 300;
 
 // ─── Drag-scrollable Featured Carousel ────────────────────────────────────────
 
@@ -109,61 +122,77 @@ export function ExplorePage() {
   // the same status) never fire requests that would 503 during maintenance.
   const { data: maintenance } = useMaintenanceStatus();
 
-  // Data — both types are always fetched (not just the active one) so the type
-  // switch can show a real count on each side and so flipping tabs is instant,
-  // reading from the already-cached query instead of refetching.
-  const { data: appProjectsData, isLoading: appLoading } = useProjects({ type: PROJECT_TYPES.APP });
-  const { data: standaloneProjectsData, isLoading: standaloneLoading } = useProjects({ type: PROJECT_TYPES.STANDALONE });
-  const projectsData = activeType === PROJECT_TYPES.STANDALONE ? standaloneProjectsData : appProjectsData;
-  const isLoading = activeType === PROJECT_TYPES.STANDALONE ? standaloneLoading : appLoading;
-  const allItems = projectsData?.projects ?? [];
-  // Apps + standalone together — the hero stats describe the whole catalog,
-  // not just the active tab, so they must read identically on both tabs and
-  // never collapse just because the tab you happen to be on is empty.
-  const combinedItems = useMemo(
-    () => [...(appProjectsData?.projects ?? []), ...(standaloneProjectsData?.projects ?? [])],
-    [appProjectsData, standaloneProjectsData],
-  );
+  // Typing drives a SERVER-side search, so it is debounced before it reaches
+  // the query key. The raw value stays on the input so the box itself never
+  // lags behind the keyboard.
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
+
+  // Data — only the active tab is fetched. Both tabs used to be fetched on
+  // every mount so the hero could add them up; the hero now reads
+  // catalog-wide totals from the API instead, which is both correct and
+  // independent of what has been loaded. react-query keeps each tab's pages
+  // cached for staleTime, so flipping back to a tab is still instant — only
+  // the first visit costs a request.
+  const {
+    data, isLoading, isPlaceholderData,
+    hasNextPage, fetchNextPage, isFetchingNextPage,
+  } = useInfiniteProjects({ type: activeType, category, search: debouncedSearch });
   const { data: featured } = useFeaturedProjects(activeType);
+  const { data: stats } = useMarketplaceStats();
+  const { data: categoryCounts } = useCategories(activeType);
 
-  // Single batch request for live metrics across every project on this page —
-  // sourced from the combined list so hero stats and card metrics are equally
-  // live regardless of which tab is active.
-  const allProjectIds = useMemo(
-    () => [...new Set([...combinedItems, ...(featured ?? [])].map((p) => p._id))],
-    [combinedItems, featured],
-  );
-  const { data: metricsByProject = {} } = useProjectMetricsBatch(allProjectIds);
-
-  // Filtered items
-  const filtered = useMemo(() => {
-    let result = allItems;
-    if (category) result = result.filter((p) => p.category === category);
-    if (search) {
-      const q = search.toLowerCase();
-      result = result.filter(
-        (p) => p.name.toLowerCase().includes(q) || p.tags.some((t) => t.toLowerCase().includes(q)),
-      );
+  // Pages flattened into one list. Deduped by id: the server's sort is a
+  // total order, but a project published between two page requests still
+  // shifts the window, and a repeated card is worse than a missing one.
+  const items = useMemo(() => {
+    const seen = new Set<string>();
+    const flat: ProjectSummary[] = [];
+    for (const page of data?.pages ?? []) {
+      for (const project of page.projects) {
+        if (seen.has(project._id)) continue;
+        seen.add(project._id);
+        flat.push(project);
+      }
     }
-    return result;
-  }, [allItems, category, search]);
+    return flat;
+  }, [data]);
+
+  // How many projects match the current filters catalog-wide — not how many
+  // are on screen.
+  const matchingTotal = data?.pages[0]?.total ?? 0;
+
+  // Live metrics, grouped so each loaded page keeps its own cached request
+  // instead of re-fetching every project seen so far on each "Load more".
+  const metricGroups = useMemo(() => {
+    const groups = (data?.pages ?? []).map((page) => page.projects.map((p) => p._id));
+    if (featured?.length) groups.push(featured.map((p) => p._id));
+    return groups;
+  }, [data, featured]);
+  const metricsByProject = useProjectMetricsByGroups(metricGroups);
 
   // Featured items
   const featuredItems = featured ?? [];
 
-  // Hero stats — apps + standalone combined (never just the active tab), prefer
-  // live metrics, fall back to denormalized stats
-  const heroStats = useMemo(() => {
-    const projects = combinedItems.length;
-    const users = combinedItems.reduce((sum, p) => {
-      const live = metricsByProject[p._id]?.uniqueUsers;
-      return sum + (live ?? p.stats.totalUsers ?? 0);
-    }, 0);
-    const categoriesCount = new Set(combinedItems.map((p) => p.category)).size;
-    return { projects, users, categoriesCount };
-  }, [combinedItems, metricsByProject]);
+  // Hero stats — counted across the whole published catalog by the API.
+  // Deriving them from the loaded list is what made this row report the page
+  // size (20) while the catalog held 24, and paging would only have made that
+  // worse. `skill` projects are excluded from the project count on purpose:
+  // Explore surfaces apps and standalone only, and a total the tabs below it
+  // cannot reach is the same bug wearing a different number.
+  const heroStats = useMemo(() => ({
+    projects:
+      (stats?.byType?.[PROJECT_TYPES.APP] ?? 0) +
+      (stats?.byType?.[PROJECT_TYPES.STANDALONE] ?? 0),
+    users:           stats?.totalUsers ?? 0,
+    categoriesCount: stats?.totalCategories ?? 0,
+  }), [stats]);
 
-  const categories = APP_CATEGORIES;
+  // Chips come from the API, scoped to the active tab, so every chip offers a
+  // filter this tab can actually satisfy. They used to be a hardcoded four
+  // (game/defi/social/tool) while the catalog held eight categories, which
+  // left utility, nft, trading and other unreachable by any filter.
+  const categories = categoryCounts ?? [];
+  const categoriesTotal = categories.reduce((sum, c) => sum + c.count, 0);
   const itemLabel = activeType === PROJECT_TYPES.STANDALONE ? 'standalone projects' : 'projects';
   const searchPlaceholder = activeType === PROJECT_TYPES.STANDALONE ? 'Search standalone projects...' : 'Search projects...';
 
@@ -297,7 +326,12 @@ export function ExplorePage() {
               className="w-full pl-10 pr-4 py-2.5 rounded-xl bg-white dark:bg-white/6 border border-neutral-200 dark:border-white/8 text-sm text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 transition-all"
             />
           </div>
-          <CategoryFilter categories={categories} active={category} onChange={setCategory} />
+          <CategoryFilter
+            categories={categories}
+            active={category}
+            onChange={setCategory}
+            totalCount={categoriesTotal}
+          />
         </div>
       </section>
 
@@ -318,7 +352,13 @@ export function ExplorePage() {
         <div>
           <h2 className="text-lg font-semibold mb-6">
             {category ? `${category.charAt(0).toUpperCase() + category.slice(1)} ${itemLabel}` : `All ${itemLabel}`}
-            {filtered.length > 0 && <span className="text-neutral-400 dark:text-white/35 font-normal ml-2">({filtered.length})</span>}
+            {/* The catalog-wide match count, not the number of loaded cards —
+                otherwise this bracket would just restate the page size. */}
+            {matchingTotal > 0 && (
+              <span data-testid="grid-total" className="text-neutral-400 dark:text-white/35 font-normal ml-2">
+                ({matchingTotal})
+              </span>
+            )}
           </h2>
 
           {isLoading ? (
@@ -327,20 +367,54 @@ export function ExplorePage() {
                 <div key={i} className="h-40 rounded-2xl bg-neutral-100 dark:bg-white/4 animate-pulse" />
               ))}
             </div>
-          ) : filtered.length > 0 ? (
-            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}>
-              {filtered.map((project, i) => (
-                <ProjectCard
-                  key={project.slug}
-                  project={project}
-                  index={i}
-                  metrics={metricsByProject[project._id]}
-                />
-              ))}
-            </div>
+          ) : items.length > 0 ? (
+            <>
+              {/* Dimmed while a settled search term is still in flight: the
+                  cards below are the PREVIOUS term's results, and pretending
+                  otherwise would read as "these match what you just typed". */}
+              <div
+                className={`grid gap-4 transition-opacity ${isPlaceholderData ? 'opacity-50' : 'opacity-100'}`}
+                style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}
+              >
+                {items.map((project, i) => (
+                  <ProjectCard
+                    key={project.slug}
+                    project={project}
+                    index={i}
+                    metrics={metricsByProject[project._id]}
+                  />
+                ))}
+              </div>
+
+              {/* Paging is an explicit button rather than infinite scroll:
+                  this page ends in the developer CTA poster, and a list that
+                  grows on scroll would push that out of reach forever. It
+                  also states what is left, so "24 published but I see 20" is
+                  answerable from the screen. */}
+              {hasNextPage && (
+                <div className="mt-8 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => { void fetchNextPage(); }}
+                    // Disabled on placeholder data too: the next page number
+                    // is derived from results that are about to be replaced.
+                    disabled={isFetchingNextPage || isPlaceholderData}
+                    className="px-6 py-3 rounded-xl bg-neutral-100 dark:bg-white/6 border border-neutral-200 dark:border-white/10 text-sm font-semibold text-neutral-700 dark:text-white/80 hover:border-neutral-300 dark:hover:border-white/20 hover:text-neutral-900 dark:hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                  >
+                    {isFetchingNextPage
+                      ? 'Loading…'
+                      : `Load more (${items.length} of ${matchingTotal})`}
+                  </button>
+                </div>
+              )}
+            </>
           ) : (
             <div className="text-center py-16">
-              <p className="text-neutral-400 dark:text-white/35 text-sm">No {itemLabel} found</p>
+              <p className="text-neutral-400 dark:text-white/35 text-sm">
+                {debouncedSearch
+                  ? `No ${itemLabel} match “${debouncedSearch}”`
+                  : `No ${itemLabel} found`}
+              </p>
             </div>
           )}
         </div>

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -12,6 +12,7 @@ import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCard';
 import { ProjectCard } from '../components/marketplace/ProjectCard';
 import { CategoryFilter } from '../components/marketplace/CategoryFilter';
+import { SortControl, type SortValue } from '../components/marketplace/SortControl';
 import { DragScrollRow } from '../components/common/DragScrollRow';
 import { MaintenanceScreen } from '../components/MaintenanceScreen';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
@@ -72,6 +73,10 @@ function HeroDivider() {
 export function ExplorePage() {
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState<string | null>(null);
+  // Sort deliberately survives a tab switch, unlike search and category: it is
+  // a preference about how to read the catalog, not a filter on which part of
+  // it you are looking at.
+  const [sort, setSort] = useState<SortValue>('relevant');
   const [activeType, setActiveType] = useState<typeof PROJECT_TYPES.APP | typeof PROJECT_TYPES.STANDALONE>(PROJECT_TYPES.APP);
   // Proactive maintenance status — the hook polls the allowlisted status endpoint
   // and also listens for `maintenance:forced`, so the marketplace queries (gated on
@@ -92,7 +97,7 @@ export function ExplorePage() {
   const {
     data, isLoading, isPlaceholderData,
     hasNextPage, fetchNextPage, isFetchingNextPage,
-  } = useInfiniteProjects({ type: activeType, category, search: debouncedSearch });
+  } = useInfiniteProjects({ type: activeType, category, search: debouncedSearch, sort });
   const { data: featured } = useFeaturedProjects(activeType);
   const { data: stats } = useMarketplaceStats();
   const { data: categoryCounts } = useCategories(activeType);
@@ -272,15 +277,24 @@ export function ExplorePage() {
       {/* Search + Filter */}
       <section className="px-4 sm:px-6 pb-8">
         <div className="space-y-4">
-          <div className="relative max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 dark:text-white/30" />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={searchPlaceholder}
-              className="w-full pl-10 pr-4 py-2.5 rounded-xl bg-white dark:bg-white/6 border border-neutral-200 dark:border-white/8 text-sm text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 transition-all"
-            />
+          {/* Search and sort share a row: both act on the whole catalog, and
+              both are answered by the same request. The category chips sit
+              below because they are a different kind of thing — they change
+              how many projects exist, these two do not. */}
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 dark:text-white/30" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={searchPlaceholder}
+                className="w-full pl-10 pr-4 py-2.5 rounded-xl bg-white dark:bg-white/6 border border-neutral-200 dark:border-white/8 text-sm text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-orange-500/30 focus:border-orange-500/50 transition-all"
+              />
+            </div>
+            <div className="sm:ml-auto">
+              <SortControl value={sort} onChange={setSort} />
+            </div>
           </div>
           <CategoryFilter
             categories={categories}

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Search, ArrowRight } from 'lucide-react';
 import {
   useInfiniteProjects,
@@ -7,6 +7,7 @@ import {
   useProjectMetricsByGroups,
   useMarketplaceStats,
   useCategories,
+  EXPLORE_PAGE_SIZE,
 } from '../hooks/useMarketplace';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { FeaturedProjectCard } from '../components/marketplace/FeaturedProjectCard';
@@ -82,6 +83,10 @@ export function ExplorePage() {
   // and also listens for `maintenance:forced`, so the marketplace queries (gated on
   // the same status) never fire requests that would 503 during maintenance.
   const { data: maintenance } = useMaintenanceStatus();
+  // Honoured throughout the grid below: motion here is decoration on top of a
+  // list that reads fine without it, so a viewer who has asked the OS for less
+  // of it gets none.
+  const reduceMotion = useReducedMotion();
 
   // Typing drives a SERVER-side search, so it is debounced before it reaches
   // the query key. The raw value stays on the input so the box itself never
@@ -347,12 +352,41 @@ export function ExplorePage() {
                 style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}
               >
                 {items.map((project, i) => (
-                  <ProjectCard
+                  <motion.div
                     key={project.slug}
-                    project={project}
-                    index={i}
-                    metrics={metricsByProject[project._id]}
-                  />
+                    // Two different motions, because two different things
+                    // happen to this grid:
+                    //
+                    // `layout` covers REORDERING. Changing the sort keeps the
+                    // same cards and only moves them, so React reuses every
+                    // element and nothing animates by default — the grid just
+                    // teleports into its new order. "position" rather than
+                    // full layout so only the move is animated; the cards are
+                    // uniform, and animating size would scale their contents
+                    // for a frame.
+                    //
+                    // initial/animate covers ARRIVAL — a new page appended by
+                    // Load more, or a new result set. Existing cards keep
+                    // their key, so they do not replay it.
+                    layout={reduceMotion ? false : 'position'}
+                    initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{
+                      duration: 0.22,
+                      ease: 'easeOut',
+                      // Staggered within its own page and capped, so a page
+                      // ripples in instead of appearing as one block — and
+                      // the last card of a 24-card page is never a quarter of
+                      // a second behind the first.
+                      delay: reduceMotion ? 0 : Math.min(i % EXPLORE_PAGE_SIZE, 11) * 0.02,
+                    }}
+                  >
+                    <ProjectCard
+                      project={project}
+                      index={i}
+                      metrics={metricsByProject[project._id]}
+                    />
+                  </motion.div>
                 ))}
               </div>
 

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Search, ArrowRight } from 'lucide-react';
+import { Search, ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
 import {
   useInfiniteProjects,
   useFeaturedProjects,
@@ -16,7 +16,7 @@ import { MaintenanceScreen } from '../components/MaintenanceScreen';
 import { useMaintenanceStatus } from '../hooks/useMaintenanceStatus';
 import { DEV_PORTAL_URL } from '../config/devPortal';
 import { PROJECT_TYPES } from '../utils/isStandalone';
-import type { ProjectSummary } from '../services/marketplaceApi';
+import type { ProjectSummary, ProjectMetrics } from '../services/marketplaceApi';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -30,8 +30,8 @@ const SEARCH_DEBOUNCE_MS = 300;
 // ─── Drag-scrollable Featured Carousel ────────────────────────────────────────
 
 function FeaturedCarousel({ items, metricsByProject }: {
-  items: { slug: string }[];
-  metricsByProject: Record<string, import('../services/marketplaceApi').ProjectMetrics>;
+  items: ProjectSummary[];
+  metricsByProject: Record<string, ProjectMetrics>;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
@@ -68,23 +68,99 @@ function FeaturedCarousel({ items, metricsByProject }: {
     if (Math.abs(walk) > 5) moved.current = true;
   }, []);
 
+  // Whether there is more carousel in either direction. Drives the arrows and
+  // the edge fades — with `scrollbar-hide` and no peeking card, a full-width
+  // row of tiles reads as a finished grid, and a viewer has no way to learn
+  // that two thirds of the featured projects are one drag to the right.
+  const [overflow, setOverflow] = useState({ left: false, right: false });
+
+  const syncOverflow = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // 1px slack: fractional scroll widths otherwise leave the right arrow
+    // showing forever at the end of the track.
+    setOverflow({
+      left:  el.scrollLeft > 1,
+      right: el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    });
+  }, []);
+
+  useEffect(() => {
+    syncOverflow();
+    const el = scrollRef.current;
+    if (!el) return;
+    // ResizeObserver rather than a window listener: the carousel also changes
+    // width when the sidebar opens, which never resizes the window.
+    const observer = new ResizeObserver(syncOverflow);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [syncOverflow, items]);
+
+  /** One "page" of scroll = the visible width, less a sliver so a partially
+   *  seen card stays partially seen rather than jumping out of view. */
+  const scrollByPage = useCallback((direction: 1 | -1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * Math.max(240, el.clientWidth - 96), behavior: 'smooth' });
+  }, []);
+
   return (
-    <div
-      ref={scrollRef}
-      onDragStart={e => e.preventDefault()}
-      onMouseDown={e => { e.preventDefault(); onMouseDown(e); }}
-      onMouseMove={onMouseMove}
-      onMouseUp={stopDrag}
-      onMouseLeave={stopDrag}
-      onClickCapture={(e) => { if (moved.current) { e.preventDefault(); e.stopPropagation(); } }}
-      className="flex gap-4 overflow-x-auto scrollbar-hide py-3 select-none"
-      style={{ cursor: 'grab' }}
-    >
-      {(items as import('../services/marketplaceApi').ProjectSummary[]).map((project) => (
-        <div key={project.slug} className="shrink-0">
-          <FeaturedProjectCard project={project} metrics={metricsByProject[project._id]} />
-        </div>
-      ))}
+    <div className="relative">
+      {/* Edge fades — the cheapest honest signal that content continues past
+          the edge. Non-interactive so they never eat a click on a card. */}
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-linear-to-r from-neutral-100 dark:from-[#060606] to-transparent transition-opacity duration-200 ${overflow.left ? 'opacity-100' : 'opacity-0'}`}
+      />
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-linear-to-l from-neutral-100 dark:from-[#060606] to-transparent transition-opacity duration-200 ${overflow.right ? 'opacity-100' : 'opacity-0'}`}
+      />
+
+      {/* Arrows are real buttons, not decoration: drag-to-scroll is invisible
+          to keyboard users and to anyone on a trackpad who never thinks to
+          try. Hidden entirely when there is nothing to scroll to. */}
+      {overflow.left && (
+        <button
+          type="button"
+          aria-label="Scroll featured projects left"
+          onClick={() => scrollByPage(-1)}
+          className="absolute left-1 top-1/2 -translate-y-1/2 z-20 grid place-items-center w-9 h-9 rounded-full bg-white/90 dark:bg-white/12 backdrop-blur border border-neutral-200 dark:border-white/15 text-neutral-700 dark:text-white shadow-lg hover:bg-white dark:hover:bg-white/20 transition-colors cursor-pointer"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+      )}
+      {overflow.right && (
+        <button
+          type="button"
+          aria-label="Scroll featured projects right"
+          onClick={() => scrollByPage(1)}
+          className="absolute right-1 top-1/2 -translate-y-1/2 z-20 grid place-items-center w-9 h-9 rounded-full bg-white/90 dark:bg-white/12 backdrop-blur border border-neutral-200 dark:border-white/15 text-neutral-700 dark:text-white shadow-lg hover:bg-white dark:hover:bg-white/20 transition-colors cursor-pointer"
+        >
+          <ChevronRight className="w-5 h-5" />
+        </button>
+      )}
+
+      <div
+        ref={scrollRef}
+        onScroll={syncOverflow}
+        onDragStart={e => e.preventDefault()}
+        onMouseDown={e => { e.preventDefault(); onMouseDown(e); }}
+        onMouseMove={onMouseMove}
+        onMouseUp={stopDrag}
+        onMouseLeave={stopDrag}
+        onClickCapture={(e) => { if (moved.current) { e.preventDefault(); e.stopPropagation(); } }}
+        // `snap-x` so a drag settles on a card edge instead of mid-card, which
+        // is the other half of reading as a carousel rather than a cut-off row.
+        className="flex gap-4 overflow-x-auto scrollbar-hide py-3 select-none snap-x snap-mandatory"
+        style={{ cursor: 'grab' }}
+      >
+        {items.map((project) => (
+          <div key={project.slug} className="shrink-0 snap-start">
+            <FeaturedProjectCard project={project} metrics={metricsByProject[project._id]} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/services/marketplaceApi.ts
+++ b/src/services/marketplaceApi.ts
@@ -69,6 +69,20 @@ export interface CategoryCount {
   count: number;
 }
 
+/**
+ * Catalog-wide totals for the Explore hero. Counted server-side over every
+ * published project, because a hero that says "Total Projects" must not be
+ * derived from whichever page the browser happens to have loaded — that is
+ * how it came to read 20 while the catalog held 24.
+ */
+export interface MarketplaceStats {
+  totalProjects:   number;
+  totalUsers:      number;
+  totalCategories: number;
+  /** Per-type breakdown, so a caller can count only the types it surfaces. */
+  byType:          Record<string, number>;
+}
+
 // ── Fetch helpers ─────────────────────────────────────────────────────
 
 /** Central fetch wrapper — adds X-Client header and handles 503 maintenance gate. */
@@ -127,8 +141,17 @@ export function fetchProjectAchievements(slug: string): Promise<ProjectAchieveme
   return get(`/${slug}/achievements`);
 }
 
-export function fetchCategories(): Promise<CategoryCount[]> {
-  return get('/categories');
+/**
+ * `type` scopes the counts to one project type. Explore renders these chips
+ * under an Apps/Standalone tab, and unscoped counts would offer a filter that
+ * matches nothing on the tab the user is actually looking at.
+ */
+export function fetchCategories(type?: ProjectType): Promise<CategoryCount[]> {
+  return get(type ? `/categories?type=${encodeURIComponent(type)}` : '/categories');
+}
+
+export function fetchMarketplaceStats(): Promise<MarketplaceStats> {
+  return get('/stats');
 }
 
 // ── Public project metrics (live user/install/completion counts) ──────
@@ -159,11 +182,33 @@ export async function fetchProjectMetrics(projectId: string): Promise<ProjectMet
   return res.json();
 }
 
+/**
+ * Server-side cap on `ids` per request (MAX_BATCH_SIZE in sphere-api's
+ * routes/metrics/index.ts). Over it the API answers 400 and the caller gets
+ * NO metrics at all — every card silently falls back to its denormalized
+ * stats snapshot. Explore pages through the catalog, so the id list grows
+ * past 100 as soon as the catalog does; keep this in sync with the server.
+ */
+const METRICS_BATCH_LIMIT = 100;
+
 export async function fetchProjectMetricsBatch(projectIds: string[]): Promise<Record<string, ProjectMetrics>> {
   if (projectIds.length === 0) return {};
-  const res = await marketplaceFetch(`${API_BASE}/api/metrics/projects?ids=${projectIds.join(',')}`);
-  if (!res.ok) throw new Error(`Metrics API error: ${res.status}`);
-  return res.json();
+
+  // Chunked so a large catalog degrades into several small requests rather
+  // than one rejected one. Chunks run concurrently and merge into a single
+  // map, so callers see the same shape regardless of how many were needed.
+  const chunks: string[][] = [];
+  for (let i = 0; i < projectIds.length; i += METRICS_BATCH_LIMIT) {
+    chunks.push(projectIds.slice(i, i + METRICS_BATCH_LIMIT));
+  }
+
+  const results = await Promise.all(chunks.map(async (chunk) => {
+    const res = await marketplaceFetch(`${API_BASE}/api/metrics/projects?ids=${chunk.join(',')}`);
+    if (!res.ok) throw new Error(`Metrics API error: ${res.status}`);
+    return res.json() as Promise<Record<string, ProjectMetrics>>;
+  }));
+
+  return Object.assign({}, ...results) as Record<string, ProjectMetrics>;
 }
 
 // ── Public project ratings (Steam-style reviews) ──────────────────────

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -42,6 +42,9 @@ vi.mock('../../../src/hooks/useMarketplace', () => ({
   useMarketplaceStats,
   useCategories,
   useProjectMetricsByGroups: () => ({}),
+  // The page reads this to stagger a page of cards as it arrives; the mock
+  // has to carry it or every render throws on the missing export.
+  EXPLORE_PAGE_SIZE: 24,
 }));
 vi.mock('../../../src/hooks/useMaintenanceStatus', () => ({
   useMaintenanceStatus: () => ({ data: { enabled: false } }),

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -1,11 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import type { ProjectSummary } from '../../../src/services/marketplaceApi';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { ProjectSummary, MarketplaceStats, CategoryCount } from '../../../src/services/marketplaceApi';
 import { PROJECT_TYPES } from '../../../src/utils/isStandalone';
 
 import type { ProjectType } from '../../../src/utils/isStandalone';
 
-type ProjectQueryParams = { type?: ProjectType; category?: string; search?: string; sort?: string; page?: number; limit?: number };
+type ProjectQueryParams = { type?: ProjectType; category?: string | null; search?: string; sort?: string };
+
+type InfinitePage = { projects: ProjectSummary[]; total: number; page: number; limit: number; totalPages: number };
+type InfiniteResult = {
+  data?: { pages: InfinitePage[] };
+  isLoading: boolean;
+  isPlaceholderData?: boolean;
+  hasNextPage?: boolean;
+  fetchNextPage?: () => void;
+  isFetchingNextPage?: boolean;
+};
 
 // vi.mock factories are hoisted above regular top-level `const`s, so the mocks
 // referenced inside the factory below must themselves be created via vi.hoisted
@@ -14,21 +24,24 @@ type ProjectQueryParams = { type?: ProjectType; category?: string; search?: stri
 // Typed against the real hooks: `vi.fn(() => …)` would infer a ZERO-arg mock
 // returning `projects: never[]`, so every mockImplementation that takes `params`
 // or returns real projects fails to compile.
-type ProjectsQuery = (params?: ProjectQueryParams) => {
-  data?: { projects: ProjectSummary[] };
-  isLoading: boolean;
-};
+type ProjectsQuery = (params: ProjectQueryParams) => InfiniteResult;
 type FeaturedQuery = () => { data?: ProjectSummary[] };
+type StatsQuery    = () => { data?: MarketplaceStats };
+type CategoriesQuery = (type?: ProjectType) => { data?: CategoryCount[] };
 
-const { useProjects, useFeaturedProjects } = vi.hoisted(() => ({
-  useProjects: vi.fn<ProjectsQuery>(() => ({ data: { projects: [] }, isLoading: false })),
+const { useInfiniteProjects, useFeaturedProjects, useMarketplaceStats, useCategories } = vi.hoisted(() => ({
+  useInfiniteProjects: vi.fn<ProjectsQuery>(() => ({ data: { pages: [] }, isLoading: false })),
   useFeaturedProjects: vi.fn<FeaturedQuery>(() => ({ data: [] })),
+  useMarketplaceStats: vi.fn<StatsQuery>(() => ({ data: undefined })),
+  useCategories:       vi.fn<CategoriesQuery>(() => ({ data: [] })),
 }));
 
 vi.mock('../../../src/hooks/useMarketplace', () => ({
-  useProjects,
+  useInfiniteProjects,
   useFeaturedProjects,
-  useProjectMetricsBatch: () => ({ data: {} }),
+  useMarketplaceStats,
+  useCategories,
+  useProjectMetricsByGroups: () => ({}),
 }));
 vi.mock('../../../src/hooks/useMaintenanceStatus', () => ({
   useMaintenanceStatus: () => ({ data: { enabled: false } }),
@@ -38,7 +51,7 @@ vi.mock('../../../src/hooks/useMaintenanceStatus', () => ({
 // subject) doesn't depend on card internals, so stub the card out rather than
 // wiring a full wallet context just to satisfy a grid of tiles.
 vi.mock('../../../src/components/marketplace/ProjectCard', () => ({
-  ProjectCard: () => null,
+  ProjectCard: ({ project }: { project: ProjectSummary }) => <div data-testid="project-card">{project.name}</div>,
 }));
 
 import { MemoryRouter } from 'react-router-dom';
@@ -74,34 +87,63 @@ function buildProject(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
   };
 }
 
+/** One page of results, with the catalog-wide `total` the server reports. */
+function buildPage(projects: ProjectSummary[], total = projects.length, page = 1, limit = 24): InfinitePage {
+  return { projects, total, page, limit, totalPages: Math.max(1, Math.ceil(total / limit)) };
+}
+
+function buildStats(overrides: Partial<MarketplaceStats> = {}): MarketplaceStats {
+  return {
+    totalProjects: 0,
+    totalUsers: 0,
+    totalCategories: 0,
+    byType: { app: 0, skill: 0, standalone: 0 },
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   // clearAllMocks resets call history but not a previously-installed
-  // mockImplementation, so re-pin the default here — tests that need
+  // mockImplementation, so re-pin the defaults here — tests that need
   // different data call mockImplementation themselves.
-  useProjects.mockImplementation(() => ({ data: { projects: [] }, isLoading: false }));
+  useInfiniteProjects.mockImplementation(() => ({ data: { pages: [] }, isLoading: false }));
   useFeaturedProjects.mockImplementation(() => ({ data: [] }));
+  useMarketplaceStats.mockImplementation(() => ({ data: undefined }));
+  useCategories.mockImplementation(() => ({ data: [] }));
 });
 
 describe('Explore type tabs', () => {
   it('starts on Apps', () => {
     renderExplore();
-    expect(useProjects).toHaveBeenCalledWith({ type: PROJECT_TYPES.APP });
+    expect(useInfiniteProjects).toHaveBeenCalledWith(
+      expect.objectContaining({ type: PROJECT_TYPES.APP }),
+    );
     expect(useFeaturedProjects).toHaveBeenCalledWith(PROJECT_TYPES.APP);
   });
 
   it('switches the query to standalone projects', () => {
     renderExplore();
     fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
-    expect(useProjects).toHaveBeenLastCalledWith({ type: PROJECT_TYPES.STANDALONE });
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: PROJECT_TYPES.STANDALONE }),
+    );
     expect(useFeaturedProjects).toHaveBeenLastCalledWith(PROJECT_TYPES.STANDALONE);
   });
 
-  // The category filter and the search box are CLIENT-side state — never
-  // passed to useProjects/useFeaturedProjects — so the two tests above would
-  // still pass even if the tab handler stopped resetting them. Assert on the
-  // rendered DOM instead of the hooks to actually catch that regression.
+  it('scopes the category chips to the active tab', () => {
+    renderExplore();
+    expect(useCategories).toHaveBeenLastCalledWith(PROJECT_TYPES.APP);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
+
+    // Chips built from the whole catalog would offer a filter that returns
+    // nothing on the tab the user is looking at.
+    expect(useCategories).toHaveBeenLastCalledWith(PROJECT_TYPES.STANDALONE);
+  });
+
   it('clears the search box and category filter when switching tabs', () => {
+    useCategories.mockImplementation(() => ({ data: [{ category: 'tool', count: 3 }] }));
     renderExplore();
 
     const search = screen.getByPlaceholderText('Search projects...') as HTMLInputElement;
@@ -128,59 +170,73 @@ describe('Explore type tabs', () => {
 
     expect(screen.getByText('Run on your own machine')).toBeDefined();
   });
+});
 
-  // Regression pin: the hero totals describe the WHOLE catalog (apps +
-  // standalone combined). They must read identically no matter which tab is
-  // active, and must never read zero while the combined catalog has content —
-  // both broke once already (the row was accidentally wired to the active
-  // tab's own list instead of the combined one).
-  it('computes hero totals from both lists combined, unaffected by the active tab, and never zero while the catalog has content', () => {
-    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'standalone' }) =>
-      params?.type === PROJECT_TYPES.STANDALONE
-        ? { data: { projects: [] }, isLoading: false }
-        : {
-            data: {
-              projects: [
-                buildProject({ _id: '1', slug: 'one', category: 'game', stats: { totalUsers: 10, totalCompletions: 0, activeQuests: 0 } }),
-              ],
-            },
-            isLoading: false,
-          },
-    );
+/**
+ * The hero row describes the whole published catalog. It used to be derived
+ * from the loaded project list, which is exactly how it came to report 20
+ * while the catalog held 24 — and paging would only have made that worse.
+ * These pin that it reads catalog-wide totals from the API instead.
+ */
+describe('Explore hero totals', () => {
+  it('reports the catalog total, not the number of loaded cards', () => {
+    useMarketplaceStats.mockImplementation(() => ({
+      data: buildStats({ totalProjects: 24, byType: { app: 24, skill: 0, standalone: 0 }, totalUsers: 900, totalCategories: 8 }),
+    }));
+    useInfiniteProjects.mockImplementation(() => ({
+      // Only the first page is loaded — 20 of the 24.
+      data: { pages: [buildPage(Array.from({ length: 20 }, (_, i) => buildProject({ _id: `p${i}`, slug: `p${i}` })), 24, 1, 20)] },
+      isLoading: false,
+    }));
 
     renderExplore();
 
+    expect(screen.getByTestId('hero-stat-projects').textContent).toContain('24');
+    expect(screen.getByTestId('hero-stat-categories').textContent).toContain('8');
+  });
+
+  it('stays identical across a tab switch, and never collapses to zero while the catalog has content', () => {
+    useMarketplaceStats.mockImplementation(() => ({
+      data: buildStats({ byType: { app: 7, skill: 0, standalone: 0 }, totalUsers: 10, totalCategories: 3 }),
+    }));
+    // The standalone tab is empty; the hero must not follow it down.
+    useInfiniteProjects.mockImplementation((params) =>
+      params.type === PROJECT_TYPES.STANDALONE
+        ? { data: { pages: [buildPage([], 0)] }, isLoading: false }
+        : { data: { pages: [buildPage([buildProject()])] }, isLoading: false },
+    );
+
+    renderExplore();
     const before = screen.getByTestId('hero-stat-projects').textContent;
-    expect(before).toContain('1');
-    expect(screen.getByTestId('hero-stat-users').textContent).toContain('10');
+    expect(before).toContain('7');
 
     fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
 
-    // Standalone has zero projects of its own, but the hero row describes the
-    // whole catalog (1 app + 0 standalone = 1), so it must read exactly the
-    // same as before the switch — not zero, not different.
     expect(screen.getByTestId('hero-stat-projects').textContent).toBe(before);
-    expect(screen.getByTestId('hero-stat-projects').textContent).not.toContain('0');
     expect(screen.getByTestId('hero-stat-users').textContent).toContain('10');
   });
 
-  it('uses singular wording for a hero stat only when its value is exactly one', () => {
-    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'standalone' }) =>
-      params?.type === PROJECT_TYPES.STANDALONE
-        ? { data: { projects: [] }, isLoading: false }
-        : {
-            data: {
-              projects: [
-                buildProject({ _id: '1', slug: 'one', category: 'game', stats: { totalUsers: 1, totalCompletions: 0, activeQuests: 0 } }),
-              ],
-            },
-            isLoading: false,
-          },
-    );
+  it('counts only the types the tabs can reach, so the total is never unreachable', () => {
+    // A published `skill` has no tab on Explore. Counting it here would
+    // reproduce the original complaint in a new place: a headline number
+    // larger than anything the page can show.
+    useMarketplaceStats.mockImplementation(() => ({
+      data: buildStats({ totalProjects: 29, byType: { app: 20, skill: 5, standalone: 4 } }),
+    }));
 
     renderExplore();
 
-    // One project, one user, one category — every stat must be singular.
+    expect(screen.getByTestId('hero-stat-projects').textContent).toContain('24');
+    expect(screen.getByTestId('hero-stat-projects').textContent).not.toContain('29');
+  });
+
+  it('uses singular wording for a hero stat only when its value is exactly one', () => {
+    useMarketplaceStats.mockImplementation(() => ({
+      data: buildStats({ byType: { app: 1, skill: 0, standalone: 0 }, totalUsers: 1, totalCategories: 1 }),
+    }));
+
+    renderExplore();
+
     const projectsText = screen.getByTestId('hero-stat-projects').textContent!;
     const usersText = screen.getByTestId('hero-stat-users').textContent!;
     const categoriesText = screen.getByTestId('hero-stat-categories').textContent!;
@@ -194,24 +250,207 @@ describe('Explore type tabs', () => {
   });
 
   it('uses plural wording once a hero stat is more than one (and for zero)', () => {
-    useProjects.mockImplementation((params?: { type?: 'app' | 'skill' | 'standalone' }) =>
-      params?.type === PROJECT_TYPES.STANDALONE
-        ? { data: { projects: [] }, isLoading: false }
-        : {
-            data: {
-              projects: [
-                buildProject({ _id: '1', slug: 'one', category: 'game', stats: { totalUsers: 5, totalCompletions: 0, activeQuests: 0 } }),
-                buildProject({ _id: '2', slug: 'two', category: 'tool', stats: { totalUsers: 5, totalCompletions: 0, activeQuests: 0 } }),
-              ],
-            },
-            isLoading: false,
-          },
-    );
+    useMarketplaceStats.mockImplementation(() => ({
+      data: buildStats({ byType: { app: 2, skill: 0, standalone: 0 }, totalUsers: 10, totalCategories: 2 }),
+    }));
 
     renderExplore();
 
     expect(screen.getByTestId('hero-stat-projects').textContent).toContain('Total Projects');
     expect(screen.getByTestId('hero-stat-users').textContent).toContain('Total Users');
     expect(screen.getByTestId('hero-stat-categories').textContent).toContain('Categories');
+  });
+});
+
+/**
+ * The reported bug: 24 published projects, 20 visible. The list is paged now,
+ * so the page must both say how many there are and offer a way to reach them.
+ */
+describe('Explore paging', () => {
+  const twentyOf24 = () => ({
+    data: { pages: [buildPage(Array.from({ length: 20 }, (_, i) => buildProject({ _id: `p${i}`, slug: `p${i}` })), 24, 1, 20)] },
+    isLoading: false,
+    hasNextPage: true,
+    fetchNextPage: vi.fn(),
+    isFetchingNextPage: false,
+    isPlaceholderData: false,
+  });
+
+  it('shows the catalog-wide match count next to the grid heading, not the loaded count', () => {
+    useInfiniteProjects.mockImplementation(twentyOf24);
+
+    renderExplore();
+
+    expect(screen.getByTestId('grid-total').textContent).toBe('(24)');
+  });
+
+  it('offers a Load more control that names what is left', () => {
+    useInfiniteProjects.mockImplementation(twentyOf24);
+
+    renderExplore();
+
+    expect(screen.getByRole('button', { name: /Load more \(20 of 24\)/ })).toBeDefined();
+  });
+
+  it('asks for the next page when Load more is pressed', () => {
+    const fetchNextPage = vi.fn();
+    useInfiniteProjects.mockImplementation(() => ({ ...twentyOf24(), fetchNextPage }));
+
+    renderExplore();
+    fireEvent.click(screen.getByRole('button', { name: /Load more/ }));
+
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders every loaded page, not just the first', () => {
+    useInfiniteProjects.mockImplementation(() => ({
+      data: {
+        pages: [
+          buildPage([buildProject({ _id: 'a', slug: 'a', name: 'First Page App' })], 2, 1, 1),
+          buildPage([buildProject({ _id: 'b', slug: 'b', name: 'Second Page App' })], 2, 2, 1),
+        ],
+      },
+      isLoading: false,
+      hasNextPage: false,
+    }));
+
+    renderExplore();
+
+    expect(screen.getByText('First Page App')).toBeDefined();
+    expect(screen.getByText('Second Page App')).toBeDefined();
+  });
+
+  it('never renders the same project twice when pages overlap', () => {
+    // The server sort is a total order, but a project published between two
+    // page requests still shifts the window — a duplicated card is worse
+    // than a late one.
+    const dup = buildProject({ _id: 'same', slug: 'same', name: 'Overlapping App' });
+    useInfiniteProjects.mockImplementation(() => ({
+      data: { pages: [buildPage([dup], 2, 1, 1), buildPage([dup], 2, 2, 1)] },
+      isLoading: false,
+      hasNextPage: false,
+    }));
+
+    renderExplore();
+
+    expect(screen.getAllByText('Overlapping App')).toHaveLength(1);
+  });
+
+  it('hides Load more once the last page is in', () => {
+    useInfiniteProjects.mockImplementation(() => ({
+      data: { pages: [buildPage([buildProject()])] },
+      isLoading: false,
+      hasNextPage: false,
+    }));
+
+    renderExplore();
+
+    expect(screen.queryByRole('button', { name: /Load more/ })).toBeNull();
+  });
+
+  it('disables Load more while the shown results are stale', () => {
+    // The next page number is derived from results that are about to be
+    // replaced, so paging from a placeholder frame would fetch the wrong page.
+    useInfiniteProjects.mockImplementation(() => ({ ...twentyOf24(), isPlaceholderData: true }));
+
+    renderExplore();
+
+    expect(screen.getByRole('button', { name: /Load more/ })).toHaveProperty('disabled', true);
+  });
+});
+
+/**
+ * Search and category filtering happen on the SERVER now. Filtering the
+ * loaded page in the browser is what made a project past page 1 impossible
+ * to find by typing its name.
+ */
+describe('Explore server-side filtering', () => {
+  beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('sends the typed term to the query once typing settles', () => {
+    renderExplore();
+
+    fireEvent.change(screen.getByPlaceholderText('Search projects...'), { target: { value: 'needle' } });
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: PROJECT_TYPES.APP, search: 'needle' }),
+    );
+  });
+
+  it('does not fire a query for every keystroke', () => {
+    renderExplore();
+    const input = screen.getByPlaceholderText('Search projects...');
+
+    fireEvent.change(input, { target: { value: 'n' } });
+    fireEvent.change(input, { target: { value: 'ne' } });
+    fireEvent.change(input, { target: { value: 'nee' } });
+
+    // Nothing has settled yet, so no intermediate term reached the query.
+    const searchTerms = useInfiniteProjects.mock.calls.map(([p]) => p.search);
+    expect(searchTerms).not.toContain('n');
+    expect(searchTerms).not.toContain('ne');
+
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(expect.objectContaining({ search: 'nee' }));
+  });
+
+  it('clears the search immediately rather than after the debounce', () => {
+    renderExplore();
+    const input = screen.getByPlaceholderText('Search projects...');
+
+    fireEvent.change(input, { target: { value: 'needle' } });
+    act(() => { vi.advanceTimersByTime(300); });
+    fireEvent.change(input, { target: { value: '' } });
+
+    // A user who empties the box expects the full list back at once, and
+    // waiting the delay out would fire one request for a term already gone.
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(expect.objectContaining({ search: '' }));
+  });
+
+  it('sends the chosen category to the query instead of filtering loaded cards', () => {
+    useCategories.mockImplementation(() => ({ data: [{ category: 'game', count: 6 }] }));
+    renderExplore();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Games' }));
+
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(
+      expect.objectContaining({ category: 'game' }),
+    );
+  });
+
+  it('names the term in the empty state so a fruitless search is legible', () => {
+    useInfiniteProjects.mockImplementation(() => ({ data: { pages: [buildPage([], 0)] }, isLoading: false }));
+    renderExplore();
+
+    fireEvent.change(screen.getByPlaceholderText('Search projects...'), { target: { value: 'nothing' } });
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(screen.getByText(/No projects match/)).toBeDefined();
+  });
+});
+
+/**
+ * The chips were a hardcoded four (game/defi/social/tool) while the catalog
+ * held eight categories, so utility/nft/trading/other were unreachable by any
+ * filter — a second way the page hid published projects.
+ */
+describe('Explore category chips', () => {
+  it('renders whatever categories the API reports, including ones no list hardcodes', () => {
+    useCategories.mockImplementation(() => ({
+      data: [
+        { category: 'game', count: 6 },
+        { category: 'utility', count: 5 },
+        { category: 'trading', count: 1 },
+      ],
+    }));
+
+    renderExplore();
+
+    expect(screen.getByRole('button', { name: 'Games' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Utility' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Trading' })).toBeDefined();
   });
 });

--- a/tests/unit/pages/exploreTypeTabs.test.tsx
+++ b/tests/unit/pages/exploreTypeTabs.test.tsx
@@ -432,6 +432,61 @@ describe('Explore server-side filtering', () => {
   });
 });
 
+describe('Explore sort control', () => {
+  it('starts on the curated order', () => {
+    renderExplore();
+
+    expect(screen.getByRole('radio', { name: 'Relevant' }).getAttribute('aria-checked')).toBe('true');
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sort: 'relevant' }),
+    );
+  });
+
+  it('sends the chosen order to the server rather than reordering loaded cards', () => {
+    renderExplore();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Top' }));
+
+    // Reordering in the browser would only ever rank the loaded page, which
+    // is the same mistake the client-side search made.
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sort: 'top' }),
+    );
+  });
+
+  it('offers exactly the three orders the API implements', () => {
+    renderExplore();
+
+    const labels = screen.getAllByRole('radio').map(b => b.textContent);
+    expect(labels).toEqual(['Relevant', 'New', 'Top']);
+  });
+
+  it('keeps the chosen order across a tab switch, unlike search and category', () => {
+    renderExplore();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'New' }));
+    fireEvent.click(screen.getByRole('tab', { name: /Standalone/i }));
+
+    // Sort is a preference about how to read the catalog, not a filter on
+    // which part of it you are looking at — so it survives the switch.
+    expect(useInfiniteProjects).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: PROJECT_TYPES.STANDALONE, sort: 'new' }),
+    );
+    expect(screen.getByRole('radio', { name: 'New' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('marks only the active order as checked', () => {
+    renderExplore();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Top' }));
+
+    const checked = screen.getAllByRole('radio')
+      .filter(b => b.getAttribute('aria-checked') === 'true')
+      .map(b => b.textContent);
+    expect(checked).toEqual(['Top']);
+  });
+});
+
 /**
  * The chips were a hardcoded four (game/defi/social/tool) while the catalog
  * held eight categories, so utility/nft/trading/other were unreachable by any


### PR DESCRIPTION
## Why

The backoffice reported **24 published projects while Explore showed 20**.

Explore asked `/api/marketplace` for one page and never asked for another. Worse, its search and category filter ran **in the browser over those 20**, so the other four could not be found by typing their names either.

Requires **unicity-sphere/sphere-api#85**, which must deploy first.

## Changes

**Paging.** The list is a paged query with an explicit **Load more** control that states how many are left. A button rather than infinite scroll: this page ends in the developer CTA poster, and a list that grows on scroll would push that out of reach forever. Pages are deduped by id — the server's order is total, but a project published between two requests still shifts the window, and a repeated card is worse than a late one.

**Server-side search and category.** Both are query parameters now, so they run across the whole catalog. Typing is debounced; clearing is immediate, because a user who empties the box should not wait out a delay for a term they already deleted.

**Hero totals** come from `/api/marketplace/stats`. Deriving them from the loaded list is what made the row report 20 while the catalog held 24, and paging would only have made it worse. It counts apps and standalone only — a headline number larger than anything the tabs can reach would be the same bug wearing a new number.

**Category chips** come from the API, scoped to the active tab. They were a hardcoded four (`game`/`defi`/`social`/`tool`) while the catalog held eight categories, leaving `utility`, `nft`, `trading` and `other` unreachable by any filter.

**Only the active tab is fetched.** Both were fetched on every mount purely so the hero could add them up; react-query still makes a return visit to a tab instant.

**Sort control** — Relevant / New / Top, sent to the server so it ranks the whole catalog rather than reordering the loaded page. Shaped deliberately unlike the category chips below it: those are a filter where several could sensibly be on at once and turning one on changes how many projects exist, while sort is exactly one choice that changes no counts. It survives a tab switch, unlike search and category — it is a preference about how to read the catalog, not a filter on which part you are looking at.

## Two bugs found along the way

**Installed apps were vanishing from the desktop.** `DesktopShortcuts` resolved each installed app against that same single page and did `if (!project) return null` — so an installed app outside the first 20 silently disappeared from the user's desktop, with no error and nothing to click. It resolves by slug now, which is what a lookup by a slug the user already chose should always have done.

**The featured carousel did not read as a carousel.** A row with `scrollbar-hide`, no arrows and no peeking card looks like a grid that happens to fit — nothing told a viewer that more projects were one drag to the right. It now has arrows in whichever direction has more to show, a fade at those edges, and scroll snapping. The desktop had a second copy of the same pattern, so both now share one `DragScrollRow`; the fade is a CSS mask rather than a gradient painted in the background colour, because the desktop's background is not Explore's.

## Motion

Changing the sort, category or tab replaced the grid in a single frame, which reads as a glitch rather than a result. Two motions: `layout="position"` for reordering (same cards, new places — React reuses every element, so nothing animates by default), and a staggered fade-and-rise for arrival. Both skipped under `prefers-reduced-motion`.

Verified by sampling the grid every frame in a real browser:

```
sort change -> {"minOpacity":0,"sawTransform":true}
category    -> {"minOpacity":0,"sawTransform":true}
tab switch  -> {"minOpacity":0,"sawTransform":true}
```

No card is left stuck invisible in either motion mode.

## Also

`fetchProjectMetricsBatch` chunks under the server's 100-id cap, and metrics are grouped per loaded page — so Load more costs one metrics request instead of re-fetching every project seen so far.

## Verification

**827 unit tests**, including 28 on Explore covering paging, server-side filtering, the hero's source, chip data and the sort control. Lint, build and both typechecks clean; zero warnings in changed files.

Checked by hand against a local catalog of 100 published projects with 15 featured and 1620 reviews: all four pages walked with no duplicates, a project four pages deep found by typing its name, and `?search=C++` returning its literal match instead of a 500.
