### PR TITLE
chore: sphere-sdk 0.14.9 — sender Unicity ID on incoming payments (#487)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.10",
         "@tanstack/react-table": "^8.21.3",
         "@types/katex": "^0.16.7",
-        "@unicitylabs/sphere-sdk": "0.14.8",
+        "@unicitylabs/sphere-sdk": "0.14.9",
         "@unicitylabs/sphere-ui": "^0.1.44",
         "framer-motion": "^12.23.24",
         "katex": "^0.16.27",
@@ -2795,9 +2795,9 @@
       }
     },
     "node_modules/@unicitylabs/sphere-sdk": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.14.8.tgz",
-      "integrity": "sha512-TjZ2LlnLjXFCvWhk8a0Cc+cRs8F6iwOs73Oq0ebRZ2+U3CTx4tj2AvuUlSB/ZPq2l2fmANIFwyRvalCRf1FlWA==",
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/@unicitylabs/sphere-sdk/-/sphere-sdk-0.14.9.tgz",
+      "integrity": "sha512-RarQY6uR+fgz/ruZpUF7UnlT/o1iCd90rV7B9hfx0T4w0s7AgG02yaJZefuyqrl/Qc/KTK08Oee18NnUkvIl2g==",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@tanstack/react-query": "^5.90.10",
     "@tanstack/react-table": "^8.21.3",
     "@types/katex": "^0.16.7",
-    "@unicitylabs/sphere-sdk": "0.14.8",
+    "@unicitylabs/sphere-sdk": "0.14.9",
     "@unicitylabs/sphere-ui": "^0.1.44",
     "framer-motion": "^12.23.24",
     "katex": "^0.16.27",


### PR DESCRIPTION
Closes #487

Picks up [sphere-sdk#750](https://github.com/unicity-sphere/sphere-sdk/pull/750) (released as `0.14.9`): the mailbox delivery envelope now carries the sender's Unicity ID, so an incoming payment renders **`@alice`** instead of **"Someone"**.

Nothing changes in this repo but the pin — `useSphereEvents.ts:63` was always correct:

```ts
const sender = transfer.senderNametag ? `@${transfer.senderNametag}` : 'Someone';
```

The SDK simply never populated `senderNametag`. The v2 send path built `DeliverOptions` without it, and the port's `options.senderNametag ?? this.identity.nametag` fallback had **both operands dead in production** — so the envelope carried the memo at best, and on a memo-less send no envelope was deposited at all.

## Verification

Confirmed working on the branch preview against `0.14.9-dev.1` before the release was cut. On `0.14.9`: lint 0 errors, `typecheck:tests` clean, 870 tests pass, build OK.

Preview: https://unicity-sphere.github.io/sphere/fix-sdk-487-sender-nametag/

## Notes

- **Both wallets must run this build** — the name is written by the *sender*, so upgrading only the receiving wallet shows nothing new. The sender also needs a registered Unicity ID.
- **Nothing backfills.** Received-history rows are write-once, so payments received before this stay nameless.