### PR TITLE
chore: take sphere-ui 0.1.44 so authored line breaks survive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
         "@unicitylabs/sphere-sdk": "0.14.3",
-        "@unicitylabs/sphere-ui": "^0.1.43",
+        "@unicitylabs/sphere-ui": "^0.1.44",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
         "lucide-react": "^0.552.0",
@@ -2902,15 +2902,16 @@
       }
     },
     "node_modules/@unicitylabs/sphere-ui": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.43.tgz",
-      "integrity": "sha512-p579D/83GsmaO6qqRWbcTIVBU9FQbu9CMNvhIM1oRJc2R+tJOmi05GZRV5HMtuN4Uqn9L/2NrE0kWtleDPYn6Q==",
+      "version": "0.1.44",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-ui/-/sphere-ui-0.1.44.tgz",
+      "integrity": "sha512-XcGo6wvQ9Ikk+I1W05LT1QbmwKrrQjhznVeDLetipqtKJ+nSO2YRw4TZS3RYi9mwoAVRe+0Yw+3TbB9NS5xgnA==",
       "dependencies": {
         "framer-motion": "^11.18.2",
         "lucide-react": ">=0.400.0",
         "react-dropzone": "^14.4.1",
         "react-easy-crop": "^6.2.2",
         "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1"
       },
       "peerDependencies": {
@@ -6159,6 +6160,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -7678,6 +7693,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
     "@unicitylabs/sphere-sdk": "0.14.3",
-    "@unicitylabs/sphere-ui": "^0.1.43",
+    "@unicitylabs/sphere-ui": "^0.1.44",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",
     "lucide-react": "^0.552.0",


### PR DESCRIPTION
﻿## Why

sphere-ui **0.1.44** (unicity-sphere/sphere-ui#30) makes a single newline in an announcement body render as the line break the author actually typed.

Markdown's own rule is that a lone newline is a space вЂ” only a blank line or two trailing spaces break a line. The composer's Body is a plain textarea that says nothing about being markdown, so an author who pressed Enter once watched their two lines silently run together in the delivered announcement. `remark-breaks` settles it the way comment fields everywhere do, and leaves code blocks' newlines verbatim.

## What changed

`^0.1.44` plus the lockfile. No source changes here.

## Verification

`tsc --noEmit` clean. `vitest run` — 832 passed, 1 failed (118 files).

The one failure is `tests/unit/sdk/walletLock/passwordChangeTimeoutPreservation.test.tsx` > "a custom timeout chosen before a password Change is still in effect after it", and it is **pre-existing on main**, not caused by this bump:

- it fails identically with sphere-ui pinned back to 0.1.43 (same test, same ~46s timeout), verified by downgrading and re-running the full suite;
- it passes when its own file or the whole `walletLock` folder runs alone, so it is a timing-sensitive test that times out under full-suite load;
- it imports nothing from sphere-ui \u2014 it exercises `SphereProvider` and the wallet auto-lock settings.
