### PR TITLE
fix(wallet): a self-mint credit is incoming, not a send (#488)

### DIFF
--- a/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
+++ b/src/components/wallet/L3/modals/TransactionHistoryModal.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { ArrowUpRight, ArrowDownLeft, Loader2, Clock, ChevronDown, Copy, Check } from 'lucide-react';
 import { useTransactionHistory } from '../../../../sdk';
-import { TokenRegistry } from '@unicitylabs/sphere-sdk';
+import { TokenRegistry, type TransactionHistoryEntry } from '@unicitylabs/sphere-sdk';
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { WalletScreen } from '../../ui/WalletScreen';
 import { ModalHeader, EmptyState } from '../../ui';
@@ -27,6 +27,22 @@ function useCopyToClipboard() {
   }, []);
 
   return { copiedKey, copy };
+}
+
+/**
+ * Direction of a history row. Only SENT leaves the wallet. RECEIVED is an
+ * incoming transfer and MINT is a self-mint credit — which is what "Top Up"
+ * writes (one row per coin in the basket) and what a Swap's receive leg writes,
+ * the swap being a send to the stub plus a self-mint. Deciding direction with a
+ * bare `=== 'RECEIVED'` dropped both into the outgoing branch, so money
+ * arriving was presented as "Sent −" (#488).
+ *
+ * The unlisted SPLIT of the legacy record type is deliberately not incoming:
+ * the payments facade never emits it, and an unexpected value from the server
+ * must not be signed as a credit.
+ */
+function isIncoming(type: TransactionHistoryEntry['type']): boolean {
+  return type === 'RECEIVED' || type === 'MINT';
 }
 
 /** Truncate middle of string: "abcdef...uvwxyz" */
@@ -117,6 +133,7 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
 
       return {
         ...entry,
+        incoming: isIncoming(entry.type),
         formattedAmount: formatRawAmount(entry.amount, decimals),
         formattedTokenIds: entry.tokenIds?.map(t => ({
           ...t,
@@ -191,11 +208,11 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
                         </div>
                       )}
                       <div className={`absolute -bottom-1 -right-1 w-5 h-5 rounded-full flex items-center justify-center border-2 border-neutral-50 dark:border-white/10 ${
-                        entry.type === 'RECEIVED'
+                        entry.incoming
                           ? 'bg-emerald-500'
                           : 'bg-orange-500'
                       }`}>
-                        {entry.type === 'RECEIVED' ? (
+                        {entry.incoming ? (
                           <ArrowDownLeft className="w-3 h-3 text-white" />
                         ) : (
                           <ArrowUpRight className="w-3 h-3 text-white" />
@@ -206,7 +223,7 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
                     {/* Title & Subtitle */}
                     <div className="flex-1 min-w-0">
                       <div className="text-sm font-medium text-neutral-900 dark:text-white">
-                        {entry.type === 'RECEIVED' ? 'Received' : 'Sent'}
+                        {entry.incoming ? 'Received' : 'Sent'}
                         {peerLabel && (
                           <span className="text-neutral-500 dark:text-white/45 font-normal ml-1">
                             {entry.type === 'RECEIVED' ? 'from' : 'to'} {peerLabel}
@@ -226,11 +243,11 @@ export function TransactionHistoryModal({ isOpen, onClose }: TransactionHistoryM
                     {/* Amount + chevron */}
                     <div className="flex items-center gap-1.5 shrink-0">
                       <div className={`text-sm font-semibold ${
-                        entry.type === 'RECEIVED'
+                        entry.incoming
                           ? 'text-emerald-600 dark:text-emerald-400'
                           : 'text-neutral-900 dark:text-white'
                       }`}>
-                        {entry.type === 'RECEIVED' ? '+' : '-'}{entry.formattedAmount} {entry.symbol}
+                        {entry.incoming ? '+' : '-'}{entry.formattedAmount} {entry.symbol}
                       </div>
                       <ChevronDown className={`w-4 h-4 text-neutral-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
                     </div>

--- a/tests/unit/components/transactionHistoryModal.test.tsx
+++ b/tests/unit/components/transactionHistoryModal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { TransactionHistoryEntry } from '@unicitylabs/sphere-sdk';
+
+// ============================================================================
+// Transaction history — direction of a row (issue #488).
+//
+// The history feed carries three record types: SENT, RECEIVED and MINT. Only
+// SENT leaves the wallet. MINT is a self-mint credit — it is what "Top Up"
+// produces (one row per coin in the basket), and it is also the receive leg of
+// a Swap, which is implemented as a send to the swap stub plus a self-mint.
+//
+// The modal used to decide direction with a single binary `=== 'RECEIVED'`
+// test, so every MINT row fell into the outgoing branch: the word "Sent", a
+// "-" sign, the orange up-arrow badge and the neutral (non-credit) amount
+// colour — money arriving was presented as money leaving.
+// ============================================================================
+
+const hoisted = vi.hoisted(() => ({
+  // TransactionHistoryModal calls TokenRegistry.getInstance() at MODULE scope,
+  // so the fake has to exist before the component module is evaluated.
+  registry: {
+    getDefinition: (coinId: string) => ({ id: coinId, symbol: 'UCT', decimals: 0 }),
+    getIconUrl: () => null,
+  },
+}));
+
+vi.mock('@unicitylabs/sphere-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@unicitylabs/sphere-sdk')>();
+  return { ...actual, TokenRegistry: { getInstance: () => hoisted.registry } };
+});
+
+let history: TransactionHistoryEntry[] = [];
+
+vi.mock('../../../src/sdk', () => ({
+  useTransactionHistory: () => ({ history, isLoading: false, error: null, refetch: vi.fn() }),
+}));
+
+import { TransactionHistoryModal } from '../../../src/components/wallet/L3/modals/TransactionHistoryModal';
+
+const COIN = 'c'.repeat(64);
+
+function entry(over: Partial<TransactionHistoryEntry>): TransactionHistoryEntry {
+  return {
+    dedupKey: 'k',
+    id: 'e1',
+    type: 'MINT',
+    amount: '500',
+    coinId: COIN,
+    symbol: 'UCT',
+    timestamp: 1_700_000_000_000,
+    ...over,
+  } as TransactionHistoryEntry;
+}
+
+function open() {
+  return render(<TransactionHistoryModal isOpen onClose={vi.fn()} />);
+}
+
+/** The amount cell — the node carrying the sign, so its class is the colour under test. */
+function amountCell(text: RegExp): HTMLElement {
+  return screen.getByText(text);
+}
+
+/** The direction badge over the coin icon: its colour and its arrow. */
+function badge(container: HTMLElement): { credit: boolean; arrow: string | null } {
+  const node = container.querySelector('.bg-emerald-500, .bg-orange-500')!;
+  const svg = node.querySelector('svg');
+  return {
+    credit: node.classList.contains('bg-emerald-500'),
+    arrow: svg && (svg.getAttribute('class')?.match(/lucide-arrow-[a-z-]+/)?.[0] ?? null),
+  };
+}
+
+beforeEach(() => {
+  history = [];
+});
+
+describe('TransactionHistoryModal — row direction', () => {
+  it('renders a self-mint (Top Up / swap receive leg) as an incoming credit', () => {
+    history = [entry({ id: 'mint-1', type: 'MINT' })];
+
+    const { container } = open();
+
+    expect(screen.getByText('Received')).toBeTruthy();
+    expect(screen.queryByText('Sent')).toBeNull();
+    expect(amountCell(/\+500 UCT/).className).toMatch(/text-emerald/);
+    expect(screen.queryByText(/-500 UCT/)).toBeNull();
+    expect(badge(container)).toEqual({ credit: true, arrow: 'lucide-arrow-down-left' });
+  });
+
+  it('still renders an incoming transfer as a credit', () => {
+    history = [entry({ id: 'recv-1', type: 'RECEIVED', senderNametag: 'bob' })];
+
+    open();
+
+    expect(screen.getByText(/from @bob/)).toBeTruthy();
+    expect(amountCell(/\+500 UCT/).className).toMatch(/text-emerald/);
+  });
+
+  it('still renders an outgoing transfer as a debit', () => {
+    history = [entry({ id: 'sent-1', type: 'SENT', recipientNametag: 'bob' })];
+
+    const { container } = open();
+
+    expect(screen.getByText('Sent')).toBeTruthy();
+    expect(badge(container)).toEqual({ credit: false, arrow: 'lucide-arrow-up-right' });
+    expect(screen.getByText(/to @bob/)).toBeTruthy();
+    expect(amountCell(/-500 UCT/).className).not.toMatch(/text-emerald/);
+    expect(screen.queryByText(/\+500 UCT/)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #488

## The bug

Top Up and Swap both wrote history rows the wallet then presented as money
*leaving*: the word "Sent", a `-` sign, the orange up-arrow badge and the
neutral (non-credit) amount colour.

The history feed carries three record types. Only `SENT` leaves the wallet;
`RECEIVED` is an incoming transfer and `MINT` is a self-mint credit.

`MINT` is exactly what both reported actions produce:

- **Top Up** — `useTopUp` calls `payments.mint()` once per basket coin
  (UCT/BTC/SOL/ETH), so a single top-up produced **four** wrong rows.
- **Swap** — `SwapModal.handleSwap` is a `transfer()` to the swap stub
  (correctly `SENT`) **plus** a `payments.mint()` for the receive leg. That
  mint leg raises no toast, so the history row is the only surface it ever
  appears on — and it was the surface that got it wrong.

`TransactionHistoryModal` decided direction with a bare
`entry.type === 'RECEIVED'` in five places — badge colour, arrow icon, the
word "Sent", the `-` sign, the amount colour — which put `MINT` in the
outgoing branch of every one of them.

The SDK is not at fault: `History.recordMint` / `recordSent` /
`recordReceived` each hard-code their own type literal, and nothing between
there and the modal rewrites it.

## The fix

An `isIncoming(type)` predicate, carried on each formatted row and used at
the five direction sites.

- **An unrecognised type stays outgoing on purpose.** The history response
  is cast without validation on the way here, so an unexpected value must
  never be signed as a credit.
- **The counterparty label stays keyed on `RECEIVED`-vs-`SENT`.** That asks
  which side of the record holds the peer — a different question from
  direction — and a `MINT` has neither side, so the whole "from/to @x"
  clause is already withheld.
- **Copy:** mint rows read "Received", matching the top-up toast that
  already says `Received 100 UCT` under the title "Top Up". No new
  vocabulary.

## Tests

New `tests/unit/components/transactionHistoryModal.test.tsx` (3 cases):
the MINT row, plus `RECEIVED` and `SENT` controls so neither regresses —
including the `Sent` / `-…UCT` inline shape `tests/e2e/two-profile-smoke.spec.ts`
asserts.

Written first and watched fail (`getByText('Received')` — the row said
"Sent"), then pass. The badge/arrow assertions were separately proven
non-vacuous by reverting *only* the two badge sites and confirming they
fail.

## Verification

- `npm run lint` — 0 errors (2 pre-existing warnings in `SphereProvider.tsx`)
- `npm run typecheck:tests` — clean
- `npm run build` — clean
- `npm run test:run` — **891 passing across 128 files**

## Out of scope, worth recording

The wallet is itself a Connect host, and `sphere_getHistory` hands
`HistoryEntry[]` to dApps verbatim, `MINT` included. Any dApp that wrote the
same binary `=== 'RECEIVED'` test has the identical bug; fixing this modal
does not fix them.

## Preview

https://unicity-sphere.github.io/sphere/fix-488-mint-history-direction/